### PR TITLE
fix(#584): create new process definition version for older content re…

### DIFF
--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5"
 	"encoding/json"
@@ -420,41 +421,46 @@ func (node *ZenNode) EvaluateDecision(ctx context.Context, bindingType string, d
 }
 
 // DeployProcessDefinitionToAllPartitions deploys a BPMN process definition.
-// The alreadyExisted return is true when an identical definition (matched by
-// content checksum) is already deployed; in that case the existing key is
+// The alreadyExisted return is true when the latest version of the same BPMN
+// process definition has identical content; in that case the existing key is
 // returned and no new deployment is performed, so callers can treat this as
 // success (idempotent deploy).
 func (node *ZenNode) DeployProcessDefinitionToAllPartitions(ctx context.Context, data []byte, resourceName string) (int64, bool, error) {
-	key, err := node.GetDefinitionKeyByBytes(ctx, data)
+
+	processId, err := getProcessIdFromDefinition(data)
 	if err != nil {
-		return key, false, zenerr.TechnicalError(fmt.Errorf("failed to get process definition key by bytes: %w", err))
+		return 0, false, zenerr.TechnicalError(fmt.Errorf("failed to get process definition id: %w", err))
 	}
-	if key != 0 {
-		return key, true, nil
+
+	existingDefinitionKey, err := node.GetDefinitionKeyByProcessId(ctx, processId, data)
+
+	if err != nil {
+		return 0, false, zenerr.TechnicalError(fmt.Errorf("failed to get process definition key by bytes: %w", err))
 	}
-	definitionKey := node.idGen.Generate()
+
+	if existingDefinitionKey != 0 {
+		return existingDefinitionKey, true, nil
+	}
+
+	hash := fnv.New32a()
+	_, err = hash.Write([]byte(processId))
+	if err != nil {
+		return 0, false, zenerr.TechnicalError(fmt.Errorf("failed to hash process definition id: %w", err))
+	}
+
 	clusterState := node.store.ClusterState()
 	partitionIds := sortedPartitionIds(clusterState)
-	group, groupCtx := errgroup.WithContext(ctx)
 
-	// determine partitionIdx using incoming process definition id
-	var definitions bpmn20.TDefinitions
-	err = xml.Unmarshal(data, &definitions)
-	if err != nil {
-		return key, false, fmt.Errorf("failed to unmarshal xml data: %w", err)
-	}
-	h := fnv.New32a()
-	_, err = h.Write([]byte(definitions.Process.Id))
-	if err != nil {
-		return key, false, fmt.Errorf("failed to hash process definition id: %w", err)
-	}
 	if len(partitionIds) == 0 {
-		return key, false, fmt.Errorf("no partitions available in cluster state")
+		return 0, false, zenerr.ClusterError(fmt.Errorf("no partitions available in cluster state"))
 	}
-	partitionIdx := int(h.Sum32() % uint32(len(partitionIds)))
+
+	partitionIdx := int(hash.Sum32() % uint32(len(partitionIds)))
+	definitionKey := node.idGen.Generate()
 
 	// use that partitionIdx to create process definition subscriptions always only on that one partitionIdx
 	subscriptionPartitionId := partitionIds[partitionIdx]
+	group, groupCtx := errgroup.WithContext(ctx)
 	for _, partitionId := range partitionIds {
 		leaderId := clusterState.Partitions[partitionId].LeaderId
 		registerProcessDefinitionSubscriptions := subscriptionPartitionId == partitionId
@@ -476,6 +482,37 @@ func (node *ZenNode) DeployProcessDefinitionToAllPartitions(ctx context.Context,
 		return definitionKey.Int64(), false, waitErr
 	}
 	return definitionKey.Int64(), false, nil
+}
+
+func getProcessIdFromDefinition(data []byte) (string, error) {
+	var definitions bpmn20.TDefinitions
+	err := xml.Unmarshal(data, &definitions)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal xml data: %w", err)
+	}
+	return definitions.Process.Id, nil
+}
+
+func (node *ZenNode) GetDefinitionKeyByProcessId(ctx context.Context, processId string, newDefinitionData []byte) (int64, error) {
+	db, err := node.GetReadOnlyDB(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get database for definition key lookup: %w", err)
+	}
+
+	latestDefinition, err := db.Queries.FindLatestProcessDefinitionById(ctx, processId)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to find latest process definition by id %s: %w", processId, err)
+	}
+
+	newDefinitionMD5Sum := md5.Sum(newDefinitionData)
+
+	if bytes.Equal(latestDefinition.BpmnChecksum, newDefinitionMD5Sum[:]) {
+		return latestDefinition.Key, nil
+	}
+	return 0, nil
 }
 
 func (node *ZenNode) deployProcessDefinitionToPartition(
@@ -513,19 +550,6 @@ func (node *ZenNode) deployProcessDefinitionToPartition(
 	}
 
 	return nil
-}
-
-func (node *ZenNode) GetDefinitionKeyByBytes(ctx context.Context, data []byte) (int64, error) {
-	db, err := node.GetReadOnlyDB(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get database for definition key lookup: %w", err)
-	}
-	md5sum := md5.Sum(data)
-	key, err := db.Queries.GetDefinitionKeyByChecksum(ctx, md5sum[:])
-	if err != nil && err.Error() != "No result row" {
-		return 0, fmt.Errorf("failed to find process definition by checksum: %w", err)
-	}
-	return key, nil
 }
 
 func (node *ZenNode) CompleteJob(ctx context.Context, key int64, variables map[string]any) error {

--- a/internal/sql/process_definition.sql.go
+++ b/internal/sql/process_definition.sql.go
@@ -444,23 +444,6 @@ func (q *Queries) FindProcessDefinitionsByKeys(ctx context.Context, keys []int64
 	return items, nil
 }
 
-const getDefinitionKeyByChecksum = `-- name: GetDefinitionKeyByChecksum :one
-SELECT
-    key
-FROM
-    process_definition
-WHERE
-    bpmn_checksum = ?1
-LIMIT 1
-`
-
-func (q *Queries) GetDefinitionKeyByChecksum(ctx context.Context, bpmnChecksum []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getDefinitionKeyByChecksum, bpmnChecksum)
-	var key int64
-	err := row.Scan(&key)
-	return key, err
-}
-
 const getElementStatisticsByProcessDefinitionKey = `-- name: GetElementStatisticsByProcessDefinitionKey :many
 WITH active_tokens AS (
     SELECT

--- a/internal/sql/querier.go
+++ b/internal/sql/querier.go
@@ -79,7 +79,6 @@ type Querier interface {
 	FindTokenMessageSubscriptions(ctx context.Context, arg FindTokenMessageSubscriptionsParams) ([]MessageSubscription, error)
 	FindTokenTimers(ctx context.Context, arg FindTokenTimersParams) ([]Timer, error)
 	GetAllTokensForProcessInstance(ctx context.Context, processInstanceKey int64) ([]ExecutionToken, error)
-	GetDefinitionKeyByChecksum(ctx context.Context, bpmnChecksum []byte) (int64, error)
 	GetDmnResourceDefinitionKeyByChecksum(ctx context.Context, dmnChecksum []byte) (int64, error)
 	GetElementStatisticsByProcessDefinitionKey(ctx context.Context, processDefinitionKey int64) ([]GetElementStatisticsByProcessDefinitionKeyRow, error)
 	GetElementStatisticsByProcessInstanceKey(ctx context.Context, processInstanceKey int64) ([]GetElementStatisticsByProcessInstanceKeyRow, error)

--- a/internal/sql/queries/process_definition.sql
+++ b/internal/sql/queries/process_definition.sql
@@ -97,15 +97,6 @@ FROM
 WHERE
     key IN (sqlc.slice('keys'));
 
--- name: GetDefinitionKeyByChecksum :one
-SELECT
-    key
-FROM
-    process_definition
-WHERE
-    bpmn_checksum = @bpmn_checksum
-LIMIT 1;
-
 -- name: GetElementStatisticsByProcessDefinitionKey :many
 WITH active_tokens AS (
     SELECT

--- a/test/e2e/process_definition_test.go
+++ b/test/e2e/process_definition_test.go
@@ -217,6 +217,29 @@ func TestRestApiProcessDefinition(t *testing.T) {
 	})
 }
 
+func TestRestApiProcessDefinitionRedeployOlderContentCreatesNewVersion(t *testing.T) {
+	processID := fmt.Sprintf("redeploy_older_content-%d", time.Now().UnixNano())
+	version1Definition := versioningTestProcessDefinition(t, processID, "version 1")
+	version2Definition := versioningTestProcessDefinition(t, processID, "version 2")
+
+	version1Key := deployDefinitionFromBytesExpectingStatus(t, version1Definition, "redeploy_older_content-v1.bpmn", http.StatusCreated)
+	version2Key := deployDefinitionFromBytesExpectingStatus(t, version2Definition, "redeploy_older_content-v2.bpmn", http.StatusCreated)
+	redeployedVersion1Key := deployDefinitionFromBytesExpectingStatus(t, version1Definition, "redeploy_older_content-v1.bpmn", http.StatusCreated)
+	duplicateLatestKey := deployDefinitionFromBytesExpectingStatus(t, version1Definition, "redeploy_older_content-v1.bpmn", http.StatusOK)
+
+	require.NotEqual(t, version1Key, version2Key)
+	require.NotEqual(t, version1Key, redeployedVersion1Key)
+	require.NotEqual(t, version2Key, redeployedVersion1Key)
+	require.Equal(t, redeployedVersion1Key, duplicateLatestKey)
+
+	assertProcessDefinitionVersions(t, processID, []expectedProcessDefinitionVersion{
+		{version: 1, key: version1Key},
+		{version: 2, key: version2Key},
+		{version: 3, key: redeployedVersion1Key},
+	})
+	assertLatestProcessDefinitionVersion(t, processID, 3, redeployedVersion1Key)
+}
+
 func getDefinitionDetail(t testing.TB, key int64) (public.ProcessDefinitionDetail, error) {
 	var detail public.ProcessDefinitionDetail
 	resp, err := app.NewRequest(t).
@@ -427,6 +450,26 @@ func deployDefinitionFromBytes(t testing.TB, content []byte, filename string) (*
 	return resp, nil
 }
 
+func deployDefinitionFromBytesExpectingStatus(t testing.TB, content []byte, filename string, expectedStatus int) int64 {
+	t.Helper()
+
+	resp, err := deployDefinitionFromBytes(t, content, filename)
+	require.NoError(t, err)
+	require.Equal(t, expectedStatus, resp.StatusCode())
+
+	switch expectedStatus {
+	case http.StatusCreated:
+		require.NotNil(t, resp.JSON201)
+		return resp.JSON201.ProcessDefinitionKey
+	case http.StatusOK:
+		require.NotNil(t, resp.JSON200)
+		return resp.JSON200.ProcessDefinitionKey
+	default:
+		t.Fatalf("unsupported expected status %d", expectedStatus)
+		return 0
+	}
+}
+
 func deployDefinitionRaw(t testing.TB, filename string) (*zenclient.CreateProcessDefinitionResponse, error) {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -452,6 +495,62 @@ func deployDefinitionRaw(t testing.TB, filename string) (*zenclient.CreateProces
 	}
 
 	return app.restClient.CreateProcessDefinitionWithBodyWithResponse(t.Context(), writer.FormDataContentType(), &requestBody)
+}
+
+type expectedProcessDefinitionVersion struct {
+	version int
+	key     int64
+}
+
+func assertProcessDefinitionVersions(t testing.TB, processID string, expectedVersions []expectedProcessDefinitionVersion) {
+	t.Helper()
+
+	definitions := getProcessDefinitionVersions(t, processID, false)
+	require.Len(t, definitions, len(expectedVersions))
+
+	for i, expected := range expectedVersions {
+		assert.Equal(t, expected.version, definitions[i].Version)
+		assert.Equal(t, expected.key, definitions[i].Key)
+	}
+}
+
+func assertLatestProcessDefinitionVersion(t testing.TB, processID string, expectedVersion int, expectedKey int64) {
+	t.Helper()
+
+	definitions := getProcessDefinitionVersions(t, processID, true)
+	require.Len(t, definitions, 1)
+	assert.Equal(t, expectedVersion, definitions[0].Version)
+	assert.Equal(t, expectedKey, definitions[0].Key)
+}
+
+func getProcessDefinitionVersions(t testing.TB, processID string, onlyLatest bool) []zenclient.ProcessDefinitionSimple {
+	t.Helper()
+
+	sortBy := zenclient.GetProcessDefinitionsParamsSortByVersion
+	sortOrder := zenclient.GetProcessDefinitionsParamsSortOrderAsc
+	response, err := app.restClient.GetProcessDefinitionsWithResponse(t.Context(), &zenclient.GetProcessDefinitionsParams{
+		BpmnProcessId: &processID,
+		OnlyLatest:    &onlyLatest,
+		SortBy:        &sortBy,
+		SortOrder:     &sortOrder,
+		Size:          ptr.To(int32(10)),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, response.StatusCode())
+	require.NotNil(t, response.JSON200)
+	require.Equal(t, len(response.JSON200.Items), response.JSON200.TotalCount)
+	return response.JSON200.Items
+}
+
+func versioningTestProcessDefinition(t testing.TB, processID string, taskName string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "process_definition", "redeploy_older_content.bpmn"))
+	require.NoError(t, err)
+
+	definition := strings.ReplaceAll(string(data), "{{PROCESS_ID}}", processID)
+	definition = strings.ReplaceAll(definition, "{{TASK_NAME}}", taskName)
+	return []byte(definition)
 }
 
 func TestRestApiProcessDefinitionErrors(t *testing.T) {

--- a/test/e2e/testdata/process_definition/redeploy_older_content.bpmn
+++ b/test/e2e/testdata/process_definition/redeploy_older_content.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_{{PROCESS_ID}}" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="{{PROCESS_ID}}" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Activity_1" />
+    <bpmn:serviceTask id="Activity_1" name="{{TASK_NAME}}">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="{{PROCESS_ID}}">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1_di" bpmnElement="Activity_1">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="412" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="412" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
…deploys

Compare redeployed BPMN content only against the latest version of the same process id, so content matching an older version creates a new version while duplicate latest deployments remain idempotent.

Add an e2e regression test with a BPMN fixture for v1 -> v2 -> v1 deployment versioning.