### PR TITLE
fix(460): Fail on migration errors and support explicit rollback scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 site/
 temp.*.json
+.run
 _
 cmd/__debug*
 ./zenbpm

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,3 +17,30 @@ Use this pattern for optional arguments in constructors and other public APIs th
 especially if you already have three or more arguments on those functions.
 
 Example code: https://github.com/uber-go/guide/blob/master/style.md#functional-options
+
+
+
+### SQL Migrations
+
+Migration filenames follow the `golang-migrate` convention:
+
+```text
+{version}_{title}.up.sql
+{version}_{title}.down.sql
+```
+
+The `title` part is only for readability. In this repository, use a zero-padded four-digit numeric `version` in the range `0000` to `9999`.
+
+`sqlc` parses migration files in lexicographic order and ignores `down` migrations when generating code, so zero-padding is required to keep lexicographic and numeric ordering aligned.
+
+SQL schema for `sqlc` is loaded from [`internal/sql/migrations`](./internal/sql/migrations), as configured in [`sqlc.yaml`](./sqlc.yaml). 
+
+Examples:
+
+```text
+internal/sql/migrations/0000_init.up.sql
+internal/sql/migrations/0001_schema.up.sql
+internal/sql/migrations/0002_add_job_priority.up.sql
+```
+
+If a rollback is needed, use the matching `.down.sql` filename, for example `0002_add_job_priority.down.sql`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -74,18 +74,30 @@ Raft consensus and cluster joining settings.
 
 ---
 
-## Persistence Configuration: `Persistence`
+### Persistence Configuration: `Persistence`
 
 Configuration for caching and storage.
 
-| Field                | Type          | Env Variable                             | Default     | Description                                    |
-|----------------------|---------------|------------------------------------------|-------------|------------------------------------------------|
-| `instanceHistoryTTL` | types.TTL     | `PERSISTENCE_INSTANCE_HISTORY_TTL`       | `0`         | TTL for finished process instances             |
-| `procDefCacheTTL`    | types.TTL     | `PERSISTENCE_PROC_DEF_CACHE_TTL_SECONDS` | `24h`       | TTL for cached process definitions             |
-| `procDefCacheSize`   | int           | `PERSISTENCE_PROC_DEF_CACHE_SIZE`        | `200`       | Max number of cached process definitions       |
-| `decDefCacheTTL`     | types.TTL     | `PERSISTENCE_DEC_DEF_CACHE_TTL_SECONDS`  | `24h`       | TTL for cached dmn resource definitions        |
-| `decDefCacheSize`    | int           | `PERSISTENCE_DEC_DEF_CACHE_SIZE`         | `200`       | Max number of cached dmn resource definitions  |
-| `rqlite`             | `*RqLite`     | —                                        | —           | Configuration for embedded RQLite database     |
+| Field                | Type        | Env Variable                             | Default     | Description                                   |
+|----------------------|-------------|------------------------------------------|-------------|-----------------------------------------------|
+| `instanceHistoryTTL` | types.TTL   | `PERSISTENCE_INSTANCE_HISTORY_TTL`       | `0`         | TTL for finished process instances            |
+| `procDefCacheTTL`    | types.TTL   | `PERSISTENCE_PROC_DEF_CACHE_TTL_SECONDS` | `24h`       | TTL for cached process definitions            |
+| `procDefCacheSize`   | int         | `PERSISTENCE_PROC_DEF_CACHE_SIZE`        | `200`       | Max number of cached process definitions      |
+| `decDefCacheTTL`     | types.TTL   | `PERSISTENCE_DEC_DEF_CACHE_TTL_SECONDS`  | `24h`       | TTL for cached dmn resource definitions       |
+| `decDefCacheSize`    | int         | `PERSISTENCE_DEC_DEF_CACHE_SIZE`         | `200`       | Max number of cached dmn resource definitions |
+| `rqlite`             | `*RqLite`   | —                                        | —           | Configuration for embedded RQLite database    |
+| `migration`          | `Migration` | —                                        | —           | Configuration for SQL migration               |
+
+
+---
+
+#### SQL Migration Configuration: `Migration`
+
+Configuration for caching and storage.
+
+| Field | Type      | Env Variable                | Default                   | Description                               |
+|-------|-----------|-----------------------------|---------------------------|-------------------------------------------|
+| `dir` | `string`  | `PERSISTENCE_MIGRATION_DIR` | `internal/sql/migrations` | Configuration for SQL migration directory |
 
 ---
 
