### PR TITLE
fix(bpmn): propagate createInstance error before batch.Flush

### DIFF
--- a/pkg/bpmn/engine_api.go
+++ b/pkg/bpmn/engine_api.go
@@ -300,8 +300,13 @@ func (engine *Engine) CreateInstance(ctx context.Context, process *runtime.Proce
 		runtime.NewVariableHolder(nil, variableContext),
 		&runtime.DefaultProcessInstance{},
 	)
-	err = batch.Flush(ctx)
+	// Propagate createInstance errors before calling batch.Flush — the old
+	// code overwrote err with Flush's return and then dereferenced the nil
+	// instance on the happy-path line below, panicking the gRPC handler.
 	if err != nil {
+		return nil, fmt.Errorf("failed to start process instance: %w", err)
+	}
+	if err = batch.Flush(ctx); err != nil {
 		return nil, fmt.Errorf("failed to start process instance: %w", err)
 	}
 


### PR DESCRIPTION
Fixes pbinitiative/zenbpm#518.

## Problem

`Engine.CreateInstance` assigned the result of `engine.createInstance(...)` to `err` and then immediately overwrote `err` with `batch.Flush(...)`, discarding the original failure. When `createInstance` returned an error, the returned `instance` pointer was nil; but `Flush` often succeeded on an empty batch, so execution fell through to `instance.ProcessInstance().Definition.BpmnProcessId` and panicked the gRPC `CreateInstance` handler:

```
panic recovered in gRPC handler /cluster.ZenService/CreateInstance:
runtime error: invalid memory address or nil pointer dereference
pkg/bpmn/engine_api.go:326
```

## Fix

Check the `createInstance` error first and return it unchanged. Only flush the batch when the instance was created successfully.

## Test

`go test -run TestCreate ./pkg/bpmn/` passes locally; the CreateInstance happy-path and error-path tests continue to pass.