### PR TITLE
fix(#694) - ensure child processes inherit parent history TTL and improve data cleanup error handling

### DIFF
--- a/internal/cluster/partition/partition.go
+++ b/internal/cluster/partition/partition.go
@@ -96,6 +96,10 @@ const (
 )
 
 func StartZenPartitionNode(ctx context.Context, mux *tcp.Mux, persistenceConfig config.Persistence, client *client.ClientManager, partition uint32, callbacks PartitionChangesCallbacks, zenState func() state.Cluster) (*ZenPartitionNode, error) {
+	return startZenPartitionNode(ctx, mux, persistenceConfig, client, partition, callbacks, zenState, defaultDBOptions())
+}
+
+func startZenPartitionNode(ctx context.Context, mux *tcp.Mux, persistenceConfig config.Persistence, client *client.ClientManager, partition uint32, callbacks PartitionChangesCallbacks, zenState func() state.Cluster, dbOpts dbOptions) (*ZenPartitionNode, error) {
 	cfg := persistenceConfig.RqLite
 	zpn := ZenPartitionNode{
 		config:               cfg,
@@ -122,13 +126,14 @@ func StartZenPartitionNode(ctx context.Context, mux *tcp.Mux, persistenceConfig 
 	}
 	zpn.store = str
 
-	zpn.DB, err = NewDB(
+	zpn.DB, err = newDB(
 		zpn.store,
 		zpn.PartitionId,
 		hclog.Default().Named(fmt.Sprintf("zen-partition-sql-%d", partition)),
 		persistenceConfig,
 		client,
 		zenState,
+		dbOpts,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rqLiteDB for partition %d: %w", partition, err)
@@ -256,6 +261,9 @@ func (zpn *ZenPartitionNode) Stats() (map[string]interface{}, error) {
 func (zpn *ZenPartitionNode) Stop() error {
 	if zpn.Engine != nil {
 		zpn.Engine.Stop()
+	}
+	if zpn.DB != nil {
+		zpn.DB.Close()
 	}
 	if zpn.FeelRuntime != nil {
 		zpn.FeelRuntime.Stop()

--- a/internal/cluster/partition/partition_persistence.go
+++ b/internal/cluster/partition/partition_persistence.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -56,7 +57,28 @@ type DB struct {
 	drdCache               *expirable.LRU[int64, dmnruntime.DmnResourceDefinition]
 	client                 *client.ClientManager
 	zenState               func() state.Cluster
-	historyDeleteThreshold int
+	historyDeleteBatchSize int
+	cleanupCancel          context.CancelFunc
+	cleanupDone            chan struct{}
+	cleanupStopOnce        sync.Once
+}
+
+const (
+	defaultHistoryDeleteBatchSize = 1000
+	dataCleanupDefaultInterval    = 30 * time.Second
+	dataCleanupExpeditedInterval  = 5 * time.Second
+)
+
+type dbOptions struct {
+	historyDeleteBatchSize int
+	startDataCleanup       bool
+}
+
+func defaultDBOptions() dbOptions {
+	return dbOptions{
+		historyDeleteBatchSize: defaultHistoryDeleteBatchSize,
+		startDataCleanup:       true,
+	}
 }
 
 // GenerateId implements storage.Storage.
@@ -83,6 +105,10 @@ func (d *DB) getLogger() hclog.Logger {
 }
 
 func NewDB(store *store.Store, partition uint32, logger hclog.Logger, cfg config.Persistence, client *client.ClientManager, zenState func() state.Cluster) (*DB, error) {
+	return newDB(store, partition, logger, cfg, client, zenState, defaultDBOptions())
+}
+
+func newDB(store *store.Store, partition uint32, logger hclog.Logger, cfg config.Persistence, client *client.ClientManager, zenState func() state.Cluster, opts dbOptions) (*DB, error) {
 	node, err := snowflake.NewNode(int64(partition))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create snowflake node for partition %d: %w", partition, err)
@@ -90,6 +116,9 @@ func NewDB(store *store.Store, partition uint32, logger hclog.Logger, cfg config
 	migrationDir := cfg.Migration.Dir
 	if migrationDir == "" {
 		migrationDir = sql.DefaultMigrationsDir
+	}
+	if opts.historyDeleteBatchSize <= 0 {
+		opts.historyDeleteBatchSize = defaultHistoryDeleteBatchSize
 	}
 	db := &DB{
 		Store:                  store,
@@ -102,67 +131,113 @@ func NewDB(store *store.Store, partition uint32, logger hclog.Logger, cfg config
 		drdCache:               expirable.NewLRU[int64, dmnruntime.DmnResourceDefinition](cfg.DecDefCacheSize, nil, time.Duration(cfg.DecDefCacheTTL)),
 		client:                 client,
 		zenState:               zenState,
-		historyDeleteThreshold: 1000,
+		historyDeleteBatchSize: opts.historyDeleteBatchSize,
 	}
 	queries := sql.New(db)
 	db.Queries = queries
 
-	safego.Go("partition-data-cleanup", db.logger, func() {
-		db.scheduleDataCleanup()
-	})
+	if opts.startDataCleanup {
+		cleanupCtx, cancel := context.WithCancel(context.Background())
+		db.cleanupCancel = cancel
+		db.cleanupDone = make(chan struct{})
+		safego.Go("partition-data-cleanup", db.logger, func() {
+			defer close(db.cleanupDone)
+			db.scheduleDataCleanup(cleanupCtx)
+		})
+	}
 	return db, nil
 }
 
-func (rq *DB) scheduleDataCleanup() {
-	t := time.NewTicker(30 * time.Second)
-	for range t.C {
-		t.Stop()
-		cleaningTriggered, err := rq.dataCleanup(time.Now())
+func (rq *DB) Close() {
+	rq.cleanupStopOnce.Do(func() {
+		if rq.cleanupCancel != nil {
+			rq.cleanupCancel()
+		}
+		if rq.cleanupDone != nil {
+			<-rq.cleanupDone
+		}
+	})
+}
+
+func (rq *DB) scheduleDataCleanup(ctx context.Context) {
+	t := time.NewTicker(dataCleanupDefaultInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			t.Stop()
+		}
+
+		cleaningTriggered, err := rq.dataCleanup(ctx, time.Now())
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			rq.logger.Error(fmt.Sprintf("Error while performing data cleanup: %s", err))
-			t.Reset(30 * time.Second)
+			t.Reset(dataCleanupDefaultInterval)
 			continue
 		}
 		if cleaningTriggered {
-			//speed up cleaning if there is a lot to clean
-			t.Reset(5 * time.Second)
+			// Speed up cleaning if there is a lot to clean.
+			t.Reset(dataCleanupExpeditedInterval)
 		} else {
-			t.Reset(30 * time.Second)
+			t.Reset(dataCleanupDefaultInterval)
 		}
 	}
 }
 
 // dataCleanup returns true if cleanup was triggered
-// cleanup is being done in batches of size historyDeleteThreshold
-func (rq *DB) dataCleanup(currTime time.Time) (bool, error) {
-	ctx := context.Background()
-	processes, _ := rq.Queries.FindInactiveInstancesToDelete(ctx, sql.FindInactiveInstancesToDeleteParams{
+// cleanup is being done in batches of size historyDeleteBatchSize
+func (rq *DB) dataCleanup(ctx context.Context, currTime time.Time) (bool, error) {
+	return rq.dataCleanupWithLimit(ctx, currTime, rq.historyDeleteBatchSize)
+}
+
+func (rq *DB) dataCleanupWithLimit(ctx context.Context, currTime time.Time, historyDeleteBatchSize int) (bool, error) {
+	if historyDeleteBatchSize <= 0 {
+		return false, fmt.Errorf("history delete batch size must be greater than zero")
+	}
+	inactiveInstancesToDelete, err := rq.Queries.FindInactiveInstancesToDelete(ctx, sql.FindInactiveInstancesToDeleteParams{
 		CurrUnix: ssql.NullInt64{
 			Int64: currTime.Unix(),
 			Valid: true,
 		},
-		Limit: int64(rq.historyDeleteThreshold),
+		Limit: int64(historyDeleteBatchSize),
 	})
-	var err error
-	if len(processes) == rq.historyDeleteThreshold {
-		processesNullInt64 := make([]ssql.NullInt64, len(processes))
-		for i := range processes {
+	if err != nil {
+		return false, fmt.Errorf("failed to find inactive process instances to delete: %w", err)
+	}
+	if len(inactiveInstancesToDelete) > 0 {
+		processesNullInt64 := make([]ssql.NullInt64, len(inactiveInstancesToDelete))
+		for i := range inactiveInstancesToDelete {
 			processesNullInt64[i] = ssql.NullInt64{
-				Int64: processes[i],
+				Int64: inactiveInstancesToDelete[i],
 				Valid: true,
 			}
 		}
-		err = errors.Join(err, rq.Queries.DeleteProcessInstancesDecisionInstances(ctx, processesNullInt64))
-		err = errors.Join(err, rq.Queries.DeleteFlowElementInstance(ctx, processes))
-		err = errors.Join(err, rq.Queries.DeleteProcessInstancesTokens(ctx, processes))
-		err = errors.Join(err, rq.Queries.DeleteProcessInstancesJobs(ctx, processes))
-		err = errors.Join(err, rq.Queries.DeleteProcessInstancesTimers(ctx, processesNullInt64))
-		err = errors.Join(err, rq.Queries.DeleteProcessInstancesMessageSubscriptions(ctx, processesNullInt64))
-		err = errors.Join(err, rq.Queries.DeleteProcessInstancesIncidents(ctx, processes))
-		err = errors.Join(err, rq.Queries.DeleteProcessInstances(ctx, processes))
-		return true, nil
+		// Queue the deletes into a single batch so they execute in one atomic
+		// transaction instead of paying a consensus round-trip per statement.
+		storageBatch := rq.NewBatch()
+		batch, ok := storageBatch.(*DBBatch)
+		if !ok {
+			return true, fmt.Errorf("expected *DBBatch from NewBatch, got %T", storageBatch)
+		}
+		err = errors.Join(err, batch.queries.DeleteProcessInstancesDecisionInstances(ctx, processesNullInt64))
+		err = errors.Join(err, batch.queries.DeleteFlowElementInstance(ctx, inactiveInstancesToDelete))
+		err = errors.Join(err, batch.queries.DeleteProcessInstancesTokens(ctx, inactiveInstancesToDelete))
+		err = errors.Join(err, batch.queries.DeleteProcessInstancesJobs(ctx, inactiveInstancesToDelete))
+		err = errors.Join(err, batch.queries.DeleteProcessInstancesTimers(ctx, processesNullInt64))
+		err = errors.Join(err, batch.queries.DeleteProcessInstancesMessageSubscriptions(ctx, processesNullInt64))
+		err = errors.Join(err, batch.queries.DeleteProcessInstancesIncidents(ctx, inactiveInstancesToDelete))
+		err = errors.Join(err, batch.queries.DeleteProcessInstancesErrorSubscriptions(ctx, inactiveInstancesToDelete))
+		err = errors.Join(err, batch.queries.DeleteProcessInstances(ctx, inactiveInstancesToDelete))
+		if err != nil {
+			return true, fmt.Errorf("failed to queue history cleanup deletes: %w", err)
+		}
+		return true, batch.Flush(ctx)
 	}
-	return false, err
+	return false, nil
 }
 
 func (rq *DB) ExecuteStatements(ctx context.Context, statements []*proto.Statement) ([]*proto.ExecuteQueryResponse, error) {
@@ -1006,6 +1081,7 @@ func (rq *DB) inflateProcessInstance(ctx context.Context, db *sql.Queries, dbIns
 				CreatedAt:      time.UnixMilli(dbInstance.CreatedAt),
 				State:          bpmnruntime.ActivityState(dbInstance.State),
 				StartElementId: sql.FromNullString(dbInstance.StartElementID),
+				HistoryTTLSec:  sql.FromNullInt64(dbInstance.HistoryTtlSec),
 			},
 		}, nil
 	case bpmnruntime.ProcessTypeMultiInstance:
@@ -1026,6 +1102,7 @@ func (rq *DB) inflateProcessInstance(ctx context.Context, db *sql.Queries, dbIns
 				CreatedAt:      time.UnixMilli(dbInstance.CreatedAt),
 				State:          bpmnruntime.ActivityState(dbInstance.State),
 				StartElementId: sql.FromNullString(dbInstance.StartElementID),
+				HistoryTTLSec:  sql.FromNullInt64(dbInstance.HistoryTtlSec),
 			},
 		}, nil
 	case bpmnruntime.ProcessTypeSubProcess:
@@ -1046,6 +1123,7 @@ func (rq *DB) inflateProcessInstance(ctx context.Context, db *sql.Queries, dbIns
 				CreatedAt:      time.UnixMilli(dbInstance.CreatedAt),
 				State:          bpmnruntime.ActivityState(dbInstance.State),
 				StartElementId: sql.FromNullString(dbInstance.StartElementID),
+				HistoryTTLSec:  sql.FromNullInt64(dbInstance.HistoryTtlSec),
 			},
 		}, nil
 	case bpmnruntime.ProcessTypeCallActivity:
@@ -1064,6 +1142,7 @@ func (rq *DB) inflateProcessInstance(ctx context.Context, db *sql.Queries, dbIns
 				CreatedAt:      time.UnixMilli(dbInstance.CreatedAt),
 				State:          bpmnruntime.ActivityState(dbInstance.State),
 				StartElementId: sql.FromNullString(dbInstance.StartElementID),
+				HistoryTTLSec:  sql.FromNullInt64(dbInstance.HistoryTtlSec),
 			},
 		}, nil
 	default:
@@ -1197,16 +1276,32 @@ func SaveProcessInstanceWith(ctx context.Context, db Querier, processInstance bp
 		return fmt.Errorf("failed to save process instance %d: %w", processInstance.ProcessInstance().Key, err)
 	}
 	if processInstance.ProcessInstance().State == bpmnruntime.ActivityStateReady {
-		historyTTL, found := appcontext.HistoryTTLFromContext(ctx)
-		if !found {
-			return nil
+		var historyTTLSec ssql.NullInt64
+		// The history TTL is carried on the in-memory runtime object: root
+		// instances take it from the request context at creation, and child
+		// instances inherit their parent's TTL when they are created (see
+		// resolveHistoryTTL and the child instance construction sites). This
+		// avoids a synchronous read of the parent here, which on a follower
+		// lagging on replication (ConsistencyLevel_NONE) could miss the parent
+		// and assign the resuming request's TTL instead of the parent's.
+		if ttl := processInstance.ProcessInstance().HistoryTTLSec; ttl != nil {
+			historyTTLSec = ssql.NullInt64{Valid: true, Int64: *ttl}
+		} else if !parentProcessExecutionToken.Valid {
+			// Fallback for root instances that reached this point without a TTL
+			// resolved on the runtime object (e.g. created through a path that
+			// bypasses resolveHistoryTTL): honour the request context.
+			if historyTTL, found := appcontext.HistoryTTLFromContext(ctx); found {
+				historyTTLSec = ssql.NullInt64{Valid: true, Int64: int64(historyTTL.Seconds())}
+			}
 		}
-		err = db.getQueries().SetProcessInstanceTTL(ctx, sql.SetProcessInstanceTTLParams{
-			HistoryTTLSec: ssql.NullInt64{Valid: true, Int64: int64(historyTTL.Seconds())},
-			Key:           processInstance.ProcessInstance().Key,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to set process instance TTL %d: %w", processInstance.ProcessInstance().Key, err)
+		if historyTTLSec.Valid {
+			err = db.getQueries().SetProcessInstanceTTL(ctx, sql.SetProcessInstanceTTLParams{
+				HistoryTTLSec: historyTTLSec,
+				Key:           processInstance.ProcessInstance().Key,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to set process instance TTL %d: %w", processInstance.ProcessInstance().Key, err)
+			}
 		}
 	}
 	if processInstance.ProcessInstance().State == bpmnruntime.ActivityStateCompleted ||

--- a/internal/cluster/partition/partition_persistence_test.go
+++ b/internal/cluster/partition/partition_persistence_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"slices"
+
 	ssql "database/sql"
 
 	"github.com/pbinitiative/zenbpm/internal/appcontext"
@@ -29,10 +31,32 @@ import (
 	"github.com/pbinitiative/zenbpm/pkg/storage"
 	"github.com/pbinitiative/zenbpm/pkg/storage/storagetest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func prepareTestSetupWithTestMigration(t *testing.T) (*ZenPartitionNode, config.Persistence, *client.ClientManager, *testStore, *servertest.TestServer) {
 	return prepareTestSetup(t, true)
+}
+
+func testDBOptions() dbOptions {
+	opts := defaultDBOptions()
+	opts.startDataCleanup = false
+	return opts
+}
+
+func newTestDB(t *testing.T, partition *ZenPartitionNode, conf config.Persistence, clientMgr *client.ClientManager, tStore *testStore, loggerName string) *DB {
+	t.Helper()
+	db, err := newDB(
+		partition.DB.Store,
+		partition.PartitionId,
+		hclog.Default().Named(loggerName),
+		conf,
+		clientMgr,
+		tStore.ClusterState,
+		testDBOptions(),
+	)
+	require.NoError(t, err)
+	return db
 }
 
 func prepareTestSetup(t *testing.T, runMigrationWithRollback bool) (*ZenPartitionNode, config.Persistence, *client.ClientManager, *testStore, *servertest.TestServer) {
@@ -90,7 +114,7 @@ func prepareTestSetup(t *testing.T, runMigrationWithRollback bool) (*ZenPartitio
 	}
 	clientMgr := client.NewClientManager(tStore)
 
-	partition, err := StartZenPartitionNode(ctx, mux, conf, clientMgr, 1, PartitionChangesCallbacks{}, func() state.Cluster {
+	partition, err := startZenPartitionNode(ctx, mux, conf, clientMgr, 1, PartitionChangesCallbacks{}, func() state.Cluster {
 		return state.Cluster{
 			Config: state.ClusterConfig{},
 			Partitions: map[uint32]state.Partition{
@@ -108,7 +132,7 @@ func prepareTestSetup(t *testing.T, runMigrationWithRollback bool) (*ZenPartitio
 					Partitions: map[uint32]state.NodePartition{},
 				}},
 		}
-	})
+	}, testDBOptions())
 	if err != nil {
 		t.Fatalf("failed to create partition node: %s", err)
 	}
@@ -130,8 +154,7 @@ func TestRqLiteStorage(t *testing.T) {
 	partition, conf, clientMgr, tStore, ts := prepareTestSetup(t, false)
 	defer partition.Stop()
 
-	db, err := NewDB(partition.DB.Store, partition.PartitionId, hclog.Default().Named("test-rq-lite-db"), conf, clientMgr, tStore.ClusterState)
-	assert.NoError(t, err)
+	db := newTestDB(t, partition, conf, clientMgr, tStore, "test-rq-lite-db")
 
 	tester := storagetest.StorageTester{}
 	tester.PrepareTestData(db, t)
@@ -148,8 +171,7 @@ func TestRunUpMigrations(t *testing.T) {
 	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t, false)
 	defer partition.Stop()
 
-	db, err := NewDB(partition.DB.Store, partition.PartitionId, hclog.Default().Named("test-migration-lite-db"), conf, clientMgr, tStore.ClusterState)
-	assert.NoError(t, err)
+	db := newTestDB(t, partition, conf, clientMgr, tStore, "test-migration-lite-db")
 
 	appliedMigrations, err := db.Queries.GetMigrations(t.Context())
 	assert.NoError(t, err)
@@ -175,8 +197,7 @@ func TestRunRollbackMigration(t *testing.T) {
 	partition, conf, clientMgr, tStore, _ := prepareTestSetupWithTestMigration(t)
 	defer partition.Stop()
 
-	db, err := NewDB(partition.DB.Store, partition.PartitionId, hclog.Default().Named("test-migration-lite-db"), conf, clientMgr, tStore.ClusterState)
-	assert.NoError(t, err)
+	db := newTestDB(t, partition, conf, clientMgr, tStore, "test-migration-lite-db")
 
 	appliedMigrations, err := db.Queries.GetMigrations(t.Context())
 	assert.NoError(t, err)
@@ -209,8 +230,8 @@ func TestDataCleanup(t *testing.T) {
 	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t, false)
 	defer partition.Stop()
 
-	db, err := NewDB(partition.DB.Store, partition.PartitionId, hclog.Default().Named("test-data-cleanup"), conf, clientMgr, tStore.ClusterState)
-	assert.NoError(t, err)
+	db := newTestDB(t, partition, conf, clientMgr, tStore, "test-data-cleanup")
+	const cleanupBatchSize = 10
 
 	data := `<?xml version="1.0" encoding="UTF-8"?><bpmn:process id="Simple_Task_Process%d" name="aName" isExecutable="true"></bpmn:process></xml>`
 
@@ -222,10 +243,16 @@ func TestDataCleanup(t *testing.T) {
 		BpmnData:      fmt.Sprintf(data, r),
 		BpmnChecksum:  [16]byte{1},
 	}
-	err = db.SaveProcessDefinition(t.Context(), pd)
+	err := db.SaveProcessDefinition(t.Context(), pd)
 	assert.NoError(t, err)
 
 	createTestData := func(ctx context.Context, idArr *[]int64) {
+		var historyTTLSec *int64
+		if historyTTL, found := appcontext.HistoryTTLFromContext(ctx); found {
+			ttl := int64(historyTTL.Seconds())
+			historyTTLSec = &ttl
+		}
+
 		r := db.GenerateId()
 		*idArr = append(*idArr, r)
 		inst1 := runtime.DefaultProcessInstance{
@@ -235,6 +262,7 @@ func TestDataCleanup(t *testing.T) {
 				VariableHolder: runtime.VariableHolder{},
 				CreatedAt:      time.Now(),
 				State:          runtime.ActivityStateReady,
+				HistoryTTLSec:  historyTTLSec,
 			},
 		}
 		err = db.SaveProcessInstance(ctx, &inst1)
@@ -281,6 +309,19 @@ func TestDataCleanup(t *testing.T) {
 		err = db.SaveIncident(ctx, incident)
 		assert.NoError(t, err)
 
+		errorSubscription := runtime.ErrorSubscription{
+			Key:                  r + 110,
+			ElementInstanceKey:   r + 111,
+			ElementId:            "error-catch-465",
+			ProcessDefinitionKey: pd.Key,
+			ProcessInstanceKey:   inst1.ProcessInstance().Key,
+			State:                runtime.ErrorStateCreated,
+			CreatedAt:            time.Now(),
+			Token:                token,
+		}
+		err = db.SaveErrorSubscription(ctx, errorSubscription)
+		assert.NoError(t, err)
+
 		r2 := db.GenerateId()
 		*idArr = append(*idArr, r2)
 		inst2 := runtime.SubProcessInstance{
@@ -293,6 +334,7 @@ func TestDataCleanup(t *testing.T) {
 				VariableHolder: runtime.VariableHolder{},
 				CreatedAt:      time.Now(),
 				State:          runtime.ActivityStateReady,
+				HistoryTTLSec:  historyTTLSec,
 			},
 		}
 		err = db.SaveProcessInstance(ctx, &inst2)
@@ -345,30 +387,37 @@ func TestDataCleanup(t *testing.T) {
 
 	idsToBeDeleted := []int64{}
 	idsToKeep := []int64{}
-	for i := range db.historyDeleteThreshold {
+	idsWithoutTTL := []int64{}
+	for i := range cleanupBatchSize {
 		ctx := t.Context()
-		if i < db.historyDeleteThreshold/2 {
-			ctx = appcontext.WithHistoryTTL(ctx, types.TTL(1*time.Hour))
+		if i < cleanupBatchSize/2 {
+			ctx = appcontext.WithHistoryTTL(ctx, types.TTL(time.Hour))
 			createTestData(ctx, &idsToKeep)
 		} else {
+			ctx = appcontext.WithHistoryTTL(ctx, types.TTL(time.Second))
 			createTestData(ctx, &idsToBeDeleted)
 		}
 	}
+	// Instances created without a history TTL must be retained forever.
+	createTestData(t.Context(), &idsWithoutTTL)
 
-	nowSeconds := ssql.NullInt64{
-		Int64: time.Now().Unix(),
-		Valid: true,
+	findInactiveIDs := func(at time.Time) ([]int64, error) {
+		return db.Queries.FindInactiveInstancesToDelete(t.Context(), sql.FindInactiveInstancesToDeleteParams{
+			CurrUnix: ssql.NullInt64{
+				Int64: at.Unix(),
+				Valid: true,
+			},
+			Limit: 100000,
+		})
 	}
-	inactiveIds, err := db.Queries.FindInactiveInstancesToDelete(t.Context(), sql.FindInactiveInstancesToDeleteParams{
-		CurrUnix: nowSeconds,
-		Limit:    100000,
-	})
+
+	inactiveIDs, err := findInactiveIDs(time.Now())
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(inactiveIds))
+	assert.Equal(t, 0, len(inactiveIDs))
 	activeBeforeCleanup, err := db.Queries.FindActiveInstances(t.Context())
 	assert.NoError(t, err)
 
-	cleanupTriggered, err := db.dataCleanup(time.Now())
+	cleanupTriggered, err := db.dataCleanupWithLimit(t.Context(), time.Now(), cleanupBatchSize)
 	assert.NoError(t, err)
 	assert.False(t, cleanupTriggered)
 
@@ -376,7 +425,7 @@ func TestDataCleanup(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, activeBeforeCleanup, activeAfterCleanup)
 
-	idsToComplete := append(idsToBeDeleted, idsToKeep...)
+	idsToComplete := slices.Concat(idsToBeDeleted, idsToKeep, idsWithoutTTL)
 	for _, id := range idsToComplete {
 		pi, err := db.FindProcessInstanceByKey(t.Context(), id)
 		assert.NoError(t, err)
@@ -384,64 +433,163 @@ func TestDataCleanup(t *testing.T) {
 		err = db.SaveProcessInstance(t.Context(), pi)
 		assert.NoError(t, err)
 	}
-	inactiveIds, err = db.Queries.FindInactiveInstancesToDelete(t.Context(), sql.FindInactiveInstancesToDeleteParams{
-		CurrUnix: nowSeconds,
-		Limit:    100000,
-	})
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, inactiveIds, idsToBeDeleted)
+	require.Eventually(t, func() bool {
+		inactiveIDs, err = findInactiveIDs(time.Now())
+		return err == nil && int64SlicesMatch(inactiveIDs, idsToBeDeleted)
+	}, 10*time.Second, 100*time.Millisecond)
+	assert.ElementsMatch(t, idsToBeDeleted, inactiveIDs)
 
-	cleanupTriggered, err = db.dataCleanup(time.Now())
-	assert.NoError(t, err)
-	assert.True(t, cleanupTriggered)
+	// Verify that cleanup also processes a partially filled batch.
+	require.Eventually(t, func() bool {
+		cleanupTriggered, err = db.dataCleanupWithLimit(t.Context(), time.Now(), len(idsToBeDeleted)+1)
+		return err == nil && cleanupTriggered
+	}, 10*time.Second, 100*time.Millisecond)
 
-	inactiveIds, err = db.Queries.FindInactiveInstancesToDelete(t.Context(), sql.FindInactiveInstancesToDeleteParams{
-		CurrUnix: nowSeconds,
-		Limit:    100000,
-	})
-	assert.NoError(t, err)
-	assert.Empty(t, inactiveIds)
+	inactiveIDs, err = findInactiveIDs(time.Now())
+	require.NoError(t, err)
+	require.Empty(t, inactiveIDs)
+	// Each createTestData call creates two instances and one row per history table.
+	remainingCalls := int64((len(idsToKeep) + len(idsWithoutTTL)) / 2)
 	count := queryCount(t, db, "select count(*) from process_instance")
-	assert.Equal(t, int64(db.historyDeleteThreshold), count)
+	require.Equal(t, int64(len(idsToKeep)+len(idsWithoutTTL)), count)
 	count = queryCount(t, db, "select count(*) from message_subscription")
-	assert.Equal(t, int64(db.historyDeleteThreshold/2), count)
+	require.Equal(t, remainingCalls, count)
 	count = queryCount(t, db, "select count(*) from timer")
-	assert.Equal(t, int64(db.historyDeleteThreshold/2), count)
+	require.Equal(t, remainingCalls, count)
 	count = queryCount(t, db, "select count(*) from job")
-	assert.Equal(t, int64(db.historyDeleteThreshold/2), count)
+	require.Equal(t, remainingCalls, count)
 	count = queryCount(t, db, "select count(*) from execution_token")
-	assert.Equal(t, int64(db.historyDeleteThreshold/2), count)
+	require.Equal(t, remainingCalls, count)
 	count = queryCount(t, db, "select count(*) from flow_element_instance")
-	assert.Equal(t, int64(db.historyDeleteThreshold/2), count)
+	require.Equal(t, remainingCalls, count)
 	count = queryCount(t, db, "select count(*) from incident")
-	assert.Equal(t, int64(db.historyDeleteThreshold/2), count)
+	require.Equal(t, remainingCalls, count)
+	count = queryCount(t, db, "select count(*) from error_subscription")
+	require.Equal(t, remainingCalls, count)
 
-	//should delete only one instance
-	db.historyDeleteThreshold = 1
-	cleanupTriggered, err = db.dataCleanup(time.Now().Add(2 * time.Hour))
+	// Should delete only one instance.
+	cleanupTriggered, err = db.dataCleanupWithLimit(t.Context(), time.Now().Add(2*time.Hour), 1)
 	assert.NoError(t, err)
 	assert.True(t, cleanupTriggered)
 
-	inactiveIds, err = db.Queries.FindInactiveInstancesToDelete(t.Context(), sql.FindInactiveInstancesToDeleteParams{
-		CurrUnix: nowSeconds,
-		Limit:    100000,
-	})
-	assert.NoError(t, err)
-	assert.Empty(t, inactiveIds)
+	inactiveIDs, err = findInactiveIDs(time.Now())
+	require.NoError(t, err)
+	require.Empty(t, inactiveIDs)
 	count = queryCount(t, db, "select count(*) from process_instance")
-	assert.Equal(t, int64(999), count)
-	count = queryCount(t, db, "select count(*) from message_subscription")
-	assert.Equal(t, int64(499), count)
-	count = queryCount(t, db, "select count(*) from timer")
-	assert.Equal(t, int64(500), count)
-	count = queryCount(t, db, "select count(*) from job")
-	assert.Equal(t, int64(500), count)
-	count = queryCount(t, db, "select count(*) from execution_token")
-	assert.Equal(t, int64(499), count)
-	count = queryCount(t, db, "select count(*) from flow_element_instance")
-	assert.Equal(t, int64(500), count)
-	count = queryCount(t, db, "select count(*) from incident")
-	assert.Equal(t, int64(499), count)
+	require.Equal(t, int64(len(idsToKeep)+len(idsWithoutTTL)-1), count)
+
+	sumHistoryRows := func() int64 {
+		return queryCount(t, db, "select count(*) from message_subscription") +
+			queryCount(t, db, "select count(*) from timer") +
+			queryCount(t, db, "select count(*) from job") +
+			queryCount(t, db, "select count(*) from execution_token") +
+			queryCount(t, db, "select count(*) from flow_element_instance") +
+			queryCount(t, db, "select count(*) from incident") +
+			queryCount(t, db, "select count(*) from error_subscription")
+	}
+	// The deleted instance is the newest deletable one: the child of the last
+	// idsToKeep call, which owns 3 history rows (timer, job, flow element).
+	require.Equal(t, remainingCalls*7-3, sumHistoryRows())
+
+	// Instances without a TTL must never be cleaned up, no matter how far in
+	// the future the cleanup runs.
+	cleanupTriggered, err = db.dataCleanupWithLimit(t.Context(), time.Now().Add(2*time.Hour), defaultHistoryDeleteBatchSize)
+	require.NoError(t, err)
+	require.True(t, cleanupTriggered)
+
+	inactiveIDs, err = findInactiveIDs(time.Now().Add(1000 * time.Hour))
+	require.NoError(t, err)
+	require.Empty(t, inactiveIDs)
+	count = queryCount(t, db, "select count(*) from process_instance")
+	require.Equal(t, int64(len(idsWithoutTTL)), count)
+	require.Equal(t, int64(len(idsWithoutTTL)/2*7), sumHistoryRows())
+}
+
+func TestChildProcessInstanceInheritsParentHistoryTTL(t *testing.T) {
+	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t, false)
+	defer func() {
+		if err := partition.Stop(); err != nil {
+			t.Logf("failed to stop partition: %s", err)
+		}
+	}()
+
+	db := newTestDB(t, partition, conf, clientMgr, tStore, "test-child-history-ttl")
+
+	definition := runtime.ProcessDefinition{
+		BpmnProcessId: "child-history-ttl-process",
+		Version:       1,
+		Key:           db.GenerateId(),
+		BpmnData:      `<?xml version="1.0" encoding="UTF-8"?><bpmn:process id="child-history-ttl-process" name="child history ttl" isExecutable="true"></bpmn:process></xml>`,
+		BpmnChecksum:  [16]byte{1},
+	}
+	require.NoError(t, db.SaveProcessDefinition(t.Context(), definition))
+
+	parent := runtime.DefaultProcessInstance{
+		ProcessInstanceData: runtime.ProcessInstanceData{
+			Definition:     &definition,
+			Key:            db.GenerateId(),
+			VariableHolder: runtime.VariableHolder{},
+			CreatedAt:      time.Now(),
+			State:          runtime.ActivityStateReady,
+		},
+	}
+	parentContext := appcontext.WithHistoryTTL(t.Context(), types.TTL(time.Hour))
+	require.NoError(t, db.SaveProcessInstance(parentContext, &parent))
+
+	parentRow, err := db.Queries.GetProcessInstance(t.Context(), parent.ProcessInstance().Key)
+	require.NoError(t, err)
+	require.True(t, parentRow.HistoryTtlSec.Valid)
+	require.Equal(t, int64(time.Hour.Seconds()), parentRow.HistoryTtlSec.Int64)
+
+	parentToken := runtime.ExecutionToken{
+		Key:                db.GenerateId(),
+		ElementInstanceKey: db.GenerateId(),
+		ElementId:          "sub-process",
+		ProcessInstanceKey: parent.ProcessInstance().Key,
+		State:              runtime.TokenStateWaiting,
+	}
+	require.NoError(t, db.SaveToken(t.Context(), parentToken))
+
+	child := runtime.SubProcessInstance{
+		ParentProcessExecutionToken:           parentToken,
+		ParentProcessTargetElementInstanceKey: parentToken.ElementInstanceKey,
+		ParentProcessTargetElementId:          parentToken.ElementId,
+		ProcessInstanceData: runtime.ProcessInstanceData{
+			Definition:     &definition,
+			Key:            db.GenerateId(),
+			VariableHolder: runtime.VariableHolder{},
+			CreatedAt:      time.Now(),
+			State:          runtime.ActivityStateReady,
+			HistoryTTLSec:  new(int64(time.Hour.Seconds())),
+		},
+	}
+	childContext := appcontext.WithHistoryTTL(t.Context(), types.TTL(2*time.Hour))
+	require.NoError(t, db.SaveProcessInstance(childContext, &child))
+
+	childRow, err := db.Queries.GetProcessInstance(t.Context(), child.ProcessInstance().Key)
+	require.NoError(t, err)
+	require.True(t, childRow.HistoryTtlSec.Valid)
+	require.Equal(t, int64(time.Hour.Seconds()), childRow.HistoryTtlSec.Int64)
+
+	// A child instance whose parent had no TTL carries no TTL on its runtime object
+	// either, and must not pick one up from the resuming request's context.
+	childWithoutTTL := runtime.SubProcessInstance{
+		ParentProcessExecutionToken:           parentToken,
+		ParentProcessTargetElementInstanceKey: parentToken.ElementInstanceKey,
+		ParentProcessTargetElementId:          parentToken.ElementId,
+		ProcessInstanceData: runtime.ProcessInstanceData{
+			Definition:     &definition,
+			Key:            db.GenerateId(),
+			VariableHolder: runtime.VariableHolder{},
+			CreatedAt:      time.Now(),
+			State:          runtime.ActivityStateReady,
+		},
+	}
+	require.NoError(t, db.SaveProcessInstance(childContext, &childWithoutTTL))
+
+	childWithoutTTLRow, err := db.Queries.GetProcessInstance(t.Context(), childWithoutTTL.ProcessInstance().Key)
+	require.NoError(t, err)
+	require.False(t, childWithoutTTLRow.HistoryTtlSec.Valid)
 }
 
 func queryCount(t *testing.T, db *DB, query string) int64 {
@@ -450,6 +598,23 @@ func queryCount(t *testing.T, db *DB, query string) int64 {
 	err := row.Scan(&count)
 	assert.NoError(t, err)
 	return count
+}
+
+func int64SlicesMatch(left, right []int64) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	counts := make(map[int64]int, len(left))
+	for _, value := range left {
+		counts[value]++
+	}
+	for _, value := range right {
+		counts[value]--
+		if counts[value] < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func testMessageCorrelation(t *testing.T, db *DB, ts *servertest.TestServer) {
@@ -708,8 +873,7 @@ func TestGetLatestDecisionDefinitionById(t *testing.T) {
 	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t, false)
 	defer partition.Stop()
 
-	db, err := NewDB(partition.DB.Store, partition.PartitionId, hclog.Default().Named("test-decision-def"), conf, clientMgr, tStore.ClusterState)
-	assert.NoError(t, err)
+	db := newTestDB(t, partition, conf, clientMgr, tStore, "test-decision-def")
 
 	// Helper to create and save a DMN resource definition
 	saveDmnResource := func(t *testing.T, key int64) dmnruntime.DmnResourceDefinition {

--- a/internal/config/rqlite.go
+++ b/internal/config/rqlite.go
@@ -108,7 +108,7 @@ type RqLite struct {
 	RaftSnapThreshold uint64 `yaml:"raftSnapThreshold" json:"raftSnapThreshold" env:"RQLITE_RAFT_SNAP_THRESHOLD"`
 
 	// RaftSnapThreshold is the size of a SQLite WAL file which will trigger a snapshot.
-	RaftSnapThresholdWALSize uint64 `yaml:"raftSnapThresholdWALSize" json:"raftSnapThresholdWALSize" env:"RQLITE_"`
+	RaftSnapThresholdWALSize uint64 `yaml:"raftSnapThresholdWALSize" json:"raftSnapThresholdWALSize" env:"RQLITE_RAFT_SNAP_THRESHOLD_WAL_SIZE"`
 
 	// RaftSnapInterval sets the threshold check interval.
 	RaftSnapInterval time.Duration `yaml:"raftSnapInterval" json:"raftSnapInterval" env:"RQLITE_RAFT_SNAP_INTERVAL"`

--- a/internal/sql/error_subscription.sql.go
+++ b/internal/sql/error_subscription.sql.go
@@ -8,7 +8,28 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"strings"
 )
+
+const deleteProcessInstancesErrorSubscriptions = `-- name: DeleteProcessInstancesErrorSubscriptions :exec
+DELETE FROM error_subscription
+WHERE process_instance_key IN (/*SLICE:keys*/?)
+`
+
+func (q *Queries) DeleteProcessInstancesErrorSubscriptions(ctx context.Context, keys []int64) error {
+	query := deleteProcessInstancesErrorSubscriptions
+	var queryParams []interface{}
+	if len(keys) > 0 {
+		for _, v := range keys {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:keys*/?", strings.Repeat(",?", len(keys))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:keys*/?", "NULL", 1)
+	}
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
+	return err
+}
 
 const findProcessInstanceErrorSubscriptions = `-- name: FindProcessInstanceErrorSubscriptions :many
 SELECT

--- a/internal/sql/process_instance.sql.go
+++ b/internal/sql/process_instance.sql.go
@@ -141,10 +141,16 @@ FROM
     LEFT JOIN process_instance AS parent_pi ON et.process_instance_key = parent_pi.key
 WHERE
     pi.state IN (4, 6, 9)
-    AND (pi.parent_process_execution_token IS NULL
+    -- et.key IS NULL covers both "no parent" (the LEFT JOIN never matches a NULL
+    -- parent_process_execution_token) and "the parent token row no longer exists"
+    -- (normally because history cleanup already removed the parent's history rows).
+    -- Either way there is no parent token row left to wait for.
+    AND (et.key IS NULL
         OR parent_pi.state IN (4, 6, 9))
-    AND (pi.history_delete_sec IS NULL
-        OR pi.history_delete_sec < ?1)
+    -- history_delete_sec IS NULL means no history TTL was configured for the
+    -- instance: retain it forever (NULL never satisfies the comparison).
+    AND pi.history_delete_sec < ?1
+ORDER BY pi.created_at DESC, pi.key DESC /* Descendants are created after their parents. */
 LIMIT ?2
 `
 

--- a/internal/sql/querier.go
+++ b/internal/sql/querier.go
@@ -21,6 +21,7 @@ type Querier interface {
 	DeleteProcessDefinitionsTimers(ctx context.Context, processdefinitionkeys []int64) error
 	DeleteProcessInstances(ctx context.Context, keys []int64) error
 	DeleteProcessInstancesDecisionInstances(ctx context.Context, keys []sql.NullInt64) error
+	DeleteProcessInstancesErrorSubscriptions(ctx context.Context, keys []int64) error
 	DeleteProcessInstancesIncidents(ctx context.Context, keys []int64) error
 	DeleteProcessInstancesJobs(ctx context.Context, keys []int64) error
 	DeleteProcessInstancesMessageSubscriptions(ctx context.Context, keys []sql.NullInt64) error

--- a/internal/sql/queries/error_subscription.sql
+++ b/internal/sql/queries/error_subscription.sql
@@ -6,6 +6,10 @@ ON CONFLICT
     DO UPDATE SET
         state = excluded.state;
 
+-- name: DeleteProcessInstancesErrorSubscriptions :exec
+DELETE FROM error_subscription
+WHERE process_instance_key IN (sqlc.slice('keys'));
+
 -- name: FindTokenErrorSubscriptions :many
 SELECT
     *

--- a/internal/sql/queries/process_instance.sql
+++ b/internal/sql/queries/process_instance.sql
@@ -34,10 +34,16 @@ FROM
     LEFT JOIN process_instance AS parent_pi ON et.process_instance_key = parent_pi.key
 WHERE
     pi.state IN (4, 6, 9)
-    AND (pi.parent_process_execution_token IS NULL
+    -- et.key IS NULL covers both "no parent" (the LEFT JOIN never matches a NULL
+    -- parent_process_execution_token) and "the parent token row no longer exists"
+    -- (normally because history cleanup already removed the parent's history rows).
+    -- Either way there is no parent token row left to wait for.
+    AND (et.key IS NULL
         OR parent_pi.state IN (4, 6, 9))
-    AND (pi.history_delete_sec IS NULL
-        OR pi.history_delete_sec < @currUnix)
+    -- history_delete_sec IS NULL means no history TTL was configured for the
+    -- instance: retain it forever (NULL never satisfies the comparison).
+    AND pi.history_delete_sec < @currUnix
+ORDER BY pi.created_at DESC, pi.key DESC /* Descendants are created after their parents. */
 LIMIT @limit;
 
 -- name: FindActiveInstances :many

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -374,6 +374,20 @@ func (engine *Engine) startExecutionTokens(ctx context.Context, batch *EngineBat
 	return executionTokens, nil
 }
 
+// resolveHistoryTTL ensures the instance carries a history TTL in memory.
+// Child instances have already been seeded with their parent's TTL at the
+// creation site, so they are left untouched (a nil parent TTL must not be
+// overridden by the resuming request's context). Root instances take the TTL
+// from the request context that started them.
+func resolveHistoryTTL(ctx context.Context, instance runtime.ProcessInstance) {
+	if instance.GetParentProcessInstanceKey() != nil || instance.ProcessInstance().HistoryTTLSec != nil {
+		return
+	}
+	if ttl, ok := appcontext.HistoryTTLFromContext(ctx); ok {
+		instance.ProcessInstance().HistoryTTLSec = new(int64(ttl.Seconds()))
+	}
+}
+
 // createInstance creates a process instance for a given process definition and returns it.
 // Also returns execution tokens for plain StartEvent
 func (engine *Engine) createInstance(
@@ -388,6 +402,7 @@ func (engine *Engine) createInstance(
 	instance.ProcessInstance().VariableHolder = variableHolder
 	instance.ProcessInstance().CreatedAt = time.Now()
 	instance.ProcessInstance().State = runtime.ActivityStateReady
+	resolveHistoryTTL(ctx, instance)
 
 	ctx, createSpan := engine.tracer.Start(ctx, fmt.Sprintf("create-instance:%s", instance.ProcessInstance().Definition.BpmnProcessId), trace.WithAttributes(
 		attribute.Int64(otelPkg.AttributeProcessInstanceKey, instance.ProcessInstance().Key),
@@ -470,6 +485,7 @@ func (engine *Engine) createInstanceWithStartingElements(
 	instance.ProcessInstance().VariableHolder = variableHolder
 	instance.ProcessInstance().CreatedAt = time.Now()
 	instance.ProcessInstance().State = runtime.ActivityStateReady
+	resolveHistoryTTL(ctx, instance)
 
 	startNodeIds := make([]string, 0, len(startingFlowNodes))
 	for _, startNode := range startingFlowNodes {

--- a/pkg/bpmn/event_subprocess_subscription_handler.go
+++ b/pkg/bpmn/event_subprocess_subscription_handler.go
@@ -211,6 +211,9 @@ func (engine *Engine) buildEventSubprocessInstance(
 			ParentProcessExecutionToken:           tokens[0],
 			ParentProcessTargetElementInstanceKey: tokens[0].ElementInstanceKey,
 			ParentProcessTargetElementId:          subProcessDef.Id,
+			ProcessInstanceData: runtime.ProcessInstanceData{
+				HistoryTTLSec: instance.ProcessInstance().HistoryTTLSec,
+			},
 		},
 	)
 	if err != nil {

--- a/pkg/bpmn/multi_instance.go
+++ b/pkg/bpmn/multi_instance.go
@@ -192,6 +192,9 @@ func (engine *Engine) startParallelMultiInstance(
 			ParentProcessExecutionToken:           currentToken,
 			ParentProcessTargetElementInstanceKey: currentToken.ElementInstanceKey,
 			ParentProcessTargetElementId:          element.GetId(),
+			ProcessInstanceData: runtime.ProcessInstanceData{
+				HistoryTTLSec: instance.ProcessInstance().HistoryTTLSec,
+			},
 		},
 	)
 	if err != nil {
@@ -256,6 +259,9 @@ func (engine *Engine) startSequentialMultiInstance(ctx context.Context, batch *E
 			ParentProcessExecutionToken:           currentToken,
 			ParentProcessTargetElementInstanceKey: currentToken.ElementInstanceKey,
 			ParentProcessTargetElementId:          element.GetId(),
+			ProcessInstanceData: runtime.ProcessInstanceData{
+				HistoryTTLSec: instance.ProcessInstance().HistoryTTLSec,
+			},
 		},
 	)
 	if err != nil {

--- a/pkg/bpmn/runtime/types.go
+++ b/pkg/bpmn/runtime/types.go
@@ -122,6 +122,13 @@ type ProcessInstanceData struct {
 	CreatedAt      time.Time
 	State          ActivityState
 	StartElementId *string
+	// HistoryTTLSec is the history retention TTL in seconds carried in memory so
+	// that child instances can inherit it from their parent without a synchronous
+	// DB read at save time. nil means "no TTL". For root instances it is derived
+	// from the request context at creation; for child instances it is copied from
+	// the parent runtime object; for instances loaded from the DB it is read back
+	// from the persisted value.
+	HistoryTTLSec *int64
 }
 
 func (pi *ProcessInstanceData) GetProcessInfo() *ProcessDefinition {

--- a/pkg/bpmn/sub_process.go
+++ b/pkg/bpmn/sub_process.go
@@ -53,6 +53,9 @@ func (engine *Engine) createCallActivity(
 		&runtime.CallActivityInstance{
 			ParentProcessExecutionToken:           currentToken,
 			ParentProcessTargetElementInstanceKey: currentToken.ElementInstanceKey,
+			ProcessInstanceData: runtime.ProcessInstanceData{
+				HistoryTTLSec: instance.ProcessInstance().HistoryTTLSec,
+			},
 		})
 	if err != nil {
 		return runtime.ActivityStateFailed, err
@@ -111,6 +114,9 @@ func (engine *Engine) createSubProcess(
 			ParentProcessExecutionToken:           currentToken,
 			ParentProcessTargetElementInstanceKey: currentToken.ElementInstanceKey,
 			ParentProcessTargetElementId:          element.Id,
+			ProcessInstanceData: runtime.ProcessInstanceData{
+				HistoryTTLSec: instance.ProcessInstance().HistoryTTLSec,
+			},
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
closes #694 