### PR TITLE
feat(cluster): add support to form a multi-node zen cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,18 @@ run: ## Start this project locally with dev configuration
 	export CONFIG_FILE=$(CURDIR)/conf/zenbpm/conf-dev.yaml; \
 	go run cmd/zenbpm/*.go
 
+.PHONY: run1
+run1: ## Start 1st node
+	export PROFILE=DEV; \
+	export CONFIG_FILE=$(CURDIR)/conf/zenbpm/conf-dev-node1.yaml; \
+	go run cmd/zenbpm/*.go
+
+.PHONY: run2
+run2: ## Start 2nd node
+	export PROFILE=DEV; \
+	export CONFIG_FILE=$(CURDIR)/conf/zenbpm/conf-dev-node2.yaml; \
+	go run cmd/zenbpm/*.go
+
 .PHONY: test
 test: ## Run tests
 	LOG_LEVEL=INFO go test ./...

--- a/conf/zenbpm/conf-dev-node1.yaml
+++ b/conf/zenbpm/conf-dev-node1.yaml
@@ -1,15 +1,16 @@
 name: zenbpm
 server:
   context: /
-  addr: :8080
+  addr: :8081
 cluster:
-  addr: localhost:8090
-  adv: localhost:8090
+  addr: localhost:8091
+  adv: localhost:8091
   raft:
     dir: node-1
-    bootstrapExpect: 1
     bootstrapExpectTimeout: 30m
+    bootstrapExpect: 2
     joinAttempts: 5
     joinAddresses: 
-      - localhost:8090
+      - localhost:8091
+      - localhost:8092
   nodeId: node-1

--- a/conf/zenbpm/conf-dev-node2.yaml
+++ b/conf/zenbpm/conf-dev-node2.yaml
@@ -1,0 +1,16 @@
+name: zenbpm
+server:
+  context: /
+  addr: :8082
+cluster:
+  addr: localhost:8092
+  adv: localhost:8092
+  raft:
+    dir: node-2
+    bootstrapExpectTimeout: 30m
+    bootstrapExpect: 2
+    joinAttempts: 5
+    joinAddresses: 
+      - localhost:8091
+      - localhost:8092
+  nodeId: node-2

--- a/internal/cluster/bootstrap.go
+++ b/internal/cluster/bootstrap.go
@@ -1,0 +1,182 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/pbinitiative/zenbpm/internal/cluster/client"
+	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
+	"github.com/rqlite/rqlite/v8/cluster"
+	"github.com/rqlite/rqlite/v8/random"
+)
+
+const (
+	requestTimeout    = 5 * time.Second
+	numJoinAttempts   = 1
+	bootCheckInterval = 1 * time.Second
+)
+
+// AddressProvider is the interface types must implement to provide
+// addresses to a Bootstrapper.
+type AddressProvider interface {
+	Lookup() ([]string, error)
+}
+
+// Bootstrapper performs a bootstrap of this node.
+type Bootstrapper struct {
+	provider AddressProvider
+
+	clientMgr *client.ClientManager
+
+	logger   hclog.Logger
+	Interval time.Duration
+
+	bootStatusMu sync.RWMutex
+	bootStatus   cluster.BootStatus
+
+	// White-box testing only
+	nBootCanceled int
+}
+
+// NewBootstrapper returns an instance of a Bootstrapper.
+func NewBootstrapper(p AddressProvider, client *client.ClientManager) *Bootstrapper {
+	bs := &Bootstrapper{
+		provider:  p,
+		clientMgr: client,
+		logger:    hclog.Default().Named("cluster-bootstrap"),
+		Interval:  bootCheckInterval,
+	}
+	return bs
+}
+
+// Boot performs the bootstrapping process for this node. This means it will
+// ensure this node becomes part of a cluster. It does this by either:
+//   - joining an existing cluster by explicitly joining it through a node returned
+//     by the AddressProvider, or
+//   - if it's a Voting node, notifying all nodes returned by the AddressProvider
+//     that it exists, potentially allowing a cluster-wide bootstrap take place
+//     which will include this node.
+//
+// Returns nil if the boot operation was successful, or if done() ever returns
+// true. done() is periodically polled by the boot process. Returns an error
+// the boot process encounters an unrecoverable error, or booting does not
+// occur within the given timeout. If booting was canceled, ErrBootCanceled is
+// returned unless done() returns true at the time of cancelation, in which case
+// no error is returned.
+//
+// id and raftAddr are those of the node calling Boot. suf is whether this node
+// is a Voter or NonVoter.
+func (b *Bootstrapper) Boot(ctx context.Context, id, raftAddr string, suf cluster.Suffrage, done func() bool, timeout time.Duration) error {
+	timeoutT := time.NewTimer(timeout)
+	defer timeoutT.Stop()
+	tickerT := time.NewTimer(random.Jitter(time.Millisecond)) // Check fast, just once at the start.
+	defer tickerT.Stop()
+
+	joiner := NewJoiner(b.clientMgr, numJoinAttempts, requestTimeout)
+	for {
+		select {
+		case <-ctx.Done():
+			b.nBootCanceled++
+			if done() {
+				b.logger.Info("boot operation marked done")
+				b.setBootStatus(cluster.BootDone)
+				return nil
+			}
+			b.setBootStatus(cluster.BootCanceled)
+			return cluster.ErrBootCanceled
+
+		case <-timeoutT.C:
+			b.setBootStatus(cluster.BootTimeout)
+			return cluster.ErrBootTimeout
+
+		case <-tickerT.C:
+			if done() {
+				b.logger.Info("boot operation marked done")
+				b.setBootStatus(cluster.BootDone)
+				return nil
+			}
+			tickerT.Reset(random.Jitter(b.Interval)) // Move to longer-period polling
+
+			targets, err := b.provider.Lookup()
+			if err != nil {
+				b.logger.Warn(fmt.Sprintf("provider lookup failed %s", err.Error()))
+			}
+			if len(targets) == 0 {
+				continue
+			}
+
+			// Try an explicit join first. Joining an existing cluster is always given priority
+			// over trying to form a new cluster.
+			if j, err := joiner.Do(ctx, targets, id, raftAddr, suf); err == nil {
+				b.logger.Info(fmt.Sprintf("succeeded directly joining cluster via node at %s as %s", j, suf))
+				b.setBootStatus(cluster.BootJoin)
+				return nil
+			}
+
+			if suf.IsVoter() {
+				// This is where we have to be careful. This node failed to join with any node
+				// in the targets list. This could be because none of the nodes are contactable,
+				// or none of the nodes are in a functioning cluster with a leader. That means that
+				// this node could be part of a set nodes that are bootstrapping to form a cluster
+				// de novo. For that to happen it needs to now let the other nodes know it is here.
+				// If this is a new cluster, some node will then reach the bootstrap-expect value
+				// first, form the cluster, beating all other nodes to it.
+				if err := b.notify(targets, id, raftAddr); err != nil {
+					b.logger.Warn(fmt.Sprintf("failed to notify all targets: %s (%s, will retry)", targets,
+						err.Error()))
+				} else {
+					b.logger.Info(fmt.Sprintf("succeeded notifying all targets: %s", targets))
+				}
+			}
+		}
+	}
+}
+
+// Status returns the reason for the boot process completing.
+func (b *Bootstrapper) Status() cluster.BootStatus {
+	b.bootStatusMu.RLock()
+	defer b.bootStatusMu.RUnlock()
+	return b.bootStatus
+}
+
+func (b *Bootstrapper) notify(targets []string, id, raftAddr string) error {
+	nr := &proto.NotifyRequest{
+		Address: raftAddr,
+		Id:      id,
+	}
+	for _, t := range targets {
+		client, err := b.clientMgr.For(t)
+		if err != nil {
+			return fmt.Errorf("failed to create client for %s: %s", t, err)
+		}
+		timeoutCtx, cancelCtx := context.WithTimeout(context.Background(), requestTimeout)
+		_, err = client.Notify(timeoutCtx, nr)
+		cancelCtx()
+		if err != nil {
+			return fmt.Errorf("failed to notify node at %s: %s", t, err)
+		}
+	}
+	return nil
+}
+
+func (b *Bootstrapper) setBootStatus(status cluster.BootStatus) {
+	b.bootStatusMu.Lock()
+	defer b.bootStatusMu.Unlock()
+	b.bootStatus = status
+}
+
+type stringAddressProvider struct {
+	ss []string
+}
+
+func (s *stringAddressProvider) Lookup() ([]string, error) {
+	return s.ss, nil
+}
+
+// NewAddressProviderString wraps an AddressProvider around a string slice.
+func NewAddressProviderString(ss []string) AddressProvider {
+	return &stringAddressProvider{ss}
+}

--- a/internal/cluster/bootstrap_test.go
+++ b/internal/cluster/bootstrap_test.go
@@ -1,0 +1,308 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/internal/cluster/client"
+	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
+	"github.com/pbinitiative/zenbpm/internal/cluster/server/servertest"
+	"github.com/rqlite/rqlite/v8/cluster"
+)
+
+func Test_AddressProviderString(t *testing.T) {
+	a := []string{"a", "b", "c"}
+	p := NewAddressProviderString(a)
+	b, err := p.Lookup()
+	if err != nil {
+		t.Fatalf("failed to lookup addresses: %s", err.Error())
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("failed to get correct addresses")
+	}
+}
+
+func Test_NewBootstrapper(t *testing.T) {
+	bs := NewBootstrapper(nil, nil)
+	if bs == nil {
+		t.Fatalf("failed to create a simple Bootstrapper")
+	}
+	if exp, got := cluster.BootUnknown, bs.Status(); exp != got {
+		t.Fatalf("wrong status, exp %s, got %s", exp, got)
+	}
+}
+
+func Test_BootstrapperBootDoneImmediately(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+
+	srv.JoinHandler = func(jr *proto.JoinRequest) (*proto.JoinResponse, error) {
+		t.Fatalf("client made request")
+		return &proto.JoinResponse{}, nil
+	}
+
+	done := func() bool {
+		return true
+	}
+	p := NewAddressProviderString([]string{srv.Addr()})
+	bs := NewBootstrapper(p, nil)
+	if err := bs.Boot(context.Background(), "node1", "192.168.1.1:1234", cluster.Voter, done, 10*time.Second); err != nil {
+		t.Fatalf("failed to boot: %s", err)
+	}
+	if exp, got := cluster.BootDone, bs.Status(); exp != got {
+		t.Fatalf("wrong status, exp %s, got %s", exp, got)
+	}
+}
+
+func Test_BootstrapperBootTimeout(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+	srv.JoinHandler = func(jr *proto.JoinRequest) (*proto.JoinResponse, error) {
+		return nil, fmt.Errorf("not a cluster")
+	}
+	srv.NotifyHandler = func(nr *proto.NotifyRequest) (*proto.NotifyResponse, error) {
+		time.Sleep(10 * time.Second)
+		return nil, fmt.Errorf("some err")
+	}
+
+	done := func() bool {
+		return false
+	}
+	p := NewAddressProviderString([]string{srv.Addr()})
+	clientMgr := client.NewClientManager(nil)
+	bs := NewBootstrapper(p, clientMgr)
+	bs.Interval = time.Second
+	err := bs.Boot(context.Background(), "node1", "192.168.1.1:1234", cluster.Voter, done, 5*time.Second)
+	if err == nil {
+		t.Fatalf("no error returned from timed-out boot")
+	}
+	if !errors.Is(err, cluster.ErrBootTimeout) {
+		t.Fatalf("wrong error returned")
+	}
+	if exp, got := cluster.BootTimeout, bs.Status(); exp != got {
+		t.Fatalf("wrong status, exp %s, got %s", exp, got)
+	}
+}
+
+func Test_BootstrapperBootCanceled(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+
+	done := func() bool {
+		return false
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	p := NewAddressProviderString([]string{srv.Addr()})
+	clientMgr := client.NewClientManager(nil)
+	bs := NewBootstrapper(p, clientMgr)
+	bs.Interval = time.Second
+	err := bs.Boot(ctx, "node1", "192.168.1.1:1234", cluster.Voter, done, 5*time.Second)
+	if err == nil {
+		t.Fatalf("no error returned from timed-out boot")
+	}
+	if !errors.Is(err, cluster.ErrBootCanceled) {
+		t.Fatalf("wrong error returned")
+	}
+	if exp, got := cluster.BootCanceled, bs.Status(); exp != got {
+		t.Fatalf("wrong status, exp %s, got %s", exp, got)
+	}
+}
+
+// Test_BootstrapperBootCanceledDone tests that a boot that is canceled
+// but is done does not return an error.
+func Test_BootstrapperBootCanceledDone(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+
+	done := func() bool {
+		return true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	p := NewAddressProviderString([]string{srv.Addr()})
+	clientMgr := client.NewClientManager(nil)
+	bs := NewBootstrapper(p, clientMgr)
+	bs.Interval = time.Second
+	err := bs.Boot(ctx, "node1", "192.168.1.1:1234", cluster.Voter, done, 5*time.Second)
+	if err != nil {
+		t.Fatalf("error returned from canceled boot even though it's done: %s", err)
+	}
+	if bs.nBootCanceled == 0 {
+		t.Fatalf("boot not actually canceled")
+	}
+}
+
+func Test_BootstrapperBootSingleJoin(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+
+	srv.JoinHandler = func(req *proto.JoinRequest) (*proto.JoinResponse, error) {
+		if req == nil {
+			t.Fatal("expected join node request, got nil")
+		}
+		if req.Address != "192.168.1.1:1234" {
+			t.Fatalf("unexpected node address, got %s", req.Address)
+		}
+
+		return &proto.JoinResponse{}, nil
+	}
+
+	done := func() bool {
+		return false
+	}
+
+	p := NewAddressProviderString([]string{srv.Addr()})
+	clientMgr := client.NewClientManager(nil)
+	bs := NewBootstrapper(p, clientMgr)
+	bs.Interval = time.Second
+
+	err := bs.Boot(context.Background(), "node1", "192.168.1.1:1234", cluster.Voter, done, 5*time.Second)
+	if err != nil {
+		t.Fatalf("failed to boot: %s", err)
+	}
+	if exp, got := cluster.BootJoin, bs.Status(); exp != got {
+		t.Fatalf("wrong status, exp %s, got %s", exp, got)
+	}
+}
+
+// Test_BootstrapperBootNonVoter tests that a non-voter just attempts
+// to join the cluster, and does not send a notify request.
+func Test_BootstrapperBootNonVoter(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+	srv.JoinHandler = func(req *proto.JoinRequest) (*proto.JoinResponse, error) {
+		if req == nil {
+			t.Fatal("expected join node request, got nil")
+		}
+		if req.Address != "192.168.1.1:1234" {
+			t.Fatalf("unexpected node address, got %s", req.Address)
+		}
+		// timeout the bootstrapper.
+		time.Sleep(5 * time.Second)
+		return &proto.JoinResponse{}, nil
+	}
+
+	done := func() bool {
+		return false
+	}
+
+	p := NewAddressProviderString([]string{srv.Addr()})
+	clientMgr := client.NewClientManager(nil)
+	bs := NewBootstrapper(p, clientMgr)
+	bs.Interval = time.Second
+
+	err := bs.Boot(context.Background(), "node1", "192.168.1.1:1234", cluster.NonVoter, done, 3*time.Second)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+	if exp, got := cluster.BootTimeout, bs.Status(); exp != got {
+		t.Fatalf("wrong status, exp %s, got %s", exp, got)
+	}
+}
+
+func Test_BootstrapperBootSingleNotify(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+
+	var gotNR *proto.NotifyRequest
+	srv.JoinHandler = func(jr *proto.JoinRequest) (*proto.JoinResponse, error) {
+		return nil, fmt.Errorf("not a cluster")
+	}
+	srv.NotifyHandler = func(nr *proto.NotifyRequest) (*proto.NotifyResponse, error) {
+		gotNR = nr
+		return &proto.NotifyResponse{}, nil
+	}
+	n := -1
+	done := func() bool {
+		n++
+		return n == 5
+	}
+
+	p := NewAddressProviderString([]string{srv.Addr()})
+	clientMgr := client.NewClientManager(nil)
+	bs := NewBootstrapper(p, clientMgr)
+	bs.Interval = time.Second
+
+	err := bs.Boot(context.Background(), "node1", "192.168.1.1:1234", cluster.Voter, done, 60*time.Second)
+	if err != nil {
+		t.Fatalf("failed to boot: %s", err)
+	}
+
+	if got, exp := gotNR.Id, "node1"; got != exp {
+		t.Fatalf("wrong node ID supplied, exp %s, got %s", exp, got)
+	}
+	if got, exp := gotNR.Address, "192.168.1.1:1234"; got != exp {
+		t.Fatalf("wrong address supplied, exp %s, got %s", exp, got)
+	}
+	if exp, got := cluster.BootDone, bs.Status(); exp != got {
+		t.Fatalf("wrong status, exp %s, got %s", exp, got)
+	}
+}
+
+func Test_BootstrapperBootMultiJoinNotify(t *testing.T) {
+	var srv1JoinC int32
+	var srv1NotifiedC int32
+	srv1 := servertest.NewTestServer()
+	defer srv1.Close()
+
+	srv1.JoinHandler = func(nr *proto.JoinRequest) (*proto.JoinResponse, error) {
+		atomic.AddInt32(&srv1JoinC, 1)
+		return nil, fmt.Errorf("not a cluster")
+	}
+
+	srv1.NotifyHandler = func(nr *proto.NotifyRequest) (*proto.NotifyResponse, error) {
+		atomic.AddInt32(&srv1NotifiedC, 1)
+		return &proto.NotifyResponse{}, nil
+	}
+
+	var srv2JoinC int32
+	var srv2NotifiedC int32
+	srv2 := servertest.NewTestServer()
+	defer srv2.Close()
+
+	srv2.JoinHandler = func(nr *proto.JoinRequest) (*proto.JoinResponse, error) {
+		atomic.AddInt32(&srv2JoinC, 1)
+		return nil, fmt.Errorf("not a cluster")
+	}
+
+	srv2.NotifyHandler = func(nr *proto.NotifyRequest) (*proto.NotifyResponse, error) {
+		atomic.AddInt32(&srv2NotifiedC, 1)
+		return &proto.NotifyResponse{}, nil
+	}
+
+	n := -1
+	done := func() bool {
+		n++
+		return n == 5
+	}
+
+	p := NewAddressProviderString([]string{srv1.Addr(), srv2.Addr()})
+	clientMgr := client.NewClientManager(nil)
+	bs := NewBootstrapper(p, clientMgr)
+	bs.Interval = time.Second
+
+	err := bs.Boot(context.Background(), "node1", "192.168.1.1:1234", cluster.Voter, done, 60*time.Second)
+	if err != nil {
+		t.Fatalf("failed to boot: %s", err)
+	}
+
+	if atomic.LoadInt32(&srv1JoinC) < 1 || atomic.LoadInt32(&srv2JoinC) < 1 {
+		t.Fatalf("all join targets not contacted")
+	}
+	if atomic.LoadInt32(&srv2JoinC) < 1 || atomic.LoadInt32(&srv2NotifiedC) < 1 {
+		t.Fatalf("all notify targets not contacted")
+	}
+	if exp, got := cluster.BootDone, bs.Status(); exp != got {
+		t.Fatalf("wrong status, exp %s, got %s", exp, got)
+	}
+}

--- a/internal/cluster/client/client_manager.go
+++ b/internal/cluster/client/client_manager.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -11,70 +12,103 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
 	"github.com/pbinitiative/zenbpm/internal/cluster/store"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
 	dialTimeout = 5 * time.Second
 )
 
+type clientData struct {
+	conn *grpc.ClientConn
+	c    proto.ZenServiceClient
+}
+
 type ClientManager struct {
 	// mu is a mutext for protecting activeClients
 	mu sync.RWMutex
-	// TODO: clear map of clients after its node is shut down
-	activeClients map[string]proto.ZenServiceClient
+
+	activeClients map[string]clientData
 
 	store *store.Store
 }
 
-func New(store *store.Store) *ClientManager {
+func NewClientManager(store *store.Store) *ClientManager {
 	return &ClientManager{
-		activeClients: map[string]proto.ZenServiceClient{},
+		activeClients: map[string]clientData{},
 		store:         store,
 		mu:            sync.RWMutex{},
 	}
 }
 
+func (c *ClientManager) Close() error {
+	var joinErr error
+	for _, cd := range c.activeClients {
+		err := cd.conn.Close()
+		if err != nil {
+			joinErr = errors.Join(joinErr, fmt.Errorf("failed to close client %s: %w", cd.conn.Target(), err))
+		}
+	}
+	return joinErr
+}
+
 func (c *ClientManager) ClusterLeader() (proto.ZenServiceClient, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	leaderAddr, leaderId := c.store.LeaderWithID()
+	leaderAddr, _ := c.store.LeaderWithID()
 	var err error
 	if leaderAddr == "" {
 		return nil, fmt.Errorf("failed to get leader address for cluster client: no leader available")
 	}
-	client, ok := c.activeClients[leaderId]
+	c.mu.RLock()
+	client, ok := c.activeClients[leaderAddr]
+	c.mu.RUnlock()
 	if !ok {
-		client, err = c.newClient(leaderId, leaderAddr)
+		return c.newClient(leaderAddr)
 	}
-	return client, err
+	return client.c, err
 }
 
 func (c *ClientManager) PartitionLeader(partition uint32) (proto.ZenServiceClient, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	leaderAddr, leaderId := c.store.PartitionLeaderWithID(partition)
+	leaderAddr, _ := c.store.PartitionLeaderWithID(partition)
 	var err error
 	if leaderAddr == "" {
 		return nil, fmt.Errorf("failed to get leader address for cluster client: no leader available")
 	}
-	client, ok := c.activeClients[leaderId]
+	c.mu.RLock()
+	client, ok := c.activeClients[leaderAddr]
+	c.mu.RUnlock()
 	if !ok {
-		client, err = c.newClient(leaderId, leaderAddr)
+		return c.newClient(leaderAddr)
 	}
-	return client, err
+	return client.c, err
 }
 
-func (c *ClientManager) newClient(nodeId string, nodeAddr string) (proto.ZenServiceClient, error) {
+func (c *ClientManager) For(targetAddr string) (proto.ZenServiceClient, error) {
+	c.mu.RLock()
+	client, ok := c.activeClients[targetAddr]
+	c.mu.RUnlock()
+	if !ok {
+		return c.newClient(targetAddr)
+	}
+	return client.c, nil
+}
+
+func (c *ClientManager) newClient(nodeAddr string) (proto.ZenServiceClient, error) {
 	dialer := network.NewZenBpmClusterDialer()
-	grpcClient, err := grpc.NewClient(nodeAddr, grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
-		return dialer.Dial(s, dialTimeout)
-	}))
+	grpcClient, err := grpc.NewClient(nodeAddr,
+		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+			return dialer.Dial(s, dialTimeout)
+		}),
+		// TODO: add credentials at later stage
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new GRPC client")
+		return nil, fmt.Errorf("failed to create new GRPC client: %w", err)
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	zsc := proto.NewZenServiceClient(grpcClient)
-	c.activeClients[nodeId] = zsc
-	return zsc, nil
+	c.activeClients[nodeAddr] = clientData{
+		conn: grpcClient,
+		c:    proto.NewZenServiceClient(grpcClient),
+	}
+	return c.activeClients[nodeAddr].c, nil
 }

--- a/internal/cluster/controller.go
+++ b/internal/cluster/controller.go
@@ -35,7 +35,7 @@ func (c *controller) Start() error {
 	rqLiteConfig := c.config.RqLite
 
 	if c.config.RqLite == nil {
-		defaultConfig := GetRqLiteDefaultConfig(c.store.ID(), c.store.Addr(), c.store.ID(), []string{})
+		defaultConfig := GetRqLiteDefaultConfig(c.store.ID(), c.store.Addr(), c.store.ID(), c.config.Raft.JoinAddresses)
 		rqLiteConfig = &defaultConfig
 	}
 	err := rqLiteConfig.Validate()
@@ -81,7 +81,7 @@ func (c *controller) startPartition(ctx context.Context, partitionId uint32) err
 	}
 	partitionConf := *rqLiteConfig
 	partitionConf.NodeID = fmt.Sprintf("zen-%s-partition-%d", c.store.ID(), partitionId)
-	partitionConf.DataPath = path.Join(c.config.RaftDir, fmt.Sprintf("partition-%d", partitionId))
+	partitionConf.DataPath = path.Join(c.config.Raft.Dir, fmt.Sprintf("partition-%d", partitionId))
 	partition, err := StartZenPartitionNode(ctx, c.mux, &partitionConf, partitionId)
 	if err != nil {
 		return fmt.Errorf("failed to start zen partition %d: %w", partitionId, err)

--- a/internal/cluster/join.go
+++ b/internal/cluster/join.go
@@ -1,0 +1,105 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/pbinitiative/zenbpm/internal/cluster/client"
+	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
+	"github.com/rqlite/rqlite/v8/cluster"
+)
+
+var (
+	// ErrNodeIDRequired is returned a join request doesn't supply a node ID
+	ErrNodeIDRequired = errors.New("node required")
+
+	// ErrJoinFailed is returned when a node fails to join a cluster
+	ErrJoinFailed = errors.New("failed to join cluster")
+
+	// ErrJoinCanceled is returned when a join operation is canceled
+	ErrJoinCanceled = errors.New("join operation canceled")
+
+	// ErrNotifyFailed is returned when a node fails to notify another node
+	ErrNotifyFailed = errors.New("failed to notify node")
+)
+
+// Joiner executes a node-join operation.
+type Joiner struct {
+	numAttempts     int
+	attemptInterval time.Duration
+
+	clientMgr *client.ClientManager
+	logger    hclog.Logger
+}
+
+// NewJoiner returns an instantiated Joiner.
+func NewJoiner(clientMgr *client.ClientManager, numAttempts int, attemptInterval time.Duration) *Joiner {
+	return &Joiner{
+		clientMgr:       clientMgr,
+		numAttempts:     numAttempts,
+		attemptInterval: attemptInterval,
+		logger:          hclog.Default().Named("cluster-join"),
+	}
+}
+
+// Do makes the actual join request. If the join is successful with any address,
+// that address is returned. Otherwise, an error is returned.
+func (j *Joiner) Do(ctx context.Context, targetAddrs []string, id, addr string, suf cluster.Suffrage) (string, error) {
+	if id == "" {
+		return "", ErrNodeIDRequired
+	}
+
+	var err error
+	var joinee string
+	for i := range j.numAttempts {
+		for _, ta := range targetAddrs {
+			select {
+			case <-ctx.Done():
+				return "", ErrJoinCanceled
+			default:
+				joinee, err = j.join(ta, id, addr, suf)
+				if err == nil {
+					return joinee, nil
+				}
+				j.logger.Error(fmt.Sprintf("failed to join via node at %s: %s", ta, err))
+			}
+		}
+		if i+1 < j.numAttempts {
+			// This logic message only make sense if performing more than 1 join-attempt.
+			j.logger.Error(fmt.Sprintf("failed to join cluster at %s, sleeping %s before retry", targetAddrs, j.attemptInterval))
+			select {
+			case <-ctx.Done():
+				return "", ErrJoinCanceled
+			case <-time.After(j.attemptInterval):
+				continue // Proceed with the next attempt
+			}
+		}
+	}
+	j.logger.Error(fmt.Sprintf("failed to join cluster at %s, after %d attempt(s)", targetAddrs, j.numAttempts))
+	return "", ErrJoinFailed
+}
+
+func (j *Joiner) join(targetAddr, id, addr string, suf cluster.Suffrage) (string, error) {
+	req := &proto.JoinRequest{
+		Id:      id,
+		Address: addr,
+		Voter:   suf.IsVoter(),
+	}
+
+	// Attempt to join.
+	client, err := j.clientMgr.For(targetAddr)
+	if err != nil {
+		j.logger.Error(fmt.Sprintf("failed to create client for %s: %s", targetAddr, err))
+		return "", fmt.Errorf("failed to create client for %s: %w", targetAddr, err)
+	}
+	timeoutCtx, cancelCtx := context.WithTimeout(context.Background(), time.Second)
+	_, err = client.Join(timeoutCtx, req)
+	cancelCtx()
+	if err != nil {
+		return "", fmt.Errorf("failed to call Join on %s: %w", targetAddr, err)
+	}
+	return targetAddr, nil
+}

--- a/internal/cluster/join_test.go
+++ b/internal/cluster/join_test.go
@@ -1,0 +1,120 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/internal/cluster/client"
+	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
+	"github.com/pbinitiative/zenbpm/internal/cluster/server/servertest"
+	"github.com/rqlite/rqlite/v8/cluster"
+)
+
+const numAttempts int = 3
+const attemptInterval = 1 * time.Second
+
+func Test_SingleJoinOK(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+	srv.JoinHandler = func(jr *proto.JoinRequest) (*proto.JoinResponse, error) {
+		if jr == nil {
+			t.Fatal("join request is nil")
+		}
+		if exp, got := "id0", jr.Id; exp != got {
+			t.Fatalf("unexpected id, got %s, exp: %s", got, exp)
+		}
+		if exp, got := "1.2.3.4", jr.Address; exp != got {
+			t.Fatalf("unexpected addr, got %s, exp: %s", got, exp)
+		}
+		return &proto.JoinResponse{}, nil
+	}
+
+	clientMgr := client.NewClientManager(nil)
+	joiner := NewJoiner(clientMgr, numAttempts, attemptInterval)
+	addr, err := joiner.Do(context.Background(), []string{srv.Addr()}, "id0", "1.2.3.4", cluster.Voter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := srv.Addr(), addr; exp != got {
+		t.Fatalf("unexpected addr, got %s, exp: %s", got, exp)
+	}
+}
+
+func Test_SingleJoinZeroAttempts(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+	srv.GlobalHandler = func() error {
+		t.Fatalf("handler should not have been called")
+		return nil
+	}
+
+	clientMgr := client.NewClientManager(nil)
+	joiner := NewJoiner(clientMgr, 0, attemptInterval)
+	_, err := joiner.Do(context.Background(), []string{srv.Addr()}, "id0", "1.2.3.4", cluster.Voter)
+	if err != ErrJoinFailed {
+		t.Fatalf("Incorrect error returned when zero attempts specified")
+	}
+}
+
+func Test_SingleJoinFail(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+	srv.JoinHandler = func(jr *proto.JoinRequest) (*proto.JoinResponse, error) {
+		return &proto.JoinResponse{}, fmt.Errorf("bad request")
+	}
+
+	clientMgr := client.NewClientManager(nil)
+	joiner := NewJoiner(clientMgr, numAttempts, attemptInterval)
+	_, err := joiner.Do(context.Background(), []string{srv.Addr()}, "id0", "1.2.3.4", cluster.Voter)
+	if err == nil {
+		t.Fatalf("expected error when joining bad node")
+	}
+}
+
+func Test_SingleJoinCancel(t *testing.T) {
+	srv := servertest.NewTestServer()
+	defer srv.Close()
+	srv.JoinHandler = func(jr *proto.JoinRequest) (*proto.JoinResponse, error) {
+		return &proto.JoinResponse{}, fmt.Errorf("bad request")
+	}
+
+	// Cancel the join in a few seconds time.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(3 * time.Second)
+		cancel()
+	}()
+
+	clientMgr := client.NewClientManager(nil)
+	joiner := NewJoiner(clientMgr, 10, attemptInterval)
+	_, err := joiner.Do(ctx, []string{srv.Addr()}, "id0", "1.2.3.4", cluster.Voter)
+	if err != ErrJoinCanceled {
+		t.Fatalf("incorrect error returned when canceling: %s", err)
+	}
+}
+
+func Test_DoubleJoinOKSecondNode(t *testing.T) {
+	srv1 := servertest.NewTestServer()
+	defer srv1.Close()
+	srv1.JoinHandler = func(jr *proto.JoinRequest) (*proto.JoinResponse, error) {
+		return &proto.JoinResponse{}, fmt.Errorf("bad request")
+	}
+
+	srv2 := servertest.NewTestServer()
+	defer srv2.Close()
+	srv2.JoinHandler = func(jr *proto.JoinRequest) (*proto.JoinResponse, error) {
+		return &proto.JoinResponse{}, nil
+	}
+
+	clientMgr := client.NewClientManager(nil)
+	joiner := NewJoiner(clientMgr, numAttempts, attemptInterval)
+	addr, err := joiner.Do(context.Background(), []string{srv1.Addr(), srv2.Addr()}, "id0", "1.2.3.4", cluster.Voter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := srv2.Addr(), addr; exp != got {
+		t.Fatalf("unexpected addr, got %s, exp: %s", got, exp)
+	}
+}

--- a/internal/cluster/network/mux.go
+++ b/internal/cluster/network/mux.go
@@ -7,9 +7,10 @@ import (
 	"github.com/rqlite/rqlite/v8/tcp"
 )
 
-// NewMux creates a new instance of TCP multiplexer.
+// NewNodeMux creates a new instance of TCP multiplexer.
 // Multiplexer can route its connections based on a header byte.
-func NewMux(address string) (*tcp.Mux, error) {
+// Providing empty string to the address will start on a random free port.
+func NewNodeMux(address string) (*tcp.Mux, error) {
 	// Create internode network mux and configure it.
 	muxLn, err := net.Listen("tcp", address)
 	if err != nil {

--- a/internal/cluster/partition_persistence_test.go
+++ b/internal/cluster/partition_persistence_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRqLiteStorage(t *testing.T) {
 	ctx := context.Background()
-	mux, err := network.NewMux("")
+	mux, err := network.NewNodeMux("")
 	if err != nil {
 		t.Fatalf("failed to create mux: %s", err)
 	}

--- a/internal/cluster/proto/zen_cluster.proto
+++ b/internal/cluster/proto/zen_cluster.proto
@@ -24,6 +24,7 @@ service ZenService {
 	rpc NodeCommand(zencommand.Command) returns (NodeCommandResponse);
 }
 
+// TODO: do we want to keep custom error struct or use the default error handling?
 message ErrorResult {
 	uint32 code = 1;
 	string message = 2;

--- a/internal/cluster/server/server.go
+++ b/internal/cluster/server/server.go
@@ -63,6 +63,7 @@ func (s *Server) Notify(ctx context.Context, req *proto.NotifyRequest) (*proto.N
 	}
 	return &proto.NotifyResponse{}, nil
 }
+
 func (s *Server) Join(ctx context.Context, req *proto.JoinRequest) (*proto.JoinResponse, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()

--- a/internal/cluster/server/server_test.go
+++ b/internal/cluster/server/server_test.go
@@ -17,7 +17,7 @@ import (
 func TestServer(t *testing.T) {
 	ctx := t.Context()
 
-	mux, err := network.NewMux("")
+	mux, err := network.NewNodeMux("")
 	if err != nil {
 		t.Fatalf("failed to create new mux: %s", err)
 	}
@@ -69,7 +69,7 @@ func TestServer(t *testing.T) {
 func TestServerTCPHeaderMux(t *testing.T) {
 	ctx := t.Context()
 
-	mux, err := network.NewMux("")
+	mux, err := network.NewNodeMux("")
 	if err != nil {
 		t.Fatalf("failed to create new mux: %s", err)
 	}

--- a/internal/cluster/server/servertest/server.go
+++ b/internal/cluster/server/servertest/server.go
@@ -1,0 +1,72 @@
+package servertest
+
+import (
+	"context"
+	"net"
+
+	"github.com/pbinitiative/zenbpm/internal/cluster/network"
+	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
+	"google.golang.org/grpc"
+)
+
+type TestServer struct {
+	proto.UnimplementedZenServiceServer
+	Listener      net.Listener
+	JoinHandler   func(*proto.JoinRequest) (*proto.JoinResponse, error)
+	NotifyHandler func(*proto.NotifyRequest) (*proto.NotifyResponse, error)
+	GlobalHandler func() error
+}
+
+// New returns a new instance of a TestServer
+func NewTestServer() *TestServer {
+	mux, err := network.NewNodeMux("")
+	ln := network.NewZenBpmClusterListener(mux)
+	if err != nil {
+		panic("service: failed to listen: " + err.Error())
+	}
+	s := &TestServer{
+		Listener: ln,
+	}
+
+	srv := grpc.NewServer()
+	proto.RegisterZenServiceServer(srv, s)
+	go func() {
+		err := srv.Serve(ln)
+		if err != nil {
+			panic(err)
+		}
+	}()
+	return s
+}
+
+var _ proto.ZenServiceServer = &TestServer{}
+
+// Close closes the TestServer.
+func (s *TestServer) Close() error {
+	s.Listener.Close()
+	return nil
+}
+
+func (s *TestServer) Addr() string {
+	return s.Listener.Addr().String()
+}
+
+func (s *TestServer) Notify(ctx context.Context, req *proto.NotifyRequest) (*proto.NotifyResponse, error) {
+	if s.NotifyHandler != nil {
+		return s.NotifyHandler(req)
+	}
+	if s.GlobalHandler != nil {
+		return &proto.NotifyResponse{}, s.GlobalHandler()
+	}
+	return &proto.NotifyResponse{}, nil
+}
+
+func (s *TestServer) Join(ctx context.Context, req *proto.JoinRequest) (*proto.JoinResponse, error) {
+	if s.JoinHandler != nil {
+		return s.JoinHandler(req)
+	}
+	if s.GlobalHandler != nil {
+		return &proto.JoinResponse{}, s.GlobalHandler()
+	}
+	return &proto.JoinResponse{}, nil
+}

--- a/internal/cluster/store/store_multi_test.go
+++ b/internal/cluster/store/store_multi_test.go
@@ -14,7 +14,9 @@ import (
 
 func Test_MultiNode_VerifyLeader(t *testing.T) {
 	c1 := config.Cluster{
-		RaftDir: filepath.Join(t.TempDir(), "s1"),
+		Raft: config.ClusterRaft{
+			Dir: filepath.Join(t.TempDir(), "s1"),
+		},
 	}
 	s1, ln1 := newMustTestStore(t, c1)
 	defer s1.Close(true)
@@ -40,7 +42,9 @@ func Test_MultiNode_VerifyLeader(t *testing.T) {
 	}
 
 	c2 := config.Cluster{
-		RaftDir: filepath.Join(t.TempDir(), "s2"),
+		Raft: config.ClusterRaft{
+			Dir: filepath.Join(t.TempDir(), "s2"),
+		},
 	}
 
 	s2, ln2 := newMustTestStore(t, c2)
@@ -86,7 +90,9 @@ func Test_MultiNodeSimple(t *testing.T) {
 	testPartitionId := uint32(1)
 
 	c1 := config.Cluster{
-		RaftDir: filepath.Join(t.TempDir(), "s1"),
+		Raft: config.ClusterRaft{
+			Dir: filepath.Join(t.TempDir(), "s1"),
+		},
 	}
 	s1, ln1 := newMustTestStore(t, c1)
 	defer s1.Close(true)
@@ -108,7 +114,9 @@ func Test_MultiNodeSimple(t *testing.T) {
 	}
 
 	c2 := config.Cluster{
-		RaftDir: filepath.Join(t.TempDir(), "s2"),
+		Raft: config.ClusterRaft{
+			Dir: filepath.Join(t.TempDir(), "s2"),
+		},
 	}
 	s2, ln2 := newMustTestStore(t, c2)
 	defer s2.Close(true)
@@ -205,8 +213,10 @@ func Test_MultiNodeSimple(t *testing.T) {
 
 func Test_MultiNodePeerObservations(t *testing.T) {
 	c1 := config.Cluster{
-		RaftDir: filepath.Join(t.TempDir(), "s1"),
-		NodeId:  fmt.Sprintf("s1-%s", random.String()),
+		Raft: config.ClusterRaft{
+			Dir: filepath.Join(t.TempDir(), "s1"),
+		},
+		NodeId: fmt.Sprintf("s1-%s", random.String()),
 	}
 	s1, ln1 := newMustTestStore(t, c1)
 	defer s1.Close(true)
@@ -228,8 +238,10 @@ func Test_MultiNodePeerObservations(t *testing.T) {
 	}
 
 	c2 := config.Cluster{
-		RaftDir: filepath.Join(t.TempDir(), "s2"),
-		NodeId:  fmt.Sprintf("s2-%s", random.String()),
+		Raft: config.ClusterRaft{
+			Dir: filepath.Join(t.TempDir(), "s2"),
+		},
+		NodeId: fmt.Sprintf("s2-%s", random.String()),
 	}
 	s2, ln2 := newMustTestStore(t, c2)
 	defer s2.Close(true)
@@ -283,8 +295,10 @@ func Test_MultiNodePeerObservations(t *testing.T) {
 	verifyStoreUpdatedNodeState(t, s2)
 
 	c3 := config.Cluster{
-		RaftDir: filepath.Join(t.TempDir(), "s3"),
-		NodeId:  fmt.Sprintf("s3-%s", random.String()),
+		Raft: config.ClusterRaft{
+			Dir: filepath.Join(t.TempDir(), "s2"),
+		},
+		NodeId: fmt.Sprintf("s3-%s", random.String()),
 	}
 	s3, ln3 := newMustTestStore(t, c3)
 	defer s3.Close(true)

--- a/internal/cluster/store/store_test.go
+++ b/internal/cluster/store/store_test.go
@@ -59,7 +59,9 @@ func Test_NonOpenStore(t *testing.T) {
 // Test_OpenStoreSingleNode tests that a single node basically operates.
 func Test_OpenStoreSingleNode(t *testing.T) {
 	c := config.Cluster{
-		RaftDir: t.TempDir(),
+		Raft: config.ClusterRaft{
+			Dir: t.TempDir(),
+		},
 	}
 
 	s, ln := newMustTestStore(t, c)
@@ -100,8 +102,10 @@ func Test_OpenStoreSingleNode(t *testing.T) {
 // Test_StoreRestartSingleNode tests that a store shutdown and opening a new instance results in the same state.
 func Test_StoreRestartSingleNode(t *testing.T) {
 	c := config.Cluster{
-		RaftDir: t.TempDir(),
-		NodeId:  random.String(),
+		Raft: config.ClusterRaft{
+			Dir: t.TempDir(),
+		},
+		NodeId: random.String(),
 	}
 
 	s, ln := newMustTestStore(t, c)
@@ -168,7 +172,9 @@ func Test_StoreRestartSingleNode(t *testing.T) {
 // and recovers from it.
 func Test_SingleNodeSnapshot(t *testing.T) {
 	c := config.Cluster{
-		RaftDir: t.TempDir(),
+		Raft: config.ClusterRaft{
+			Dir: t.TempDir(),
+		},
 	}
 
 	s, ln := newMustTestStore(t, c)
@@ -287,10 +293,10 @@ func (m *mockSnapshotSink) Cancel() error {
 
 func newMustTestStore(t *testing.T, c config.Cluster) (*Store, net.Listener) {
 	addr := ""
-	if c.RaftAddr != "" {
-		addr = c.RaftAddr
+	if c.Addr != "" {
+		addr = c.Addr
 	}
-	mux, err := network.NewMux(addr)
+	mux, err := network.NewNodeMux(addr)
 	if err != nil {
 		t.Fatalf("failed to start network mux: %s", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,12 +3,17 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
+	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/ilyakaznacheev/cleanenv"
-	"github.com/rqlite/rqlite/v8/random"
+	"github.com/pbinitiative/zenbpm/internal/cluster/network"
 )
 
+// TODO: add support for discovery modes
 const (
 	DiscoModeNone     = ""
 	DiscoModeConsulKV = "consul-kv"
@@ -26,13 +31,31 @@ type Config struct {
 // TODO: clean up cluster & rqlite configuration
 type Cluster struct {
 	// BootstrapExpect sets expected number of servers to join into the cluster before bootstrap is called
-	BootstrapExpect int `yaml:"bootstrapExpect" json:"bootstrapExpect" env:"CLUSTER_BOOTSTRAP_EXPECT"`
-	// Bootstrap
-	Bootstrap bool    `yaml:"bootstrap" json:"bootstrap" env:"CLUSTER_BOOTSTRAP"`
-	RaftAddr  string  `yaml:"raftAddr" json:"raftAddr" env:"CLUSTER_RAFT_ADDR" env-default:":8090"`
-	RaftDir   string  `yaml:"raftDir" json:"raftDir" env:"CLUSTER_RAFT_DIR"`
-	NodeId    string  `yaml:"nodeId" json:"nodeId" env:"CLUSTER_NODE_ID"`
-	RqLite    *RqLite `yaml:"rqlite" json:"rqlite"`
+	NodeId string `yaml:"nodeId" json:"nodeId" env:"CLUSTER_NODE_ID"`
+	// internal communication bind address
+	Addr string `yaml:"addr" json:"addr" env:"CLUSTER_RAFT_ADDR" env-default:":8090"`
+	// inter communication advertise address. If not set, same as internal communication bind address
+	Adv    string      `yaml:"adv" json:"adv" env:"CLUSTER_RAFT_ADV"`
+	Raft   ClusterRaft `yaml:"raft" json:"raft"`
+	RqLite *RqLite     `yaml:"rqlite" json:"rqlite"`
+}
+
+type ClusterRaft struct {
+	// Dir is path to node data. Always set
+	Dir string `yaml:"dir" json:"dir" env:"CLUSTER_RAFT_DIR" env-default:"zen_bpm_node_data"`
+	// Configure as non-voting node
+	NonVoter bool `yaml:"nonVoter" json:"nonVoter" env:"CLUSTER_RAFT_NON_VOTER"`
+	// Number of join attempts to make
+	JoinAttempts int `yaml:"joinAttempts" json:"joinAttempts" env:"CLUSTER_RAFT_JOIN_ATTEMPTS" env-default:"5"`
+	// Period between join attempts
+	JoinInterval time.Duration `yaml:"joinInterval" json:"joinInterval" env:"CLUSTER_RAFT_JOIN_INTERVAL" env-default:"2s"`
+	// List of nodes, in host:port form, through which a cluster can be joined
+	JoinAddresses []string `yaml:"joinAddresses" json:"joinAddresses" env:"CLUSTER_RAFT_JOIN_ADDRESSES"`
+	// Minimum number of nodes required for a bootstrap
+	BootstrapExpect int `yaml:"bootstrapExpect" json:"bootstrapExpect" env:"CLUSTER_RAFT_BOOTSTRAP_EXPECT" env-default:"0"`
+	// Maximum time for bootstrap process
+	BootstrapExpectTimeout time.Duration `yaml:"bootstrapExpectTimeout" json:"bootstrapExpectTimeout" env:"CLUSTER_RAFT_EXPECT_BOOTSTRAP_TIMEOUT" env-default:"10s"`
+	// Bootstrap              bool `yaml:"bootstrap" json:"bootstrap" env:"CLUSTER_RAFT_BOOTSTRAP"`
 }
 
 type Server struct {
@@ -40,14 +63,74 @@ type Server struct {
 	Addr    string `yaml:"addr" json:"addr" env:"REST_API_ADDR" env-default:":8080"`
 }
 
-func (c Config) defaults() Config {
+// validate checks the configuration for internal consistency, and activates
+// important zenbpm policies. It must be called at least once on a Config
+// object before the Config object is used.
+func (c *Config) validate() error {
 	if c.Cluster.NodeId == "" {
-		c.Cluster.NodeId = random.String()
+		c.Cluster.NodeId = c.Cluster.Adv
 	}
-	if c.Cluster.RaftDir == "" {
-		c.Cluster.RaftDir = c.Cluster.NodeId
+	if c.Cluster.Raft.Dir == "" {
+		c.Cluster.Raft.Dir = c.Cluster.NodeId
 	}
-	return c
+	dataPath, err := filepath.Abs(c.Cluster.Raft.Dir)
+	if err != nil {
+		return fmt.Errorf("failed to determine absolute data path: %s", err.Error())
+	}
+	c.Cluster.Raft.Dir = dataPath
+
+	err = CheckFilePaths(&c.Cluster.Raft)
+	if err != nil {
+		return err
+	}
+
+	if c.Cluster.Adv == "" {
+		c.Cluster.Adv = c.Cluster.Addr
+	}
+
+	if _, rp, err := net.SplitHostPort(c.Cluster.Addr); err != nil {
+		return errors.New("raft bind address not valid")
+	} else if _, err := strconv.Atoi(rp); err != nil {
+		return errors.New("raft bind port not valid")
+	}
+
+	radv, rp, err := net.SplitHostPort(c.Cluster.Adv)
+	if err != nil {
+		return errors.New("raft advertised address not valid")
+	}
+	if addr := net.ParseIP(radv); addr != nil && addr.IsUnspecified() {
+		return fmt.Errorf("advertised Raft address is not routable (%s), specify it via cluster.raft.addr or cluster.raft.adv",
+			radv)
+	}
+	if _, err := strconv.Atoi(rp); err != nil {
+		return errors.New("raft advertised port is not valid")
+	}
+
+	// Enforce bootstrapping policies
+	if c.Cluster.Raft.BootstrapExpect > 0 && c.Cluster.Raft.NonVoter {
+		return errors.New("bootstrapping only applicable to voting nodes")
+	}
+
+	// Join parameters OK?
+	if len(c.Cluster.Raft.JoinAddresses) > 0 {
+		for _, addr := range c.Cluster.Raft.JoinAddresses {
+			if _, _, err := net.SplitHostPort(addr); err != nil {
+				return fmt.Errorf("%s is an invalid join address", addr)
+			}
+
+			if c.Cluster.Raft.BootstrapExpect == 0 {
+				if addr == c.Cluster.Adv || addr == c.Cluster.Addr {
+					return errors.New("node cannot join with itself unless bootstrapping")
+				}
+			}
+		}
+	}
+	err = network.CheckJoinAddrs(c.Cluster.Raft.JoinAddresses)
+	if err != nil {
+		return fmt.Errorf("invalid join addresses: %w", err)
+	}
+
+	return nil
 }
 
 func InitConfig() Config {
@@ -74,5 +157,10 @@ func InitConfig() Config {
 		fmt.Printf("Error occurred while reading the configuration: %s\n", err)
 		panic(err)
 	}
-	return c.defaults()
+	err = c.validate()
+	if err != nil {
+		fmt.Printf("Error occurred while validating configuration: %s\n", err)
+		panic(err)
+	}
+	return c
 }

--- a/internal/config/rqlite.go
+++ b/internal/config/rqlite.go
@@ -193,7 +193,7 @@ func (c *RqLite) Validate() error {
 	}
 	c.DataPath = dataPath
 
-	err = c.CheckFilePaths()
+	err = CheckFilePaths(c)
 	if err != nil {
 		return err
 	}
@@ -227,7 +227,7 @@ func (c *RqLite) Validate() error {
 		return errors.New("raft advertised address not valid")
 	}
 	if addr := net.ParseIP(radv); addr != nil && addr.IsUnspecified() {
-		return fmt.Errorf("advertised Raft address is not routable (%s), specify it via RaftAddr or RaftAdv",
+		return fmt.Errorf("advertised Raft address is not routable (%s), specify it via cluster.raft.addr or cluster.raft.adv",
 			radv)
 	}
 	if _, err := strconv.Atoi(rp); err != nil {
@@ -336,11 +336,11 @@ func (c *RqLite) DiscoConfigReader() io.ReadCloser {
 
 // CheckFilePaths checks that all file paths in the config exist.
 // Empty filepaths are ignored.
-func (c *RqLite) CheckFilePaths() error {
-	v := reflect.ValueOf(c).Elem()
+func CheckFilePaths(s any) error {
+	v := reflect.ValueOf(s).Elem()
 
 	// Iterate through the fields of the struct
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		field := v.Type().Field(i)
 		fieldValue := v.Field(i)
 

--- a/internal/log/hclog.go
+++ b/internal/log/hclog.go
@@ -170,7 +170,8 @@ func (l *HcLogger) GetLevel() hclog.Level {
 }
 
 func (l *HcLogger) StandardLogger(opts *hclog.StandardLoggerOptions) *log.Logger {
-	return log.New(l.StandardWriter(opts), "", log.LstdFlags)
+	logger := NewHcLog(l.slog, 5)
+	return log.New(logger.StandardWriter(opts), "", log.LstdFlags)
 }
 
 func (l *HcLogger) StandardWriter(opts *hclog.StandardLoggerOptions) io.Writer {


### PR DESCRIPTION
For now we support:
 - bootstrapping the cluster with expected number of nodes (one node can bootstrap itself by specifying only its address in joinAddresses)
 - joining an existing cluster by specifying joinAddresses of existing members of the cluster

closes #64 

