### PR TITLE
fix(269): deploy docs missing proto file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
           mkdir -p docusaurus/openapi/redocusaurus/
           cp openapi/api.yaml docusaurus/openapi/redocusaurus/
           mkdir -p docusaurus/proto
-          cp pkg/client/proto/zenbpm.proto docusaurus/proto/
+          cp pkg/zenclient/proto/zenbpm.proto docusaurus/proto/
 
       - name: Set up Git
         run: |


### PR DESCRIPTION
closes #269 

Fixes Documentation deploy workflow