@@ -114,6 +126,9 @@ grpcServer:
 cluster:
   addr: localhost:8090
   adv: localhost:8090
+  persistence:
+    migration:
+        dir: internal/sql/migrations
   raft:
     dir: node-1
     bootstrapExpect: 1

--- a/internal/cluster/controller/controller.go
+++ b/internal/cluster/controller/controller.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/pbinitiative/zenbpm/pkg/script"
-	"github.com/pbinitiative/zenbpm/pkg/script/feel"
-	"github.com/pbinitiative/zenbpm/pkg/script/js"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/script"
+	"github.com/pbinitiative/zenbpm/pkg/script/feel"
+	"github.com/pbinitiative/zenbpm/pkg/script/js"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/raft"
@@ -22,7 +23,6 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/sql"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn"
 	"github.com/pbinitiative/zenbpm/pkg/ptr"
-	rqproto "github.com/rqlite/rqlite/v8/command/proto"
 	rstore "github.com/rqlite/rqlite/v8/store"
 	"github.com/rqlite/rqlite/v8/tcp"
 )
@@ -371,22 +371,10 @@ func (c *Controller) handlePartitionStateInitialized(ctx context.Context, partit
 }
 
 func (c *Controller) createEngine(ctx context.Context, db *partition.DB, feelRuntime script.FeelRuntime, jsRuntime script.JsRuntime) (*bpmn.Engine, error) {
-	// TODO: add check for migrations and apply only missing
-	migrations, err := sql.GetMigrations()
-	if err != nil {
-		c.logger.Error("Failed to read migrations", "err", err)
-		return nil, fmt.Errorf("failed to read migrations: %w", err)
-	}
-	statements := make([]*rqproto.Statement, len(migrations))
-	for i, migration := range migrations {
-		statements[i] = &rqproto.Statement{
-			Sql: migration.SQL,
-		}
-	}
-	_, err = db.ExecuteStatements(ctx, statements)
+	err := db.RunMigrations(ctx)
 	if err != nil {
 		c.logger.Error("Failed to execute migrations", "err", err)
-		return nil, fmt.Errorf("failed to execute migrations: %w", err)
+		return nil, err
 	}
 
 	engine := bpmn.NewEngine(bpmn.EngineWithStorageAndFeel(db, feelRuntime), bpmn.EngineWithJs(jsRuntime))

--- a/internal/cluster/partition/migrations.go
+++ b/internal/cluster/partition/migrations.go
@@ -1,0 +1,157 @@
+package partition
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/internal/sql"
+	rqproto "github.com/rqlite/rqlite/v8/command/proto"
+)
+
+func (db *DB) RunMigrations(ctx context.Context) error {
+	if err := ensureMigrationTable(ctx, db); err != nil {
+		return err
+	}
+
+	pendingMigrations, err := loadPendingMigrations(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, migration := range pendingMigrations {
+		if migrationErr := executeSingleMigration(ctx, db, migration); migrationErr != nil {
+			return migrationErr
+		}
+	}
+
+	return nil
+}
+
+func loadPendingMigrations(ctx context.Context, db *DB) (sql.Migrations, error) {
+	fileMigrations, err := sql.GetUpMigrations(db.migrationDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read migrations: %w", err)
+	}
+
+	appliedMigrations, err := db.Queries.GetMigrations(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read applied migrations: %w", err)
+	}
+
+	return filterPendingMigrations(fileMigrations, appliedMigrations), nil
+}
+
+func filterPendingMigrations(fileMigrations sql.Migrations, appliedMigrations []sql.Migration) sql.Migrations {
+	appliedMigrationNames := make(map[string]struct{}, len(appliedMigrations))
+
+	for _, appliedMigration := range appliedMigrations {
+		appliedMigrationNames[appliedMigration.Name] = struct{}{}
+	}
+
+	pendingMigrations := make(sql.Migrations, 0, len(fileMigrations))
+	for _, fileMigration := range fileMigrations {
+		if _, ok := appliedMigrationNames[fileMigration.Filename]; ok {
+			continue
+		}
+
+		pendingMigrations = append(pendingMigrations, fileMigration)
+	}
+
+	slices.SortFunc(pendingMigrations, func(a, b sql.MigrationData) int {
+		return strings.Compare(a.Filename, b.Filename)
+	})
+
+	return pendingMigrations
+}
+
+func executeSingleMigration(ctx context.Context, db *DB, migration sql.MigrationData) error {
+	if migrationErr := executeUpMigration(ctx, db, migration); migrationErr != nil {
+		if err := executeRollbackMigration(ctx, db, migration); err != nil {
+			return err
+		}
+
+		return migrationErr
+	}
+
+	err := db.Queries.SaveMigration(ctx, sql.SaveMigrationParams{
+		Name:  migration.Filename,
+		RanAt: time.Now().UnixMilli(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to save migration info: %w", err)
+	}
+
+	db.logger.Info(fmt.Sprintf("Migration applied: %s", migration.Filename))
+
+	return nil
+}
+
+func executeUpMigration(ctx context.Context, db *DB, migration sql.MigrationData) error {
+	if err := executeSQLStatement(ctx, db, migration.SQL); err != nil {
+		return fmt.Errorf("failed to execute migration %s: %w", migration.Filename, err)
+	}
+
+	return nil
+}
+
+func executeRollbackMigration(ctx context.Context, db *DB, migration sql.MigrationData) error {
+	rollbackMigration, err := sql.GetRollbackMigration(db.migrationDir, migration.Filename)
+	if err != nil {
+		return fmt.Errorf("failed to read rollback migration: %w", err)
+	}
+
+	if rollbackMigration == nil {
+		return nil
+	}
+
+	db.logger.Info(fmt.Sprintf("Rolling back migration: %s", rollbackMigration.Filename))
+	if sqlStatementErr := executeSQLStatement(ctx, db, rollbackMigration.SQL); sqlStatementErr != nil {
+		return fmt.Errorf("failed to execute rollback migration %s: %w", rollbackMigration.Filename, sqlStatementErr)
+	}
+
+	db.logger.Info(fmt.Sprintf("Rollback migration applied: %s", rollbackMigration.Filename))
+
+	return nil
+}
+
+func ensureMigrationTable(ctx context.Context, db *DB) error {
+
+	createMigrationTableSQL, err := sql.GetMigrationInitSql(db.migrationDir)
+
+	if err != nil {
+		return err
+	}
+
+	if createMigrationTableSQL == nil {
+		return fmt.Errorf("failed to create migration table, failed to read migration init file")
+	}
+
+	createTableSQL := *createMigrationTableSQL
+
+	if sqlStatementErr := executeSQLStatement(ctx, db, createTableSQL); sqlStatementErr != nil {
+		return fmt.Errorf("failed to create migration table: %w", sqlStatementErr)
+	}
+
+	return nil
+}
+
+func executeSQLStatement(ctx context.Context, db *DB, statementSQL string) error {
+	results, err := db.ExecuteStatements(ctx, []*rqproto.Statement{{Sql: statementSQL}})
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 || results[0] == nil {
+		return nil
+	}
+
+	if executeErr := results[0].GetError(); executeErr != "" {
+		return errors.New(executeErr)
+	}
+
+	return nil
+}

--- a/internal/cluster/partition/migrations_test.go
+++ b/internal/cluster/partition/migrations_test.go
@@ -1,0 +1,66 @@
+package partition
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/sql"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterPendingMigrationsReturnsPendingMigrations(t *testing.T) {
+	fileMigrations := sql.Migrations{
+		{Filename: "0001_schema.up.sql"},
+		{Filename: "0002_indexes.up.sql"},
+		{Filename: "0003_data.up.sql"},
+	}
+	dbMigrations := []sql.Migration{
+		{Name: "0001_schema.up.sql"},
+		{Name: "0002_indexes.up.sql"},
+	}
+
+	pending := filterPendingMigrations(fileMigrations, dbMigrations)
+	assert.Equal(t, sql.Migrations{{Filename: "0003_data.up.sql"}}, pending)
+}
+
+func TestFilterPendingMigrationsDoesNotValidateDBOrder(t *testing.T) {
+	fileMigrations := sql.Migrations{
+		{Filename: "0001_schema.up.sql"},
+		{Filename: "0002_indexes.up.sql"},
+		{Filename: "0003_data.up.sql"},
+	}
+	dbMigrations := []sql.Migration{
+		{Name: "0001_schema.up.sql"},
+		{Name: "0003_data.up.sql"},
+	}
+
+	pending := filterPendingMigrations(fileMigrations, dbMigrations)
+	assert.Equal(t, sql.Migrations{{Filename: "0002_indexes.up.sql"}}, pending)
+}
+
+func TestFilterPendingMigrationsIgnoresDuplicateDBRecords(t *testing.T) {
+	fileMigrations := sql.Migrations{
+		{Filename: "0001_schema.up.sql"},
+		{Filename: "0002_indexes.up.sql"},
+	}
+	dbMigrations := []sql.Migration{
+		{Name: "0001_schema.up.sql"},
+		{Name: "0001_schema.up.sql"},
+	}
+
+	pending := filterPendingMigrations(fileMigrations, dbMigrations)
+	assert.Equal(t, sql.Migrations{{Filename: "0002_indexes.up.sql"}}, pending)
+}
+
+func TestFilterPendingMigrationsIgnoresUnknownDBMigrations(t *testing.T) {
+	fileMigrations := sql.Migrations{
+		{Filename: "0001_schema.up.sql"},
+		{Filename: "0002_indexes.up.sql"},
+	}
+	dbMigrations := []sql.Migration{
+		{Name: "0001_schema.up.sql"},
+		{Name: "9999_custom.up.sql"},
+	}
+
+	pending := filterPendingMigrations(fileMigrations, dbMigrations)
+	assert.Equal(t, sql.Migrations{{Filename: "0002_indexes.up.sql"}}, pending)
+}

--- a/internal/cluster/partition/partition_persistence.go
+++ b/internal/cluster/partition/partition_persistence.go
@@ -50,6 +50,7 @@ type DB struct {
 	logger                 hclog.Logger
 	node                   *snowflake.Node
 	Partition              uint32
+	migrationDir           string
 	tracer                 trace.Tracer
 	pdCache                *expirable.LRU[int64, bpmnruntime.ProcessDefinition]
 	drdCache               *expirable.LRU[int64, dmnruntime.DmnResourceDefinition]
@@ -86,12 +87,17 @@ func NewDB(store *store.Store, partition uint32, logger hclog.Logger, cfg config
 	if err != nil {
 		return nil, fmt.Errorf("failed to create snowflake node for partition %d: %w", partition, err)
 	}
+	migrationDir := cfg.Migration.Dir
+	if migrationDir == "" {
+		migrationDir = sql.DefaultMigrationsDir
+	}
 	db := &DB{
 		Store:                  store,
 		logger:                 logger,
 		node:                   node,
 		tracer:                 otel.GetTracerProvider().Tracer(fmt.Sprintf("partition-%d-rqlite", partition)),
 		Partition:              partition,
+		migrationDir:           migrationDir,
 		pdCache:                expirable.NewLRU[int64, bpmnruntime.ProcessDefinition](cfg.ProcDefCacheSize, nil, time.Duration(cfg.ProcDefCacheTTL)),
 		drdCache:               expirable.NewLRU[int64, dmnruntime.DmnResourceDefinition](cfg.DecDefCacheSize, nil, time.Duration(cfg.DecDefCacheTTL)),
 		client:                 client,

--- a/internal/cluster/partition/partition_persistence_test.go
+++ b/internal/cluster/partition/partition_persistence_test.go
@@ -28,11 +28,14 @@ import (
 	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/storage"
 	"github.com/pbinitiative/zenbpm/pkg/storage/storagetest"
-	"github.com/rqlite/rqlite/v8/command/proto"
 	"github.com/stretchr/testify/assert"
 )
 
-func prepareTestSetup(t *testing.T) (*ZenPartitionNode, config.Persistence, *client.ClientManager, *testStore, *servertest.TestServer) {
+func prepareTestSetupWithTestMigration(t *testing.T) (*ZenPartitionNode, config.Persistence, *client.ClientManager, *testStore, *servertest.TestServer) {
+	return prepareTestSetup(t, true)
+}
+
+func prepareTestSetup(t *testing.T, runMigrationWithRollback bool) (*ZenPartitionNode, config.Persistence, *client.ClientManager, *testStore, *servertest.TestServer) {
 	ctx := context.Background()
 	mux, muxLn, err := network.NewNodeMux("")
 	if err != nil {
@@ -44,10 +47,17 @@ func prepareTestSetup(t *testing.T) (*ZenPartitionNode, config.Persistence, *cli
 		t.TempDir(),
 		[]string{muxLn.Addr().String()},
 	)
+
+	migrationDir := ""
+	if runMigrationWithRollback {
+		migrationDir = "internal/cluster/partition/testdata/migrations_test"
+	}
+
 	conf := config.Persistence{
 		RqLite:           &c,
 		ProcDefCacheTTL:  types.TTL(24 * time.Hour),
 		ProcDefCacheSize: 200,
+		Migration:        config.Migration{Dir: migrationDir},
 	}
 
 	ts := servertest.NewTestServer()
@@ -102,36 +112,22 @@ func prepareTestSetup(t *testing.T) (*ZenPartitionNode, config.Persistence, *cli
 	if err != nil {
 		t.Fatalf("failed to create partition node: %s", err)
 	}
-	migrations, err := sql.GetMigrations()
-	if err != nil {
-		t.Fatalf("failed to get migrations: %s", err)
-	}
-	stmts := make([]*proto.Statement, len(migrations))
-	for i, mig := range migrations {
-		stmts[i] = &proto.Statement{
-			Sql: mig.SQL,
-		}
-	}
 	_, err = partition.WaitForLeader(5 * time.Second)
 	if err != nil {
 		t.Fatalf("failed to get leader for partition: %s", err)
 	}
 
-	// run migrations
-	_, err = partition.Execute(ctx, &proto.ExecuteRequest{
-		Request: &proto.Request{
-			Transaction: false,
-			Statements:  stmts,
-		},
-	})
+	err = partition.DB.RunMigrations(ctx)
 	if err != nil {
-		t.Fatalf("failed to run migrations: %s", err)
+		if !runMigrationWithRollback {
+			t.Fatalf("failed to run migrations: %s", err)
+		}
 	}
 	return partition, conf, clientMgr, tStore, ts
 }
 
 func TestRqLiteStorage(t *testing.T) {
-	partition, conf, clientMgr, tStore, ts := prepareTestSetup(t)
+	partition, conf, clientMgr, tStore, ts := prepareTestSetup(t, false)
 	defer partition.Stop()
 
 	db, err := NewDB(partition.DB.Store, partition.PartitionId, hclog.Default().Named("test-rq-lite-db"), conf, clientMgr, tStore.ClusterState)
@@ -148,8 +144,69 @@ func TestRqLiteStorage(t *testing.T) {
 	testMessageCorrelation(t, db, ts)
 }
 
+func TestRunUpMigrations(t *testing.T) {
+	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t, false)
+	defer partition.Stop()
+
+	db, err := NewDB(partition.DB.Store, partition.PartitionId, hclog.Default().Named("test-migration-lite-db"), conf, clientMgr, tStore.ClusterState)
+	assert.NoError(t, err)
+
+	appliedMigrations, err := db.Queries.GetMigrations(t.Context())
+	assert.NoError(t, err)
+
+	migrations, err := sql.GetUpMigrations(db.migrationDir)
+	assert.NoError(t, err)
+
+	assert.Equal(t, len(migrations), len(appliedMigrations),
+		"Expected number of applied migrations to match number of available migrations")
+
+	appliedMigrationNames := make(map[string]struct{}, len(appliedMigrations))
+	for _, appliedMigration := range appliedMigrations {
+		appliedMigrationNames[appliedMigration.Name] = struct{}{}
+	}
+
+	for _, migration := range migrations {
+		_, found := appliedMigrationNames[migration.Filename]
+		assert.True(t, found, "migration %s was not applied", migration.Filename)
+	}
+}
+
+func TestRunRollbackMigration(t *testing.T) {
+	partition, conf, clientMgr, tStore, _ := prepareTestSetupWithTestMigration(t)
+	defer partition.Stop()
+
+	db, err := NewDB(partition.DB.Store, partition.PartitionId, hclog.Default().Named("test-migration-lite-db"), conf, clientMgr, tStore.ClusterState)
+	assert.NoError(t, err)
+
+	appliedMigrations, err := db.Queries.GetMigrations(t.Context())
+	assert.NoError(t, err)
+
+	migrations, err := sql.GetUpMigrations(db.migrationDir)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(migrations), "Expected number of migrations to be 3, but got %d migrations", len(migrations))
+
+	assert.Equal(t, 1, len(appliedMigrations),
+		"Expected number of applied migrations to be 1, but got %d migrations", len(appliedMigrations))
+
+	appliedMigrationNames := make(map[string]struct{}, len(appliedMigrations))
+	for _, appliedMigration := range appliedMigrations {
+		appliedMigrationNames[appliedMigration.Name] = struct{}{}
+	}
+
+	assert.Contains(t, appliedMigrationNames, "0000_init.up.sql", "init migration should be applied")
+
+	var tableCount int
+	err = db.QueryRowContext(
+		t.Context(),
+		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ? or name = ?",
+		"rollback_probe", "should_not_exists",
+	).Scan(&tableCount)
+	assert.NoError(t, err)
+	assert.Zero(t, tableCount, "Only the migration table should exist after a failed migration rollback.")
+}
+
 func TestDataCleanup(t *testing.T) {
-	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t)
+	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t, false)
 	defer partition.Stop()
 
 	db, err := NewDB(partition.DB.Store, partition.PartitionId, hclog.Default().Named("test-data-cleanup"), conf, clientMgr, tStore.ClusterState)
@@ -646,7 +703,7 @@ func testInstanceParent(t *testing.T, db *DB) {
 }
 
 func TestGetLatestDecisionDefinitionById(t *testing.T) {
-	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t)
+	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t, false)
 	defer partition.Stop()
 
 	db, err := NewDB(partition.DB.Store, partition.PartitionId, hclog.Default().Named("test-decision-def"), conf, clientMgr, tStore.ClusterState)

--- a/internal/cluster/partition/testdata/migrations_test/0000_init.up.sql
+++ b/internal/cluster/partition/testdata/migrations_test/0000_init.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS migration (
+    name text PRIMARY KEY,
+    ran_at integer NOT NULL
+);

--- a/internal/cluster/partition/testdata/migrations_test/0001_test_rollback.down.sql
+++ b/internal/cluster/partition/testdata/migrations_test/0001_test_rollback.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE rollback_probe;

--- a/internal/cluster/partition/testdata/migrations_test/0001_test_rollback.up.sql
+++ b/internal/cluster/partition/testdata/migrations_test/0001_test_rollback.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE rollback_probe (
+    id INTEGER PRIMARY KEY
+);
+
+COMMIT;
+
+CREATE INDEX rollback_probe_id_idx ON rollback_probe (ida);

--- a/internal/cluster/partition/testdata/migrations_test/0002_should_not_be_executed.up.sql
+++ b/internal/cluster/partition/testdata/migrations_test/0002_should_not_be_executed.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE should_not_exists (
+    name text PRIMARY KEY
+);

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,11 @@ type Persistence struct {
 	DecDefCacheTTL     types.TTL `yaml:"decDefCacheTTL" env:"PERSISTENCE_DEC_DEF_CACHE_TTL_SECONDS" env-default:"24h"`
 	DecDefCacheSize    int       `yaml:"decDefCacheSize" env:"PERSISTENCE_DEC_DEF_CACHE_SIZE" env-default:"200"`
 	RqLite             *RqLite   `yaml:"rqlite" json:"rqlite"`
+	Migration          Migration `yaml:"migration" json:"migration"`
+}
+
+type Migration struct {
+	Dir string `yaml:"dir" json:"dir" env:"PERSISTENCE_MIGRATION_DIR" env-default:"internal/sql/migrations"`
 }
 
 type Script struct {

--- a/internal/sql/migrations.go
+++ b/internal/sql/migrations.go
@@ -1,13 +1,16 @@
 package sql
 
 import (
-	"embed"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 )
 
-//go:embed migrations
-var migrations embed.FS
+const DefaultMigrationsDir = "internal/sql/migrations"
+const migrationsInitFilename = "0000_init.up.sql"
 
 type Migrations []MigrationData
 
@@ -16,27 +19,141 @@ type MigrationData struct {
 	SQL      string
 }
 
-func GetMigrations() (Migrations, error) {
-	migDir, err := migrations.ReadDir("migrations")
+func GetUpMigrations(migrationDir string) (Migrations, error) {
+	migrationDirEntries, err := readMigrationDir(migrationDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read migration directory: %w", err)
 	}
-	res := make(Migrations, 0, len(migDir))
-	for _, f := range migDir {
-		if !strings.HasSuffix(f.Name(), ".sql") {
+
+	res := make(Migrations, 0, len(migrationDirEntries))
+	for _, f := range migrationDirEntries {
+		if f.IsDir() || !strings.HasSuffix(f.Name(), ".up.sql") {
 			continue
 		}
-		if f.IsDir() {
-			continue
-		}
-		content, err := migrations.ReadFile("migrations/" + f.Name())
+		content, err := readMigrationFile(migrationDir, f.Name())
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %s: %w", f.Name(), err)
 		}
+
 		res = append(res, MigrationData{
 			Filename: f.Name(),
 			SQL:      string(content),
 		})
 	}
 	return res, nil
+}
+
+func GetRollbackMigration(migrationDir string, migrationFilename string) (*MigrationData, error) {
+	rollbackFilename := strings.Replace(migrationFilename, ".up.sql", ".down.sql", 1)
+
+	content, err := readMigrationFile(migrationDir, rollbackFilename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read rollback file %s: %w", rollbackFilename, err)
+	}
+
+	return &MigrationData{
+		Filename: rollbackFilename,
+		SQL:      string(content),
+	}, nil
+}
+
+func GetMigrationInitSql(migrationDir string) (*string, error) {
+	content, err := readMigrationFile(migrationDir, migrationsInitFilename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read migration init file %s: %w", migrationsInitFilename, err)
+	}
+
+	fileContent := string(content)
+
+	return &fileContent, nil
+}
+
+func readMigrationDir(migrationDir string) ([]os.DirEntry, error) {
+	filesystemDir, err := filesystemMigrationDir(migrationDir)
+	if err != nil {
+		return nil, err
+	}
+	if filesystemDir == "" {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(filesystemDir)
+	if err == nil {
+		return entries, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to read filesystem migration directory %s: %w", filesystemDir, err)
+	}
+
+	return nil, nil
+}
+
+func readMigrationFile(migrationDir string, filename string) ([]byte, error) {
+	filesystemDir, err := filesystemMigrationDir(migrationDir)
+	if err != nil {
+		return nil, err
+	}
+	if filesystemDir == "" {
+		return nil, nil
+	}
+
+	filePath := filepath.Join(filesystemDir, filename)
+	content, err := os.ReadFile(filePath)
+	if err == nil {
+		return content, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to read filesystem migration file %s: %w", filePath, err)
+	}
+
+	return nil, nil
+}
+
+func filesystemMigrationDir(migrationDir string) (string, error) {
+	if migrationDir == "" {
+		return "", nil
+	}
+
+	normalizedDir := filepath.Clean(migrationDir)
+	if filepath.IsAbs(normalizedDir) {
+		return normalizedDir, nil
+	}
+
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return "", fmt.Errorf("failed to find project root: %w", err)
+	}
+
+	resolvedDir := filepath.Join(projectRoot, normalizedDir)
+	relToRoot, err := filepath.Rel(projectRoot, resolvedDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve migration directory %s from project root %s: %w", migrationDir, projectRoot, err)
+	}
+	if relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("migration directory %s escapes project root %s", migrationDir, projectRoot)
+	}
+
+	return resolvedDir, nil
+}
+
+func findProjectRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("failed to get caller file")
+	}
+
+	dir := filepath.Dir(file)
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("go.mod not found")
+		}
+
+		dir = parent
+	}
 }

--- a/internal/sql/migrations/0000_init.up.sql
+++ b/internal/sql/migrations/0000_init.up.sql
@@ -1,0 +1,6 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS migration(
+    name text PRIMARY KEY, -- migration filename
+    ran_at integer NOT NULL -- unix millis of when the migration was applied
+);

--- a/internal/sql/migrations/0001_schema.up.sql
+++ b/internal/sql/migrations/0001_schema.up.sql
@@ -1,10 +1,5 @@
 PRAGMA foreign_keys = ON;
 
-CREATE TABLE IF NOT EXISTS migration(
-    name text NOT NULL,
-    ran_at integer NOT NULL
-);
-
 -- table that holds information about all the process instances
 CREATE TABLE IF NOT EXISTS process_instance(
     key INTEGER PRIMARY KEY, -- int64 snowflake id where node is partition id which handles the process instance
@@ -22,7 +17,7 @@ CREATE TABLE IF NOT EXISTS process_instance(
     FOREIGN KEY (process_definition_key) REFERENCES process_definition(key) -- process definition that describes this process instance
 );
 
-CREATE INDEX idx_fk_process_instance_process_definition_key ON process_instance(process_definition_key);
+CREATE INDEX IF NOT EXISTS idx_fk_process_instance_process_definition_key ON process_instance(process_definition_key);
 
 -- table that holds information about all the process definitions
 CREATE TABLE IF NOT EXISTS process_definition(
@@ -45,7 +40,7 @@ CREATE TABLE IF NOT EXISTS message_subscription_pointer(
     PRIMARY KEY (name, correlation_key)
 );
 
-CREATE UNIQUE INDEX unique_name_correlation_key_waiting ON message_subscription_pointer(name, correlation_key)
+CREATE UNIQUE INDEX IF NOT EXISTS unique_name_correlation_key_waiting ON message_subscription_pointer(name, correlation_key)
 WHERE
     state = 1;
 
@@ -65,8 +60,8 @@ CREATE TABLE IF NOT EXISTS message_subscription(
     FOREIGN KEY (process_definition_key) REFERENCES process_definition(key) -- reference to process definition
 );
 
-CREATE INDEX idx_fk_message_subscription_process_instance_key ON message_subscription(process_instance_key);
-CREATE INDEX idx_fk_message_subscription_process_definition_key ON message_subscription(process_definition_key);
+CREATE INDEX IF NOT EXISTS idx_fk_message_subscription_process_instance_key ON message_subscription(process_instance_key);
+CREATE INDEX IF NOT EXISTS idx_fk_message_subscription_process_definition_key ON message_subscription(process_definition_key);
 
 CREATE TABLE IF NOT EXISTS timer(
     key INTEGER PRIMARY KEY, -- int64 snowflake id of the timer where node is partition id which handles the process instance
@@ -82,8 +77,8 @@ CREATE TABLE IF NOT EXISTS timer(
     FOREIGN KEY (process_definition_key) REFERENCES process_definition(key) -- reference to process definition
 );
 
-CREATE INDEX idx_fk_timer_process_instance_key ON timer(process_instance_key);
-CREATE INDEX idx_fk_timer_process_definition_key ON timer(process_definition_key);
+CREATE INDEX IF NOT EXISTS idx_fk_timer_process_instance_key ON timer(process_instance_key);
+CREATE INDEX IF NOT EXISTS idx_fk_timer_process_definition_key ON timer(process_definition_key);
 
 
 CREATE TABLE IF NOT EXISTS job(
@@ -100,9 +95,9 @@ CREATE TABLE IF NOT EXISTS job(
     FOREIGN KEY (process_instance_key) REFERENCES process_instance(key) -- reference to process instance
 );
 
-CREATE INDEX idx_job_state_type_created_at ON job(state,type,created_at) where state = 1;
+CREATE INDEX IF NOT EXISTS idx_job_state_type_created_at ON job(state,type,created_at) where state = 1;
 
-CREATE INDEX idx_fk_job_process_instance_key ON job(process_instance_key);
+CREATE INDEX IF NOT EXISTS idx_fk_job_process_instance_key ON job(process_instance_key);
 
 
 CREATE TABLE IF NOT EXISTS execution_token(
@@ -115,7 +110,7 @@ CREATE TABLE IF NOT EXISTS execution_token(
     FOREIGN KEY (process_instance_key) REFERENCES process_instance(key) -- reference to process instance
 );
 
-CREATE INDEX idx_fk_execution_token_process_instance_key ON execution_token(process_instance_key);
+CREATE INDEX IF NOT EXISTS idx_fk_execution_token_process_instance_key ON execution_token(process_instance_key);
 
 -- table that holds information about all the process instance visited nodes and transitions
 CREATE TABLE IF NOT EXISTS flow_element_instance(
@@ -129,7 +124,7 @@ CREATE TABLE IF NOT EXISTS flow_element_instance(
     FOREIGN KEY (process_instance_key) REFERENCES process_instance(key)
 );
 
-CREATE INDEX idx_fk_flow_element_instance_process_instance_key ON flow_element_instance(process_instance_key);
+CREATE INDEX IF NOT EXISTS idx_fk_flow_element_instance_process_instance_key ON flow_element_instance(process_instance_key);
 
 CREATE TABLE IF NOT EXISTS incident(
     key INTEGER PRIMARY KEY, -- int64 snowflake id of the incident where node is partition id which handles the process instance
@@ -143,7 +138,7 @@ CREATE TABLE IF NOT EXISTS incident(
     FOREIGN KEY (process_instance_key) REFERENCES process_instance(key) -- reference to process instance
 );
 
-CREATE INDEX idx_fk_incident_process_instance_key ON incident(process_instance_key);
+CREATE INDEX IF NOT EXISTS idx_fk_incident_process_instance_key ON incident(process_instance_key);
 
 -- table that holds information about all the dmn resource definitions
 CREATE TABLE IF NOT EXISTS dmn_resource_definition(


### PR DESCRIPTION
fix(migration): fail on migration errors and support explicit rollback scripts
           
Run only pending `.up.sql` migrations, persist applied migrations, and execute matching `.down.sql` scripts when a migration fails.

Close #460