### PR TITLE
fix(#235): Call Activity fires ResolveReferences func 2 times

### DIFF
--- a/internal/cluster/partition/partition_persistence.go
+++ b/internal/cluster/partition/partition_persistence.go
@@ -596,10 +596,6 @@ func (rq *DB) FindLatestProcessDefinitionById(ctx context.Context, processDefini
 	if err != nil {
 		return res, fmt.Errorf("failed to unmarshal xml data: %w", err)
 	}
-	err = definitions.ResolveReferences()
-	if err != nil {
-		return res, fmt.Errorf("failed to resolve references in definition with bpmn id%s: %w", processDefinitionId, err)
-	}
 
 	res = bpmnruntime.ProcessDefinition{
 		BpmnProcessId:    dbDefinition.BpmnProcessID,
@@ -668,10 +664,7 @@ func (rq *DB) FindProcessDefinitionsById(ctx context.Context, processId string) 
 		if err != nil {
 			return res, fmt.Errorf("failed to unmarshal xml data: %w", err)
 		}
-		err = definitions.ResolveReferences()
-		if err != nil {
-			return res, fmt.Errorf("failed to resolve references in definition %d: %w", def.Key, err)
-		}
+
 		res[i] = bpmnruntime.ProcessDefinition{
 			BpmnProcessId:    def.BpmnProcessID,
 			Version:          int32(def.Version),


### PR DESCRIPTION
Function ResolveReferences is called by Unmarshal function and it is not suitable to call it again.
closes #235