### PR TITLE
feat(171): Duplicate deployment returns invalid key

### DIFF
--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -2,9 +2,11 @@ package cluster
 
 import (
 	"context"
+	"crypto/md5"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/pbinitiative/zenbpm/internal/log"
 	"io"
 	"net"
 	"sync"
@@ -227,6 +229,13 @@ func (node *ZenNode) GetReadOnlyDB(ctx context.Context) (*RqLiteDB, error) {
 }
 
 func (node *ZenNode) DeployDefinitionToAllPartitions(ctx context.Context, data []byte) (int64, error) {
+	key, err := node.GetDefinitionKeyByBytes(ctx, data)
+	if err != nil {
+		log.Error("Failed to get definition key by bytes: %s", err)
+	}
+	if key != 0 {
+		return key, err
+	}
 	gen, _ := snowflake.NewNode(0)
 	definitionKey := gen.Generate()
 	state := node.store.ClusterState()
@@ -254,6 +263,19 @@ func (node *ZenNode) DeployDefinitionToAllPartitions(ctx context.Context, data [
 		return definitionKey.Int64(), errJoin
 	}
 	return definitionKey.Int64(), nil
+}
+
+func (node *ZenNode) GetDefinitionKeyByBytes(ctx context.Context, data []byte) (int64, error) {
+	db, err := node.GetReadOnlyDB(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get database for definition key lookup: %w", err)
+	}
+	md5sum := md5.Sum(data)
+	key, err := db.queries.GetDefinitionKeyByChecksum(ctx, md5sum[:])
+	if err != nil && err.Error() != "No result row" {
+		return 0, fmt.Errorf("failed to find process definition by checksum: %w", err)
+	}
+	return key, nil
 }
 
 func (node *ZenNode) CompleteJob(ctx context.Context, key int64, variables map[string]any) error {

--- a/internal/sql/process_definition.sql.go
+++ b/internal/sql/process_definition.sql.go
@@ -236,6 +236,23 @@ func (q *Queries) FindProcessDefinitionsByKeys(ctx context.Context, keys []int64
 	return items, nil
 }
 
+const getDefinitionKeyByChecksum = `-- name: GetDefinitionKeyByChecksum :one
+SELECT
+    key
+FROM
+    process_definition
+WHERE
+    bpmn_checksum = ?1
+LIMIT 1
+`
+
+func (q *Queries) GetDefinitionKeyByChecksum(ctx context.Context, bpmnChecksum []byte) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getDefinitionKeyByChecksum, bpmnChecksum)
+	var key int64
+	err := row.Scan(&key)
+	return key, err
+}
+
 const saveProcessDefinition = `-- name: SaveProcessDefinition :exec
 INSERT INTO process_definition(key, version, bpmn_process_id, bpmn_data, bpmn_checksum, bpmn_resource_name)
     VALUES (?, ?, ?, ?, ?, ?)

--- a/internal/sql/querier.go
+++ b/internal/sql/querier.go
@@ -39,15 +39,16 @@ type Querier interface {
 	FindTimersInStateTillDueAt(ctx context.Context, arg FindTimersInStateTillDueAtParams) ([]Timer, error)
 	FindTokenMessageSubscriptions(ctx context.Context, arg FindTokenMessageSubscriptionsParams) ([]MessageSubscription, error)
 	FindTokenTimers(ctx context.Context, arg FindTokenTimersParams) ([]Timer, error)
+	GetDefinitionKeyByChecksum(ctx context.Context, bpmnChecksum []byte) (int64, error)
 	GetFlowElementHistory(ctx context.Context, processInstanceKey int64) ([]FlowElementHistory, error)
 	GetMigrations(ctx context.Context) ([]Migration, error)
 	GetProcessInstance(ctx context.Context, key int64) (ProcessInstance, error)
 	GetTokens(ctx context.Context, keys []int64) ([]ExecutionToken, error)
 	GetTokensForProcessInstance(ctx context.Context, arg GetTokensForProcessInstanceParams) ([]ExecutionToken, error)
 	GetTokensInStateForPartition(ctx context.Context, arg GetTokensInStateForPartitionParams) ([]ExecutionToken, error)
+	SaveDecisionDefinition(ctx context.Context, arg SaveDecisionDefinitionParams) error
 	SaveFlowElementHistory(ctx context.Context, arg SaveFlowElementHistoryParams) error
 	SaveIncident(ctx context.Context, arg SaveIncidentParams) error
-	SaveDecisionDefinition(ctx context.Context, arg SaveDecisionDefinitionParams) error
 	SaveJob(ctx context.Context, arg SaveJobParams) error
 	SaveMessageSubscription(ctx context.Context, arg SaveMessageSubscriptionParams) error
 	SaveMigration(ctx context.Context, arg SaveMigrationParams) error

--- a/internal/sql/queries/process_definition.sql
+++ b/internal/sql/queries/process_definition.sql
@@ -57,3 +57,12 @@ FROM
     process_definition
 WHERE
     key IN (sqlc.slice('keys'));
+
+-- name: GetDefinitionKeyByChecksum :one
+SELECT
+    key
+FROM
+    process_definition
+WHERE
+    bpmn_checksum = @bpmn_checksum
+LIMIT 1;


### PR DESCRIPTION
When the existing process definition is deployed, it returns pre-generated zenflake of not existing definition.

This commit adds logic to return process definition key of the original definition.

closes #171 