### PR TITLE
build(docker, make): build binary first and fix protoc for linux-aarch?64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
+FROM golang:1.25 AS builder
+RUN apt-get update && apt-get install -y gcc make curl unzip
+WORKDIR /app
+COPY . .
+
+RUN make generate
+RUN CGO_ENABLED=1 go build -o /zenbpm cmd/zenbpm/main.go
+
+
 FROM ubuntu:latest
-ARG TARGETPLATFORM
-COPY $TARGETPLATFORM/zenbpm /usr/bin/
+COPY --from=builder /zenbpm /usr/bin/zenbpm
+
+
+EXPOSE 8080 9090
 ENTRYPOINT ["/usr/bin/zenbpm"]


### PR DESCRIPTION
- Dockerfile now compiles the Go binary before packaging
- Makefile updated to use correct protoc archive for linux-aarch_64