### PR TITLE
fix(434): boundary event and tasks in loop

### DIFF
--- a/pkg/bpmn/events.go
+++ b/pkg/bpmn/events.go
@@ -87,17 +87,15 @@ func (engine *Engine) publishMessageOnBoundaryListener(ctx context.Context, batc
 
 	if listener.CancellActivity {
 		// cancel job
-		job, err := engine.persistence.FindJobByElementID(ctx, instance.ProcessInstance().Key, token.ElementId)
-		if !errors.Is(err, storage.ErrNotFound) || job.Key != 0 {
+		jobs, err := engine.persistence.FindTokenJobsInState(ctx, token.Key, []runtime.ActivityState{runtime.ActivityStateActive})
+		if err != nil {
+			return nil, fmt.Errorf("failed to find job for token %d: %w", token.Key, err)
+		}
+		for i := range jobs {
+			jobs[i].State = runtime.ActivityStateTerminated
+			err = batch.SaveJob(ctx, jobs[i])
 			if err != nil {
-				return nil, fmt.Errorf("failed to find job for token %d: %w", token.Key, err)
-			}
-			if !errors.Is(err, storage.ErrNotFound) {
-				job.State = runtime.ActivityStateTerminated
-				err = batch.SaveJob(ctx, job)
-				if err != nil {
-					return nil, fmt.Errorf("failed to save changes to job %d: %w", job.Key, err)
-				}
+				return nil, fmt.Errorf("failed to save changes to job %d: %w", jobs[i].Key, err)
 			}
 		}
 

--- a/pkg/bpmn/timer.go
+++ b/pkg/bpmn/timer.go
@@ -88,15 +88,18 @@ func (engine *Engine) handleBoundaryTimer(ctx context.Context, batch *EngineBatc
 
 	if listener.CancellActivity {
 		// cancel job
-		job, err := engine.persistence.FindJobByElementID(ctx, instance.ProcessInstance().Key, token.ElementId)
+		jobs, err := engine.persistence.FindTokenJobsInState(ctx, token.Key, []runtime.ActivityState{runtime.ActivityStateActive})
 		if err != nil {
 			return nil, fmt.Errorf("failed to find job for token %d: %w", token.Key, err)
 		}
-		job.State = runtime.ActivityStateTerminated
-		err = batch.SaveJob(ctx, job)
-		if err != nil {
-			return nil, fmt.Errorf("failed to save changes to job %d: %w", job.Key, err)
+		for i := range jobs {
+			jobs[i].State = runtime.ActivityStateTerminated
+			err = batch.SaveJob(ctx, jobs[i])
+			if err != nil {
+				return nil, fmt.Errorf("failed to save changes to job %d: %w", jobs[i].Key, err)
+			}
 		}
+
 		err = engine.cancelBoundarySubscriptions(ctx, batch, instance, &token)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
tests are in https://github.com/pbinitiative/zenbpm/pull/393 because of new cleanup feature for e2e tests
Closes #434 