### PR TITLE
rename 'store' to 'storage' to improve semantics

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/pbinitiative/zenbpm/internal/config"
-	"github.com/pbinitiative/zenbpm/pkg/store"
+	"github.com/pbinitiative/zenbpm/pkg/storage"
 	"github.com/rqlite/rqlite/v8/command/proto"
 )
 
@@ -38,7 +38,7 @@ type ZenNode struct {
 }
 
 // make sure that the ZenNode implements PersistentStorage
-var _ store.PersistentStorage = &ZenNode{}
+var _ storage.PersistentStorage = &ZenNode{}
 
 // Starts a cluster node
 func StartZenNode(mainCtx context.Context, conf config.Config) (*ZenNode, error) {

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -8,7 +8,7 @@ import (
 	rqliteExporter "github.com/pbinitiative/zenbpm/pkg/bpmn/exporter/rqlite"
 	rqlite "github.com/pbinitiative/zenbpm/pkg/bpmn/persistence/rqlite"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/var_holder"
-	"github.com/pbinitiative/zenbpm/pkg/store"
+	"github.com/pbinitiative/zenbpm/pkg/storage"
 
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/exporter"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/model/bpmn20"
@@ -31,14 +31,14 @@ type BpmnEngine interface {
 }
 
 // New creates a new instance of the BPMN Engine;
-func New(store store.PersistentStorage) BpmnEngineState {
+func New(store storage.PersistentStorage) BpmnEngineState {
 	return NewWithName(fmt.Sprintf("Bpmn-Engine-%d", getGlobalSnowflakeIdGenerator().Generate().Int64()), store)
 }
 
 // NewWithName creates an engine with an arbitrary name of the engine;
 // useful in case you have multiple ones, in order to distinguish them;
 // also stored in when marshalling a process instance state, in case you want to store some special identifier
-func NewWithName(name string, store store.PersistentStorage) BpmnEngineState {
+func NewWithName(name string, store storage.PersistentStorage) BpmnEngineState {
 	snowflakeIdGenerator := getGlobalSnowflakeIdGenerator()
 	state := BpmnEngineState{
 		name:         name,

--- a/pkg/bpmn/persistence/rqlite/persistence_rqlite.go
+++ b/pkg/bpmn/persistence/rqlite/persistence_rqlite.go
@@ -12,16 +12,16 @@ import (
 	"github.com/bwmarrin/snowflake"
 	bpmnEngineExporter "github.com/pbinitiative/zenbpm/pkg/bpmn/exporter"
 	sql "github.com/pbinitiative/zenbpm/pkg/bpmn/persistence/rqlite/sql"
-	"github.com/pbinitiative/zenbpm/pkg/store"
+	"github.com/pbinitiative/zenbpm/pkg/storage"
 	"github.com/rqlite/rqlite/v8/command/proto"
 )
 
 type BpmnEnginePersistenceRqlite struct {
 	snowflakeIdGenerator *snowflake.Node
-	store                store.PersistentStorage
+	store                storage.PersistentStorage
 }
 
-func NewBpmnEnginePersistenceRqlite(snowflakeIdGenerator *snowflake.Node, store store.PersistentStorage) *BpmnEnginePersistenceRqlite {
+func NewBpmnEnginePersistenceRqlite(snowflakeIdGenerator *snowflake.Node, store storage.PersistentStorage) *BpmnEnginePersistenceRqlite {
 	gen := snowflakeIdGenerator
 
 	Init(store)
@@ -442,7 +442,7 @@ func (persistence *BpmnEnginePersistenceRqlite) IsLeader() bool {
 	return persistence.store.IsLeader(context.Background())
 }
 
-func Init(store store.PersistentStorage) {
+func Init(store storage.PersistentStorage) {
 	log.Printf("Is leader: %v", store.IsLeader(context.Background()))
 	if !store.IsLeader(context.Background()) {
 		log.Println("Not a leader, skipping init")
@@ -484,7 +484,7 @@ func whereClauseBuilder(mappings map[string]string, operator string) string {
 
 }
 
-func execute(statements []string, store store.PersistentStorage) ([]*proto.ExecuteQueryResponse, error) {
+func execute(statements []string, store storage.PersistentStorage) ([]*proto.ExecuteQueryResponse, error) {
 	stmts := generateStatments(statements)
 
 	er := &proto.ExecuteRequest{
@@ -516,7 +516,7 @@ func generateStatments(statements []string) []*proto.Statement {
 	return stmts
 }
 
-func query(query string, store store.PersistentStorage) ([]*proto.QueryRows, error) {
+func query(query string, store storage.PersistentStorage) ([]*proto.QueryRows, error) {
 
 	stmts := generateStatments([]string{query})
 

--- a/pkg/storage/doc.go
+++ b/pkg/storage/doc.go
@@ -1,0 +1,3 @@
+// Package storage contains interface implemented by rqlite cluster
+// and data model used by bpmn & dmn engines
+package storage

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,4 +1,4 @@
-package store
+package storage
 
 import (
 	"context"

--- a/pkg/store/doc.go
+++ b/pkg/store/doc.go
@@ -1,3 +1,0 @@
-// Package contains store interface implemented by rqlite cluster
-// and data model used by bpmn & dmn engines
-package store


### PR DESCRIPTION
### Motivation/Abstract

please describe in 1-3 sentences, 
* rename package `store` to `storage` for better semantic match