### PR TITLE
fix(518): recover from timer panics and fail fast on instance start

### DIFF
--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -276,55 +276,9 @@ func (engine *Engine) terminateExecutionTokens(
 		for _, elementInstanceKey := range elementInstanceKeysToTerminate {
 			if activeToken.ElementInstanceKey == elementInstanceKey {
 
-				err := engine.cancelBoundarySubscriptions(ctx, batch, processInstanceKey, &activeToken)
+				err = engine.terminateExecutionToken(ctx, batch, processInstanceKey, activeToken)
 				if err != nil {
-					return nil, fmt.Errorf("failed to cancel subscriptions for execution token %d: %w", activeToken.Key, err)
-				}
-
-				// Cancel all jobs
-				jobs, err := engine.persistence.GetJobsInStateByTokenKey(ctx, activeToken.Key, []runtime.ActivityState{runtime.ActivityStateActive, runtime.ActivityStateCompleting, runtime.ActivityStateFailed})
-				if err != nil {
-					return nil, fmt.Errorf("failed to find jobs for execution token %d: %w", activeToken.Key, err)
-				}
-				for _, job := range jobs {
-					job.State = runtime.ActivityStateTerminated
-					err = batch.SaveJob(ctx, job)
-					if err != nil {
-						return nil, fmt.Errorf("failed to save changes to job %d: %w", job.Key, err)
-					}
-				}
-
-				// Cancel all incidents
-				incidents, err := engine.persistence.FindIncidentsByExecutionTokenKey(ctx, activeToken.Key)
-				if err != nil {
-					return nil, fmt.Errorf("failed to find incidents for execution token %d: %w", activeToken.Key, err)
-				}
-				for _, incident := range incidents {
-					incident.ResolvedAt = ptr.To(time.Now())
-					err = batch.SaveIncident(ctx, incident)
-					if err != nil {
-						return nil, fmt.Errorf("failed to save changes to incident %d: %w", incident.Key, err)
-					}
-				}
-
-				// Cancel called processes
-				// TODO: This can cause a deadlock
-				// TODO: Fix THIS
-				calledProcesses, err := engine.persistence.FindProcessInstancesByParentExecutionTokenKey(ctx, activeToken.Key)
-				if err != nil {
-					return nil, fmt.Errorf("failed to find called process for token %d: %w", activeToken.Key, err)
-				}
-				for _, calledProcess := range calledProcesses {
-					err = engine.cancelInstance(ctx, calledProcess, batch)
-					if err != nil {
-						return nil, fmt.Errorf("failed to cancel called process for token %d: %w", activeToken.Key, err)
-					}
-				}
-
-				activeToken.State = runtime.TokenStateCanceled
-				err = batch.SaveToken(ctx, activeToken)
-				if err != nil {
-					return nil, fmt.Errorf("failed to terminate execution activeToken %d: %w", activeToken.Key, err)
+					return nil, fmt.Errorf("failed to terminate execution token %d: %w", activeToken.Key, err)
 				}
 			} else {
 				activeTokensLeft = append(activeTokensLeft, activeToken)
@@ -333,6 +287,51 @@ func (engine *Engine) terminateExecutionTokens(
 	}
 
 	return activeTokensLeft, nil
+}
+
+func (engine *Engine) terminateExecutionToken(
+	ctx context.Context,
+	batch *EngineBatch,
+	processInstanceKey int64,
+	activeToken runtime.ExecutionToken,
+) error {
+
+	err := engine.cancelBoundarySubscriptions(ctx, batch, processInstanceKey, &activeToken)
+	if err != nil {
+		return fmt.Errorf("failed to cancel subscriptions for execution token %d: %w", activeToken.Key, err)
+	}
+
+	err = engine.terminateActiveJobsForToken(ctx, batch, activeToken.Key)
+	if err != nil {
+		return fmt.Errorf("failed to terminate jobs for execution token %d: %w", activeToken.Key, err)
+	}
+
+	err = engine.resolveIncidentsForToken(ctx, batch, activeToken.Key)
+	if err != nil {
+		return fmt.Errorf("failed to close incidents for execution token %d: %w", activeToken.Key, err)
+	}
+
+	// Cancel called processes
+	// TODO: This can cause a deadlock
+	// TODO: Fix THIS
+	calledProcesses, err := engine.persistence.FindProcessInstancesByParentExecutionTokenKey(ctx, activeToken.Key)
+	if err != nil {
+		return fmt.Errorf("failed to find called process for token %d: %w", activeToken.Key, err)
+	}
+	for _, calledProcess := range calledProcesses {
+		err = engine.cancelInstance(ctx, calledProcess, batch)
+		if err != nil {
+			return fmt.Errorf("failed to cancel called process for token %d: %w", activeToken.Key, err)
+		}
+	}
+
+	activeToken.State = runtime.TokenStateCanceled
+	err = batch.SaveToken(ctx, activeToken)
+	if err != nil {
+		return fmt.Errorf("failed to terminate execution activeToken %d: %w", activeToken.Key, err)
+	}
+
+	return nil
 }
 
 func (engine *Engine) startExecutionTokens(ctx context.Context, batch *EngineBatch, startingElementIds []string, processInstance runtime.ProcessInstance) ([]runtime.ExecutionToken, error) {

--- a/pkg/bpmn/engine_api.go
+++ b/pkg/bpmn/engine_api.go
@@ -317,6 +317,9 @@ func (engine *Engine) CreateInstance(ctx context.Context, process *runtime.Proce
 		runtime.NewVariableHolder(nil, variableContext),
 		&runtime.DefaultProcessInstance{},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start process instance: %w", err)
+	}
 	err = batch.Flush(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start process instance: %w", err)

--- a/pkg/bpmn/incident_api.go
+++ b/pkg/bpmn/incident_api.go
@@ -127,3 +127,25 @@ func (engine *Engine) ResolveIncident(ctx context.Context, key int64) (retErr er
 	}
 	return nil
 }
+
+func (engine *Engine) resolveIncidentsForToken(ctx context.Context, batch *EngineBatch, tokenKey int64) error {
+
+	incidents, err := engine.persistence.FindIncidentsByExecutionTokenKey(ctx, tokenKey)
+	if err != nil {
+		return fmt.Errorf("failed to find incidents for execution token %d: %w", tokenKey, err)
+	}
+
+	for _, incident := range incidents {
+		if incident.ResolvedAt != nil {
+			continue
+		}
+
+		incident.ResolvedAt = ptr.To(time.Now())
+		err = batch.SaveIncident(ctx, incident)
+		if err != nil {
+			return fmt.Errorf("failed to save changes to incident %d: %w", incident.Key, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/bpmn/jobs.go
+++ b/pkg/bpmn/jobs.go
@@ -138,3 +138,20 @@ func (engine *Engine) createInternalTask(
 
 	return job.State, jobError
 }
+
+func (engine *Engine) terminateActiveJobsForToken(ctx context.Context, batch *EngineBatch, tokenKey int64) error {
+
+	jobs, err := engine.persistence.GetJobsInStateByTokenKey(ctx, tokenKey, []runtime.ActivityState{runtime.ActivityStateActive, runtime.ActivityStateCompleting, runtime.ActivityStateFailed})
+	if err != nil {
+		return fmt.Errorf("failed to find jobs for execution token %d: %w", tokenKey, err)
+	}
+	for _, job := range jobs {
+		job.State = runtime.ActivityStateTerminated
+		err = batch.SaveJob(ctx, job)
+		if err != nil {
+			return fmt.Errorf("failed to save changes to job %d: %w", job.Key, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/bpmn/timer_api.go
+++ b/pkg/bpmn/timer_api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/model/bpmn20"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
@@ -38,6 +39,9 @@ func (engine *Engine) TriggerTimer(ctx context.Context, timer runtime.Timer) (
 			completeTimerSpan.SetStatus(codes.Error, retErr.Error())
 		}
 		completeTimerSpan.End()
+		if r := recover(); r != nil {
+			engine.logger.Error(fmt.Sprintf("failed to process timer, panic recovered: %v\n%s", r, debug.Stack()))
+		}
 	}()
 
 	if timer.ProcessInstanceKey == nil { // timer start event creates and starts the new process instance

--- a/pkg/bpmn/timer_api.go
+++ b/pkg/bpmn/timer_api.go
@@ -34,14 +34,16 @@ func (engine *Engine) TriggerTimer(ctx context.Context, timer runtime.Timer) (
 ) {
 	ctx, completeTimerSpan := engine.tracer.Start(ctx, fmt.Sprintf("timer:%d", timer.Key))
 	defer func() {
+		if r := recover(); r != nil {
+			panicErr := fmt.Errorf("failed to process timer, panic recovered: %v\n%s", r, debug.Stack())
+			engine.logger.Error(panicErr.Error())
+			retErr = panicErr
+		}
 		if retErr != nil {
 			completeTimerSpan.RecordError(retErr)
 			completeTimerSpan.SetStatus(codes.Error, retErr.Error())
 		}
 		completeTimerSpan.End()
-		if r := recover(); r != nil {
-			engine.logger.Error(fmt.Sprintf("failed to process timer, panic recovered: %v\n%s", r, debug.Stack()))
-		}
 	}()
 
 	if timer.ProcessInstanceKey == nil { // timer start event creates and starts the new process instance
@@ -54,18 +56,18 @@ func (engine *Engine) TriggerTimer(ctx context.Context, timer runtime.Timer) (
 
 	instance, err := engine.persistence.FindProcessInstanceByKey(ctx, *timer.ProcessInstanceKey)
 	if err != nil {
-		return nil, nil, errors.Join(newEngineErrorf("failed to find process instance with key: %d", *timer.ProcessInstanceKey), err)
+		return nil, nil, newEngineErrorf("failed to find process instance with key: %d", *timer.ProcessInstanceKey)
 	}
 
 	currentToken := timer.Token
 	tokenNode := instance.ProcessInstance().Definition.Definitions.Process.GetFlowNodeById(currentToken.ElementId)
 	if tokenNode == nil || tokenNode.GetId() == "" {
-		return nil, nil, errors.Join(newEngineErrorf("failed to find timer node with elementId: %s", timer.ElementId), err)
+		return nil, nil, newEngineErrorf("failed to find timer node with elementId: %s", timer.ElementId)
 	}
 
 	batch, err := engine.NewEngineBatch(ctx, instance)
 	if err != nil {
-		return nil, nil, errors.Join(newEngineErrorf("failed to create batch for timer %d: %s", timer.Key, err))
+		return nil, nil, newEngineErrorf("failed to create batch for timer %d: %s", timer.Key, err)
 	}
 	timerRefreshed, err := engine.persistence.GetTimer(ctx, timer.Key)
 	if err != nil {

--- a/pkg/bpmn/timer_manager.go
+++ b/pkg/bpmn/timer_manager.go
@@ -3,6 +3,7 @@ package bpmn
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"slices"
 	"sync"
 	"time"
@@ -80,45 +81,57 @@ func (tm *timerManager) removeTimer(timer runtime.Timer) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	tm.waitingTimers = slices.DeleteFunc(tm.waitingTimers, func(t waitingTimer) bool {
+		if t.timer.Key != timer.Key {
+			return false
+		}
 		t.cancel()
-		return t.timer.Key == timer.Key
+		return true
 	})
 }
 
 func (tm *timerManager) run() {
 	pollTicker := time.NewTicker(tm.pollTimerDelay)
 	for {
-		select {
-		case <-tm.ctx.Done():
+		if !tm.runOnce(pollTicker) {
 			return
-		case timer := <-tm.ch:
-			// process timer firing
-			if timer.Key == 0 {
-				// receive from closed channel
-				return
-			}
-			tm.processTimerFunc(context.Background(), timer)
-			tm.mu.Lock()
-			for i, item := range tm.waitingTimers {
-				if item.timer.Key == timer.Key {
-					tm.waitingTimers = append(tm.waitingTimers[:i], tm.waitingTimers[i+1:]...)
-					break
-				}
-			}
-			tm.mu.Unlock()
-		case t := <-pollTicker.C:
-			nextPoll := t.Add(tm.pollTimerDelay)
-			toFireTimers, err := tm.pollTimerFunc(tm.ctx, nextPoll)
-			if err != nil {
-				tm.logger.Error(fmt.Sprintf("Failed to poll timers for processing: %s", err))
-				continue
-			}
-			for _, tft := range toFireTimers {
-				tm.addWaitingTimer(tft)
-			}
-			tm.nextPoll = t.Add(tm.pollTimerDelay)
 		}
 	}
+}
+
+func (tm *timerManager) runOnce(pollTicker *time.Ticker) (continueTimer bool) {
+	continueTimer = true
+	defer func() {
+		if r := recover(); r != nil {
+			tm.logger.Error(fmt.Sprintf("timerManager panic recovered: %v\n%s", r, debug.Stack()))
+		}
+	}()
+
+	select {
+	case <-tm.ctx.Done():
+		continueTimer = false
+		return
+	case timer := <-tm.ch:
+		// process timer firing
+		if timer.Key == 0 {
+			// receive from closed channel
+			continueTimer = false
+			return
+		}
+		tm.removeTimer(timer)
+		tm.processTimerFunc(context.Background(), timer)
+	case t := <-pollTicker.C:
+		nextPoll := t.Add(tm.pollTimerDelay)
+		toFireTimers, err := tm.pollTimerFunc(tm.ctx, nextPoll)
+		if err != nil {
+			tm.logger.Error(fmt.Sprintf("Failed to poll timers for processing: %s", err))
+			return
+		}
+		for _, tft := range toFireTimers {
+			tm.addWaitingTimer(tft)
+		}
+		tm.nextPoll = t.Add(tm.pollTimerDelay)
+	}
+	return
 }
 
 func (tm *timerManager) addWaitingTimer(tft runtime.Timer) {

--- a/pkg/bpmn/timer_manager_test.go
+++ b/pkg/bpmn/timer_manager_test.go
@@ -168,3 +168,160 @@ func TestTimerManagerFiresHistoricTimers(t *testing.T) {
 	}
 	assert.Equal(t, 1, count, "Historic timer should fire exactly once")
 }
+
+func TestTimerManagerRemovesWaitingTimerBeforeProcessing(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		attempts int
+		handled  int
+	)
+	timer := runtime.Timer{
+		Key:   rand.Int63(),
+		DueAt: time.Now().Add(-1 * time.Second),
+	}
+
+	tm := newTimerManager(
+		func(ctx context.Context, fired runtime.Timer) {
+			mu.Lock()
+			defer mu.Unlock()
+			attempts++
+			if attempts == 1 {
+				panic("boom")
+			}
+			handled++
+		},
+		func(ctx context.Context, end time.Time) ([]runtime.Timer, error) { return nil, nil },
+		10*time.Minute,
+	)
+	tm.start()
+	defer tm.stop()
+
+	tm.addWaitingTimer(timer)
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return attempts == 1
+	}, 2*time.Second, 50*time.Millisecond, "first processing attempt should panic")
+
+	tm.addWaitingTimer(timer)
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return attempts == 2 && handled == 1
+	}, 2*time.Second, 50*time.Millisecond, "timer should be processed again after panic")
+}
+
+func TestTimerManagerRemoveTimerLeavesOthersWaiting(t *testing.T) {
+	tm := newTimerManager(
+		func(ctx context.Context, fired runtime.Timer) {},
+		func(ctx context.Context, end time.Time) ([]runtime.Timer, error) { return nil, nil },
+		10*time.Minute,
+	)
+	tm.start()
+	defer tm.stop()
+
+	toRemove := runtime.Timer{Key: rand.Int63(), DueAt: time.Now().Add(1 * time.Hour)}
+	toKeep := runtime.Timer{Key: rand.Int63(), DueAt: time.Now().Add(1 * time.Hour)}
+
+	tm.addWaitingTimer(toRemove)
+	tm.addWaitingTimer(toKeep)
+
+	tm.removeTimer(toRemove)
+
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	if assert.Len(t, tm.waitingTimers, 1, "only the targeted timer should be removed") {
+		kept := tm.waitingTimers[0]
+		assert.Equal(t, toKeep.Key, kept.timer.Key)
+		assert.NoError(t, kept.ctx.Err(), "kept timer's context must not be cancelled by unrelated removal")
+	}
+}
+
+func TestTimerManagerFiringOneDoesNotCancelOthers(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		fired []int64
+	)
+	tm := newTimerManager(
+		func(ctx context.Context, timer runtime.Timer) {
+			mu.Lock()
+			defer mu.Unlock()
+			fired = append(fired, timer.Key)
+		},
+		func(ctx context.Context, end time.Time) ([]runtime.Timer, error) { return nil, nil },
+		10*time.Minute,
+	)
+	tm.start()
+	defer tm.stop()
+
+	first := runtime.Timer{Key: rand.Int63(), DueAt: time.Now().Add(50 * time.Millisecond)}
+	second := runtime.Timer{Key: rand.Int63(), DueAt: time.Now().Add(400 * time.Millisecond)}
+
+	tm.addWaitingTimer(first)
+	tm.addWaitingTimer(second)
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Contains(fired, first.Key) && slices.Contains(fired, second.Key)
+	}, 2*time.Second, 20*time.Millisecond, "both timers should fire — removing the first must not cancel the second")
+}
+
+func TestTimerManagerPanicDoesNotStopOtherTimers(t *testing.T) {
+	panicKey := rand.Int63()
+	normalKeys := []int64{rand.Int63(), rand.Int63(), rand.Int63()}
+
+	var (
+		mu         sync.Mutex
+		panicCount int
+		handled    []int64
+	)
+	tm := newTimerManager(
+		func(ctx context.Context, timer runtime.Timer) {
+			mu.Lock()
+			defer mu.Unlock()
+			if timer.Key == panicKey {
+				panicCount++
+				panic("boom")
+			}
+			handled = append(handled, timer.Key)
+		},
+		func(ctx context.Context, end time.Time) ([]runtime.Timer, error) { return nil, nil },
+		10*time.Minute,
+	)
+	tm.start()
+	defer tm.stop()
+
+	now := time.Now()
+	// panicking timer fires in the middle, sandwiched between normal ones, to
+	// prove the loop keeps processing both before and after the panic.
+	tm.addWaitingTimer(runtime.Timer{Key: normalKeys[0], DueAt: now.Add(50 * time.Millisecond)})
+	tm.addWaitingTimer(runtime.Timer{Key: panicKey, DueAt: now.Add(150 * time.Millisecond)})
+	tm.addWaitingTimer(runtime.Timer{Key: normalKeys[1], DueAt: now.Add(500 * time.Millisecond)})
+	tm.addWaitingTimer(runtime.Timer{Key: normalKeys[2], DueAt: now.Add(850 * time.Millisecond)})
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return panicCount == 1 && len(handled) == len(normalKeys)
+	}, 3*time.Second, 20*time.Millisecond, "every normal timer must fire exactly once despite the panic")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, panicCount, "panicking timer should fire exactly once")
+	for _, k := range normalKeys {
+		assert.Equal(t, 1, countOccurrences(handled, k), "normal timer %d should be processed exactly once", k)
+	}
+}
+
+func countOccurrences(s []int64, v int64) int {
+	n := 0
+	for _, x := range s {
+		if x == v {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
- recover from panics in timer processing and log stack traces
- keep the timer manager loop resilient to runtime failures
- Replaced inline logic for token termination with `terminateExecutionToken`.
- Added `terminateActiveJobsForToken` for job termination and `resolveIncidentsForToken` for incident resolution.
- Improved code readability and modularity.