### PR TITLE
fix reported "Invalid Go toolchain version" issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/pbinitiative/zenbpm
 
 go 1.24
 
+toolchain go1.24.0
+
 require (
 	github.com/bwmarrin/snowflake v0.3.0
 	github.com/corbym/gocrest v1.0.5


### PR DESCRIPTION
Fixes the issue, reported by Github at https://github.com/pbinitiative/zenbpm/security/code-scanning/tools/CodeQL/status
