### PR TITLE
feat(535) - add e2e tests for message event scenarios

### DIFF
--- a/internal/cluster/jobmanager/server.go
+++ b/internal/cluster/jobmanager/server.go
@@ -116,7 +116,6 @@ func (s *jobServer) distributeJobs() {
 			s.logger.Info("Stopping job distribution", "err", s.ctx.Err())
 			return
 		}
-		s.clientMu.RLock()
 		jobTypes := make([]string, 0, len(s.jobTypes))
 		clients := make(map[ClientID]int64)
 		for jobType, jobTypeData := range s.jobTypes {
@@ -125,7 +124,6 @@ func (s *jobServer) distributeJobs() {
 				clients[client] = maxActiveJobsPerClient
 			}
 		}
-		s.clientMu.RUnlock()
 		s.distributedJobsMu.Lock()
 		currentKeys := make([]int64, len(s.distributedJobs))
 		now := time.Now()
@@ -181,7 +179,7 @@ func (s *jobServer) distributeJobs() {
 			}
 			jobTypeData.index++
 			// index overflow
-			if jobTypeData.index >= len(jobTypeData.clients) {
+			if jobTypeData.index >= len(jobTypeData.clients)-1 {
 				jobTypeData.index = 0
 			}
 			clientIdx := jobTypeData.index
@@ -193,7 +191,7 @@ func (s *jobServer) distributeJobs() {
 			if clients[clientID] <= 0 {
 				jobTypeData.index++
 				// index overflow
-				if jobTypeData.index >= len(jobTypeData.clients) {
+				if jobTypeData.index >= len(jobTypeData.clients)-1 {
 					jobTypeData.index = 0
 				}
 				clientIdx = jobTypeData.index

--- a/internal/cluster/jobmanager/server.go
+++ b/internal/cluster/jobmanager/server.go
@@ -116,6 +116,7 @@ func (s *jobServer) distributeJobs() {
 			s.logger.Info("Stopping job distribution", "err", s.ctx.Err())
 			return
 		}
+		s.clientMu.RLock()
 		jobTypes := make([]string, 0, len(s.jobTypes))
 		clients := make(map[ClientID]int64)
 		for jobType, jobTypeData := range s.jobTypes {
@@ -124,6 +125,7 @@ func (s *jobServer) distributeJobs() {
 				clients[client] = maxActiveJobsPerClient
 			}
 		}
+		s.clientMu.RUnlock()
 		s.distributedJobsMu.Lock()
 		currentKeys := make([]int64, len(s.distributedJobs))
 		now := time.Now()
@@ -179,7 +181,7 @@ func (s *jobServer) distributeJobs() {
 			}
 			jobTypeData.index++
 			// index overflow
-			if jobTypeData.index >= len(jobTypeData.clients)-1 {
+			if jobTypeData.index >= len(jobTypeData.clients) {
 				jobTypeData.index = 0
 			}
 			clientIdx := jobTypeData.index
@@ -191,7 +193,7 @@ func (s *jobServer) distributeJobs() {
 			if clients[clientID] <= 0 {
 				jobTypeData.index++
 				// index overflow
-				if jobTypeData.index >= len(jobTypeData.clients)-1 {
+				if jobTypeData.index >= len(jobTypeData.clients) {
 					jobTypeData.index = 0
 				}
 				clientIdx = jobTypeData.index

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sync"
 	"time"
@@ -918,12 +919,12 @@ func (engine *Engine) completeStartEventFlowElementInstance(
 	token runtime.ExecutionToken,
 ) error {
 	var outputVariables map[string]any
-	if instance.Type() == runtime.ProcessTypeDefault && isMessageStartEvent(element) {
-		instanceVariables := instance.ProcessInstance().VariableHolder.LocalVariables()
-		outputVariables = make(map[string]any, len(instanceVariables))
-		for key, value := range instanceVariables {
-			outputVariables[key] = value
-		}
+	// Unmapped message payload already lives on the process instance. Keep history
+	// compact by recording only an explicitly mapped start-event output.
+	if instance.Type() == runtime.ProcessTypeDefault &&
+		isMessageStartEvent(element) &&
+		len(element.GetOutputMapping()) > 0 {
+		outputVariables = maps.Clone(instance.ProcessInstance().VariableHolder.LocalVariables())
 	}
 
 	return batch.UpdateOutputFlowElementInstance(ctx, runtime.FlowElementInstance{

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -279,15 +279,13 @@ func (engine *Engine) terminateExecutionTokens(
 
 	activeTokensLeft := make([]runtime.ExecutionToken, 0, len(activeTokens))
 	for _, activeToken := range activeTokens {
-		for _, elementInstanceKey := range elementInstanceKeysToTerminate {
-			if activeToken.ElementInstanceKey == elementInstanceKey {
-				err = engine.terminateExecutionToken(ctx, batch, processInstanceKey, activeToken)
-				if err != nil {
-					return nil, fmt.Errorf("failed to terminate execution token %d: %w", activeToken.Key, err)
-				}
-			} else {
-				activeTokensLeft = append(activeTokensLeft, activeToken)
+		if slices.Contains(elementInstanceKeysToTerminate, activeToken.ElementInstanceKey) {
+			err = engine.terminateExecutionToken(ctx, batch, processInstanceKey, activeToken)
+			if err != nil {
+				return nil, fmt.Errorf("failed to terminate execution token %d: %w", activeToken.Key, err)
 			}
+		} else {
+			activeTokensLeft = append(activeTokensLeft, activeToken)
 		}
 	}
 
@@ -808,13 +806,12 @@ func (engine *Engine) processFlowNode(
 
 	switch element := activity.Element().(type) {
 	case *bpmn20.TStartEvent:
-		//TODO: input output Variables
 		tokens, err := engine.handleElementTransition(ctx, batch, instance, element, currentToken)
 		if err != nil {
 			flowNodeSpan.SetStatus(codes.Error, err.Error())
 			return nil, fmt.Errorf("failed to process StartEvent flow transition %d: %w", activity.GetKey(), err)
 		}
-		if err := engine.completeFlowElementInstance(ctx, batch, instance, element, currentToken); err != nil {
+		if err := engine.completeStartEventFlowElementInstance(ctx, batch, instance, element, currentToken); err != nil {
 			return nil, fmt.Errorf("failed to complete StartEvent history %d: %w", activity.GetKey(), err)
 		}
 		return tokens, nil
@@ -911,6 +908,33 @@ func flowNodeOwnsHistory(element bpmn20.FlowNode) bool {
 	default:
 		return false
 	}
+}
+
+func (engine *Engine) completeStartEventFlowElementInstance(
+	ctx context.Context,
+	batch *EngineBatch,
+	instance runtime.ProcessInstance,
+	element *bpmn20.TStartEvent,
+	token runtime.ExecutionToken,
+) error {
+	var outputVariables map[string]any
+	if instance.Type() == runtime.ProcessTypeDefault && isMessageStartEvent(element) {
+		instanceVariables := instance.ProcessInstance().VariableHolder.LocalVariables()
+		outputVariables = make(map[string]any, len(instanceVariables))
+		for key, value := range instanceVariables {
+			outputVariables[key] = value
+		}
+	}
+
+	return batch.UpdateOutputFlowElementInstance(ctx, runtime.FlowElementInstance{
+		Key:                token.ElementInstanceKey,
+		ProcessInstanceKey: instance.ProcessInstance().GetInstanceKey(),
+		ElementId:          element.GetId(),
+		ElementType:        string(element.GetType()),
+		ExecutionTokenKey:  token.Key,
+		OutputVariables:    outputVariables,
+		CompletedAt:        new(time.Now()),
+	})
 }
 
 // completeFlowElementInstance updates the history row keyed by token.ElementInstanceKey.

--- a/pkg/bpmn/events.go
+++ b/pkg/bpmn/events.go
@@ -21,7 +21,19 @@ func (engine *Engine) publishMessageOnListener(ctx context.Context, batch *Engin
 		return nil, err
 	}
 
-	variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, nil)
+	flowElementInstance, err := engine.persistence.GetFlowElementInstanceByKey(ctx, message.Token.ElementInstanceKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load intermediate message catch event flow element instance %d: %w", message.Token.ElementInstanceKey, err)
+	}
+	var inputVariables map[string]interface{}
+	if flowElementInstance.InputVariables != nil {
+		inputVariables = make(map[string]interface{}, len(flowElementInstance.InputVariables))
+		for key, value := range flowElementInstance.InputVariables {
+			inputVariables[key] = value
+		}
+	}
+
+	variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, inputVariables)
 	outputVariables, err := variableHolder.PropagateMappedOutputsOrAll(listener.Output, variables, engine.evaluateExpression)
 	if err != nil {
 		return nil, fmt.Errorf("failed to propagate variables to process instance %d: %w", instance.ProcessInstance().Key, err)
@@ -432,8 +444,13 @@ func (engine *Engine) createMessageCatchEvent(
 	element bpmn20.FlowNode,
 	token runtime.ExecutionToken,
 ) (runtime.ExecutionToken, error) {
-	// TODO: handle input variables
-	correlationKey, err := engine.getMessageCorrelationKey(*instance.ProcessInstance().Definition, &instance, messageDef)
+	variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, nil)
+	if err := variableHolder.EvaluateAndSetMappingsToLocalVariables(messageDef.GetInputMapping(), engine.evaluateExpression); err != nil {
+		token.State = runtime.TokenStateFailed
+		return token, fmt.Errorf("failed to evaluate message catch event input variables for %s: %w", element.GetId(), err)
+	}
+
+	correlationKey, err := engine.evaluateMessageCorrelationKey(*instance.ProcessInstance().Definition, variableHolder.LocalVariables(), messageDef)
 	if err != nil {
 		token.State = runtime.TokenStateFailed
 		return token, fmt.Errorf("failed to evaluate message correlation key: %w", err)
@@ -461,6 +478,24 @@ func (engine *Engine) createMessageCatchEvent(
 	if err != nil {
 		token.State = runtime.TokenStateFailed
 		return token, fmt.Errorf("failed to save new message subscription %+v: %w", subscription, err)
+	}
+
+	_, isIntermediateCatchEvent := element.(*bpmn20.TIntermediateCatchEvent)
+	if isIntermediateCatchEvent && element.GetId() == token.ElementId {
+		err = batch.SaveFlowElementInstance(ctx, runtime.FlowElementInstance{
+			Key:                token.ElementInstanceKey,
+			ProcessInstanceKey: instance.ProcessInstance().Key,
+			ElementId:          element.GetId(),
+			ElementType:        string(element.GetType()),
+			CreatedAt:          time.Now(),
+			ExecutionTokenKey:  token.Key,
+			InputVariables:     variableHolder.LocalVariables(),
+			OutputVariables:    nil,
+		})
+		if err != nil {
+			token.State = runtime.TokenStateFailed
+			return token, fmt.Errorf("failed to save message catch event flow element instance %s: %w", element.GetId(), err)
+		}
 	}
 
 	token.State = runtime.TokenStateWaiting

--- a/pkg/bpmn/events.go
+++ b/pkg/bpmn/events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -21,20 +22,16 @@ func (engine *Engine) publishMessageOnListener(ctx context.Context, batch *Engin
 		return nil, err
 	}
 
+	// A missing history row must not wedge a waiting token: the catch event's input scope is then simply
+	// unknown and the output mapping is evaluated against the instance scope alone (nil local variables).
 	flowElementInstance, err := engine.persistence.GetFlowElementInstanceByKey(ctx, message.Token.ElementInstanceKey)
-	if err != nil {
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
 		return nil, fmt.Errorf("failed to load intermediate message catch event flow element instance %d: %w", message.Token.ElementInstanceKey, err)
 	}
-	var inputVariables map[string]interface{}
-	if flowElementInstance.InputVariables != nil {
-		inputVariables = make(map[string]interface{}, len(flowElementInstance.InputVariables))
-		for key, value := range flowElementInstance.InputVariables {
-			inputVariables[key] = value
-		}
-	}
+	inputVariables := maps.Clone(flowElementInstance.InputVariables)
 
 	variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, inputVariables)
-	outputVariables, err := variableHolder.PropagateMappedOutputsOrAll(listener.Output, variables, engine.evaluateExpression)
+	outputVariables, err := variableHolder.PropagateMappedOutputsOrAll(listener.GetOutputMapping(), variables, engine.evaluateExpression)
 	if err != nil {
 		return nil, fmt.Errorf("failed to propagate variables to process instance %d: %w", instance.ProcessInstance().Key, err)
 	}
@@ -228,10 +225,7 @@ func (engine *Engine) propagateAndSaveReceiveTaskOutputVariables(ctx context.Con
 	if err != nil {
 		return nil, fmt.Errorf("failed to load receive task flow element instance %d: %w", token.ElementInstanceKey, err)
 	}
-	inputVariables := make(map[string]interface{}, len(flowElementInstance.InputVariables))
-	for key, value := range flowElementInstance.InputVariables {
-		inputVariables[key] = value
-	}
+	inputVariables := maps.Clone(flowElementInstance.InputVariables)
 
 	variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, inputVariables)
 	if err := engine.evaluateInputMappingsAgainstScope(variableHolder.LocalVariables(), input); err != nil {
@@ -335,8 +329,11 @@ func (engine *Engine) publishEventOnEventGateway(ctx context.Context, batch *Eng
 		return nil, nil
 	}
 	var token runtime.ExecutionToken
-	var outputVariables map[string]any
-	switch catchEvent.EventDefinition.(type) {
+	var (
+		inputVariables  map[string]any
+		outputVariables map[string]any
+	)
+	switch eventDefinition := catchEvent.EventDefinition.(type) {
 	case bpmn20.TMessageEventDefinition:
 		message := event.(*runtime.TokenMessageSubscription)
 		message.State = runtime.ActivityStateCompleted
@@ -345,8 +342,12 @@ func (engine *Engine) publishEventOnEventGateway(ctx context.Context, batch *Eng
 			return nil, fmt.Errorf("failed to save changes to message subscription %d: %w", message.Key, err)
 		}
 		token = message.Token
-		variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, nil)
-		outputVariables, err = variableHolder.PropagateMappedOutputsOrAll(catchEvent.Output, variables, engine.evaluateExpression)
+		inputVariables, err = engine.evaluateMessageCatchEventInputVariables(instance, eventDefinition)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate event gateway catch event input variables for %s: %w", catchEvent.GetId(), err)
+		}
+		variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, inputVariables)
+		outputVariables, err = variableHolder.PropagateMappedOutputsOrAll(catchEvent.GetOutputMapping(), variables, engine.evaluateExpression)
 		if err != nil {
 			return nil, err
 		}
@@ -393,7 +394,7 @@ func (engine *Engine) publishEventOnEventGateway(ctx context.Context, batch *Eng
 		ElementType:        string(catchEvent.GetType()),
 		CreatedAt:          time.Now(),
 		ExecutionTokenKey:  token.Key,
-		InputVariables:     nil,
+		InputVariables:     inputVariables,
 		OutputVariables:    outputVariables,
 		CompletedAt:        new(time.Now()),
 	})
@@ -444,13 +445,13 @@ func (engine *Engine) createMessageCatchEvent(
 	element bpmn20.FlowNode,
 	token runtime.ExecutionToken,
 ) (runtime.ExecutionToken, error) {
-	variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, nil)
-	if err := variableHolder.EvaluateAndSetMappingsToLocalVariables(messageDef.GetInputMapping(), engine.evaluateExpression); err != nil {
+	inputVariables, err := engine.evaluateMessageCatchEventInputVariables(instance, messageDef)
+	if err != nil {
 		token.State = runtime.TokenStateFailed
 		return token, fmt.Errorf("failed to evaluate message catch event input variables for %s: %w", element.GetId(), err)
 	}
 
-	correlationKey, err := engine.evaluateMessageCorrelationKey(*instance.ProcessInstance().Definition, variableHolder.LocalVariables(), messageDef)
+	correlationKey, err := engine.evaluateMessageCorrelationKey(*instance.ProcessInstance().Definition, inputVariables, messageDef)
 	if err != nil {
 		token.State = runtime.TokenStateFailed
 		return token, fmt.Errorf("failed to evaluate message correlation key: %w", err)
@@ -480,6 +481,9 @@ func (engine *Engine) createMessageCatchEvent(
 		return token, fmt.Errorf("failed to save new message subscription %+v: %w", subscription, err)
 	}
 
+	// A direct intermediate catch event owns the token's history row, so persist its
+	// evaluated local scope now. Event-based gateway catches share the gateway token;
+	// the winning catch evaluates and records its own scope when the message arrives.
 	_, isIntermediateCatchEvent := element.(*bpmn20.TIntermediateCatchEvent)
 	if isIntermediateCatchEvent && element.GetId() == token.ElementId {
 		err = batch.SaveFlowElementInstance(ctx, runtime.FlowElementInstance{
@@ -489,7 +493,7 @@ func (engine *Engine) createMessageCatchEvent(
 			ElementType:        string(element.GetType()),
 			CreatedAt:          time.Now(),
 			ExecutionTokenKey:  token.Key,
-			InputVariables:     variableHolder.LocalVariables(),
+			InputVariables:     inputVariables,
 			OutputVariables:    nil,
 		})
 		if err != nil {
@@ -500,6 +504,17 @@ func (engine *Engine) createMessageCatchEvent(
 
 	token.State = runtime.TokenStateWaiting
 	return token, nil
+}
+
+func (engine *Engine) evaluateMessageCatchEventInputVariables(
+	instance runtime.ProcessInstance,
+	messageDef bpmn20.TMessageEventDefinition,
+) (map[string]any, error) {
+	variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, nil)
+	if err := variableHolder.EvaluateAndSetMappingsToLocalVariables(messageDef.GetInputMapping(), engine.evaluateExpression); err != nil {
+		return nil, err
+	}
+	return variableHolder.LocalVariables(), nil
 }
 
 func (engine *Engine) getMessageCorrelationKey(processDefinition runtime.ProcessDefinition, instance *runtime.ProcessInstance, messageDef bpmn20.TMessageEventDefinition) (string, error) {

--- a/pkg/bpmn/events_api.go
+++ b/pkg/bpmn/events_api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/model/bpmn20"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
@@ -66,10 +67,9 @@ func (engine *Engine) receiveTaskOwnsSubscription(ctx context.Context, instance 
 	if err != nil {
 		return false, fmt.Errorf("failed to load receive task flow element instance %d: %w", message.Token.ElementInstanceKey, err)
 	}
+	// Must stay non-nil: evaluateInputMappingsAgainstScope writes the mapped values back into it.
 	localVars := make(map[string]interface{}, len(flowElementInstance.InputVariables))
-	for key, value := range flowElementInstance.InputVariables {
-		localVars[key] = value
-	}
+	maps.Copy(localVars, flowElementInstance.InputVariables)
 	if err := engine.evaluateInputMappingsAgainstScope(localVars, receiveTask.GetInputMapping()); err != nil {
 		return false, fmt.Errorf("failed to evaluate input mappings for receive task %s: %w", receiveTask.GetId(), err)
 	}

--- a/pkg/bpmn/events_message_io_test.go
+++ b/pkg/bpmn/events_message_io_test.go
@@ -1,0 +1,61 @@
+package bpmn
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/model/bpmn20"
+	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntermediateMessageCatchEventPreservesInputScopeAndHistoryMetadata(t *testing.T) {
+	const fixture = "./test-cases/simple-intermediate-message-catch-event.bpmn"
+	const originalOutputMapping = `<zenbpm:output source="= foo" target="mappedFoo" />`
+	const inputScopedOutputMapping = `<zenbpm:output source="= mappedInputFoo" target="mappedFoo" />`
+
+	bpmnData, err := os.ReadFile(fixture)
+	require.NoError(t, err)
+	modifiedBPMN := strings.Replace(string(bpmnData), originalOutputMapping, inputScopedOutputMapping, 1)
+	require.NotEqual(t, string(bpmnData), modifiedBPMN, "test fixture output mapping was not replaced")
+
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+	err = engine.Start(t.Context())
+	require.NoError(t, err)
+
+	t.Cleanup(engine.Stop)
+
+	definition, err := engine.LoadFromBytes(t.Context(), []byte(modifiedBPMN), engine.generateKey())
+	require.NoError(t, err)
+	instance, err := engine.CreateInstanceByKey(t.Context(), definition.Key, map[string]any{
+		"inputFoo": "input-value",
+	})
+	require.NoError(t, err)
+
+	correlationKey := "key"
+	require.NoError(t, engine.PublishMessageByName(t.Context(), "msg", &correlationKey, map[string]any{
+		"foo": "message-value",
+	}))
+
+	persistedInstance, err := store.FindProcessInstanceByKey(t.Context(), instance.ProcessInstance().Key)
+	require.NoError(t, err)
+	require.Equal(t, "input-value", persistedInstance.ProcessInstance().GetVariable("mappedFoo"))
+
+	flowElements, err := store.GetFlowElementInstancesByProcessInstanceKey(t.Context(), instance.ProcessInstance().Key, false)
+	require.NoError(t, err)
+	for _, flowElement := range flowElements {
+		if flowElement.ElementId != "msg" {
+			continue
+		}
+		require.Equal(t, string(bpmn20.ElementTypeIntermediateCatchEvent), flowElement.ElementType)
+		require.Equal(t, map[string]any{
+			"inputFoo":       "input-value",
+			"mappedInputFoo": "input-value",
+		}, flowElement.InputVariables)
+		require.Equal(t, map[string]any{"mappedFoo": "input-value"}, flowElement.OutputVariables)
+		return
+	}
+	t.Fatal("intermediate message catch event history was not found")
+}

--- a/pkg/bpmn/model/bpmn20/events.go
+++ b/pkg/bpmn/model/bpmn20/events.go
@@ -198,6 +198,7 @@ func (definitions *TIntermediateCatchEvent) UnmarshalXML(d *xml.Decoder, start x
 		}
 	}
 	definitions.ParallelMultiple = tempStruct.ParallelMultiple
+	definitions.Input = tempStruct.Input
 	definitions.Output = tempStruct.Output
 	return nil
 }
@@ -253,6 +254,7 @@ func (definitions *TIntermediateThrowEvent) UnmarshalXML(d *xml.Decoder, start x
 			}
 		}
 	}
+	definitions.Input = tempStruct.Input
 	definitions.Output = tempStruct.Output
 	definitions.TaskDefinition = tempStruct.TaskDefinition
 	return nil

--- a/pkg/bpmn/model/bpmn20/events.go
+++ b/pkg/bpmn/model/bpmn20/events.go
@@ -164,7 +164,8 @@ type TIntermediateCatchEvent struct {
 	Output []extensions.TIoMapping `xml:"extensionElements>ioMapping>output"`
 }
 
-func (definitions *TIntermediateCatchEvent) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+// UnmarshalXML decodes an intermediate catch event from its BPMN XML representation.
+func (intermediateCatchEvent *TIntermediateCatchEvent) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	tempStruct := struct {
 		TEvent
 		MessageEventDefinition  *TMessageEventDefinition  `xml:"messageEventDefinition"`
@@ -179,32 +180,43 @@ func (definitions *TIntermediateCatchEvent) UnmarshalXML(d *xml.Decoder, start x
 	if err != nil {
 		return err
 	}
-	definitions.TEvent = tempStruct.TEvent
+	intermediateCatchEvent.TEvent = tempStruct.TEvent
 	switch {
 	case tempStruct.MessageEventDefinition != nil:
 		tempStruct.MessageEventDefinition.input = tempStruct.Input
 		tempStruct.MessageEventDefinition.output = tempStruct.Output
-		definitions.EventDefinition = *tempStruct.MessageEventDefinition
+		intermediateCatchEvent.EventDefinition = *tempStruct.MessageEventDefinition
 	case tempStruct.TimerEventDefinition != nil:
-		definitions.EventDefinition = *tempStruct.TimerEventDefinition
+		intermediateCatchEvent.EventDefinition = *tempStruct.TimerEventDefinition
 	case tempStruct.LinkEventDefinition != nil:
-		definitions.EventDefinition = *tempStruct.LinkEventDefinition
+		intermediateCatchEvent.EventDefinition = *tempStruct.LinkEventDefinition
 	default:
 		for _, u := range tempStruct.UnknownEventDefinitions {
 			if isEventDefinitionElement(u.XMLName.Local) {
-				definitions.EventDefinition = TUnsupportedEventDefinition{Name: u.XMLName.Local, Id: u.Id}
+				intermediateCatchEvent.EventDefinition = TUnsupportedEventDefinition{Name: u.XMLName.Local, Id: u.Id}
 				break
 			}
 		}
 	}
-	definitions.ParallelMultiple = tempStruct.ParallelMultiple
-	definitions.Input = tempStruct.Input
-	definitions.Output = tempStruct.Output
+	intermediateCatchEvent.ParallelMultiple = tempStruct.ParallelMultiple
+	intermediateCatchEvent.Input = tempStruct.Input
+	intermediateCatchEvent.Output = tempStruct.Output
 	return nil
 }
 
+// GetType returns the element type for an intermediate catch event.
 func (intermediateCatchEvent TIntermediateCatchEvent) GetType() ElementType {
 	return ElementTypeIntermediateCatchEvent
+}
+
+// GetInputMapping returns the input mappings configured for the intermediate catch event.
+func (intermediateCatchEvent TIntermediateCatchEvent) GetInputMapping() []extensions.TIoMapping {
+	return intermediateCatchEvent.Input
+}
+
+// GetOutputMapping returns the output mappings configured for the intermediate catch event.
+func (intermediateCatchEvent TIntermediateCatchEvent) GetOutputMapping() []extensions.TIoMapping {
+	return intermediateCatchEvent.Output
 }
 
 type TIntermediateThrowEvent struct {
@@ -216,12 +228,23 @@ type TIntermediateThrowEvent struct {
 	Output         []extensions.TIoMapping    `xml:"extensionElements>ioMapping>output"`
 }
 
-func (d TIntermediateThrowEvent) GetInputMapping() []extensions.TIoMapping  { return d.Input }
-func (d TIntermediateThrowEvent) GetOutputMapping() []extensions.TIoMapping { return d.Output }
+// GetInputMapping returns the input mappings configured for the intermediate throw event.
+func (intermediateThrowEvent TIntermediateThrowEvent) GetInputMapping() []extensions.TIoMapping {
+	return intermediateThrowEvent.Input
+}
 
-func (d TIntermediateThrowEvent) GetTaskType() string { return d.TaskDefinition.TypeName }
+// GetOutputMapping returns the output mappings configured for the intermediate throw event.
+func (intermediateThrowEvent TIntermediateThrowEvent) GetOutputMapping() []extensions.TIoMapping {
+	return intermediateThrowEvent.Output
+}
 
-func (definitions *TIntermediateThrowEvent) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+// GetTaskType returns the task type configured for the intermediate throw event.
+func (intermediateThrowEvent TIntermediateThrowEvent) GetTaskType() string {
+	return intermediateThrowEvent.TaskDefinition.TypeName
+}
+
+// UnmarshalXML decodes an intermediate throw event from its BPMN XML representation.
+func (intermediateThrowEvent *TIntermediateThrowEvent) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	tempStruct := struct {
 		TEvent
 		MessageEventDefinition  *TMessageEventDefinition   `xml:"messageEventDefinition"`
@@ -236,31 +259,32 @@ func (definitions *TIntermediateThrowEvent) UnmarshalXML(d *xml.Decoder, start x
 	if err != nil {
 		return err
 	}
-	definitions.TEvent = tempStruct.TEvent
+	intermediateThrowEvent.TEvent = tempStruct.TEvent
 	switch {
 	case tempStruct.MessageEventDefinition != nil:
 		tempStruct.MessageEventDefinition.input = tempStruct.Input
 		tempStruct.MessageEventDefinition.output = tempStruct.Output
-		definitions.EventDefinition = *tempStruct.MessageEventDefinition
+		intermediateThrowEvent.EventDefinition = *tempStruct.MessageEventDefinition
 	case tempStruct.TimerEventDefinition != nil:
-		definitions.EventDefinition = *tempStruct.TimerEventDefinition
+		intermediateThrowEvent.EventDefinition = *tempStruct.TimerEventDefinition
 	case tempStruct.LinkEventDefinition != nil:
-		definitions.EventDefinition = *tempStruct.LinkEventDefinition
+		intermediateThrowEvent.EventDefinition = *tempStruct.LinkEventDefinition
 	default:
 		for _, u := range tempStruct.UnknownEventDefinitions {
 			if isEventDefinitionElement(u.XMLName.Local) {
-				definitions.EventDefinition = TUnsupportedEventDefinition{Name: u.XMLName.Local, Id: u.Id}
+				intermediateThrowEvent.EventDefinition = TUnsupportedEventDefinition{Name: u.XMLName.Local, Id: u.Id}
 				break
 			}
 		}
 	}
-	definitions.Input = tempStruct.Input
-	definitions.Output = tempStruct.Output
-	definitions.TaskDefinition = tempStruct.TaskDefinition
+	intermediateThrowEvent.Input = tempStruct.Input
+	intermediateThrowEvent.Output = tempStruct.Output
+	intermediateThrowEvent.TaskDefinition = tempStruct.TaskDefinition
 	return nil
 }
 
-func (intermediateCatchEvent TIntermediateThrowEvent) GetType() ElementType {
+// GetType returns the element type for an intermediate throw event.
+func (intermediateThrowEvent TIntermediateThrowEvent) GetType() ElementType {
 	return ElementTypeIntermediateThrowEvent
 }
 

--- a/pkg/bpmn/model/bpmn20/events_test.go
+++ b/pkg/bpmn/model/bpmn20/events_test.go
@@ -37,6 +37,42 @@ func TestBoundaryEventParses(t *testing.T) {
 	assert.Equal(t, "simple-boundary-id", m.MessageRef)
 }
 
+func TestIntermediateMessageThrowEventParsesMappings(t *testing.T) {
+	const processXML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0">
+  <bpmn:process id="message-throw" isExecutable="true">
+    <bpmn:intermediateThrowEvent id="message_throw_event">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="message-publication" />
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=payload" target="messagePayload" />
+          <zenbpm:output source="=deliveryId" target="publicationResult" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:messageEventDefinition id="message_definition" />
+    </bpmn:intermediateThrowEvent>
+  </bpmn:process>
+</bpmn:definitions>`
+
+	var definitions TDefinitions
+	err := xml.Unmarshal([]byte(processXML), &definitions)
+	assert.NoError(t, err)
+	if assert.Len(t, definitions.Process.IntermediateThrowEvent, 1) {
+		event := definitions.Process.IntermediateThrowEvent[0]
+		assert.Equal(t, "message-publication", event.GetTaskType())
+		if assert.Len(t, event.GetInputMapping(), 1) {
+			assert.Equal(t, "=payload", event.GetInputMapping()[0].Source)
+			assert.Equal(t, "messagePayload", event.GetInputMapping()[0].Target)
+		}
+		if assert.Len(t, event.GetOutputMapping(), 1) {
+			assert.Equal(t, "=deliveryId", event.GetOutputMapping()[0].Source)
+			assert.Equal(t, "publicationResult", event.GetOutputMapping()[0].Target)
+		}
+		_, ok := event.EventDefinition.(TMessageEventDefinition)
+		assert.True(t, ok)
+	}
+}
+
 func readBpnmFile(t testing.TB, filename string) (result TDefinitions, err error) {
 	t.Helper()
 

--- a/pkg/bpmn/start_event_instance_creation_handler.go
+++ b/pkg/bpmn/start_event_instance_creation_handler.go
@@ -22,8 +22,9 @@ type startEventInstanceCreationTrigger struct {
 	processDefinitionKey int64
 	// elementId is the BPMN id of the start event that owns the trigger.
 	elementId string
-	// inputVariables are the variables passed to the newly created process instance
-	// (e.g. message payload). For timers this is empty.
+	// inputVariables are the trigger variables (e.g. a message payload). Message
+	// start-event output mappings are applied before these variables are passed to
+	// the new instance. For timers this is empty.
 	inputVariables map[string]any
 	// refresh re-reads the trigger state under the trigger lock and reports whether activation
 	// should be skipped (because a concurrent publisher/timer-fire has already consumed it).
@@ -96,11 +97,43 @@ func (engine *Engine) handleStartEventInstanceCreation(ctx context.Context, t st
 		return fmt.Errorf("failed to find start event %q on process definition %d", t.elementId, t.processDefinitionKey)
 	}
 
-	if _, err := engine.CreateInstanceWithStartingElements(ctx, t.processDefinitionKey, []string{t.elementId}, t.inputVariables, nil); err != nil {
+	instanceVariables := t.inputVariables
+	if isMessageStartEvent(startEvent) {
+		instanceVariables, err = engine.mapStartEventTriggerVariables(*startEvent, t.inputVariables)
+		if err != nil {
+			return fmt.Errorf("failed to apply output mappings for start event %s of definition %d: %w", t.elementId, t.processDefinitionKey, err)
+		}
+	}
+
+	if _, err := engine.CreateInstanceWithStartingElements(ctx, t.processDefinitionKey, []string{t.elementId}, instanceVariables, nil); err != nil {
 		return fmt.Errorf("failed to create process instance for start event %s of definition %d: %w", t.elementId, t.processDefinitionKey, err)
 	}
 
 	return nil
+}
+
+func (engine *Engine) mapStartEventTriggerVariables(startEvent bpmn20.TStartEvent, inputVariables map[string]any) (map[string]any, error) {
+	instanceVariableHolder := runtime.NewVariableHolder(nil, map[string]any{})
+	triggerVariableHolder := runtime.NewVariableHolder(&instanceVariableHolder, inputVariables)
+
+	instanceVariables, err := triggerVariableHolder.PropagateMappedOutputsOrAll(
+		startEvent.GetOutputMapping(),
+		inputVariables,
+		engine.evaluateExpression,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return instanceVariables, nil
+}
+
+func isMessageStartEvent(startEvent *bpmn20.TStartEvent) bool {
+	for _, eventDefinition := range startEvent.EventDefinitions {
+		if _, ok := eventDefinition.(bpmn20.TMessageEventDefinition); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // renewStartEventTrigger re-creates the trigger on the given start event so that subsequent firings

--- a/pkg/bpmn/start_event_instance_creation_handler.go
+++ b/pkg/bpmn/start_event_instance_creation_handler.go
@@ -43,10 +43,11 @@ type startEventInstanceCreationTrigger struct {
 // process-definition-level start event (message or timer). It:
 //  1. serializes concurrent fires of the same trigger,
 //  2. re-validates the trigger via t.refresh (silently no-ops if already consumed),
-//  3. marks the original trigger as consumed in a batch,
-//  4. re-creates a fresh subscription/timer (Active/Created state) for the same start event so that the next event can fire another process instance,
-//  5. flushes the batch (so that even if instance creation later fails the trigger is not re-fired and the renewal is persisted), and
-//  6. creates the new process instance.
+//  3. resolves the start event and evaluates its output mapping, leaving the trigger intact if the mapping fails,
+//  4. marks the original trigger as consumed in a batch,
+//  5. re-creates a fresh subscription/timer (Active/Created state) for the same start event so that the next event can fire another process instance,
+//  6. flushes the batch (so that even if instance creation later fails the trigger is not re-fired and the renewal is persisted), and
+//  7. creates the new process instance.
 func (engine *Engine) handleStartEventInstanceCreation(ctx context.Context, t startEventInstanceCreationTrigger) error {
 	engine.runningInstances.lockInstance(t.triggerKey)
 	defer engine.runningInstances.unlockInstance(t.triggerKey)
@@ -59,6 +60,27 @@ func (engine *Engine) handleStartEventInstanceCreation(ctx context.Context, t st
 		return nil
 	}
 
+	// Look up the process definition + start event so we can evaluate the output mapping and renew the
+	// trigger. A failed lookup does NOT abort here: the consumption below must still be flushed so that a
+	// trigger pointing at a missing definition/element does not get re-fired forever.
+	processDefinition, pdErr := engine.persistence.FindProcessDefinitionByKey(ctx, t.processDefinitionKey)
+	var startEvent *bpmn20.TStartEvent
+	if pdErr == nil {
+		startEvent = findStartEventById(&processDefinition.Definitions.Process, t.elementId)
+	}
+
+	// The output mapping is evaluated BEFORE the trigger is consumed. Evaluation is pure (it writes
+	// nothing to the batch), so a deterministic definition-level error — e.g. a mapping source the payload
+	// does not satisfy — fails without consuming the subscription. The message payload therefore stays
+	// replayable instead of being dropped with neither a process instance nor an incident to show for it.
+	instanceVariables := t.inputVariables
+	if startEvent != nil && isMessageStartEvent(startEvent) {
+		instanceVariables, err = engine.mapStartEventTriggerVariables(*startEvent, t.inputVariables)
+		if err != nil {
+			return fmt.Errorf("failed to apply output mappings for start event %s of definition %d: %w", t.elementId, t.processDefinitionKey, err)
+		}
+	}
+
 	batch := engine.persistence.NewBatch()
 
 	// Mark the original trigger as consumed BEFORE attempting to create the process instance.
@@ -68,16 +90,9 @@ func (engine *Engine) handleStartEventInstanceCreation(ctx context.Context, t st
 		return err
 	}
 
-	// Look up the process definition + start event so we can renew the trigger. If either lookup fails we still
-	// flush the consumption above so that the original trigger does not get re-fired forever.
-	processDefinition, pdErr := engine.persistence.FindProcessDefinitionByKey(ctx, t.processDefinitionKey)
-	var startEvent *bpmn20.TStartEvent
-	if pdErr == nil {
-		startEvent = findStartEventById(&processDefinition.Definitions.Process, t.elementId)
-		if startEvent != nil {
-			if renewErr := engine.renewStartEventTrigger(ctx, batch, processDefinition, *startEvent, t.inFlightTriggeredTimerKey); renewErr != nil {
-				return renewErr
-			}
+	if startEvent != nil {
+		if renewErr := engine.renewStartEventTrigger(ctx, batch, processDefinition, *startEvent, t.inFlightTriggeredTimerKey); renewErr != nil {
+			return renewErr
 		}
 	}
 
@@ -95,14 +110,6 @@ func (engine *Engine) handleStartEventInstanceCreation(ctx context.Context, t st
 	}
 	if startEvent == nil {
 		return fmt.Errorf("failed to find start event %q on process definition %d", t.elementId, t.processDefinitionKey)
-	}
-
-	instanceVariables := t.inputVariables
-	if isMessageStartEvent(startEvent) {
-		instanceVariables, err = engine.mapStartEventTriggerVariables(*startEvent, t.inputVariables)
-		if err != nil {
-			return fmt.Errorf("failed to apply output mappings for start event %s of definition %d: %w", t.elementId, t.processDefinitionKey, err)
-		}
 	}
 
 	if _, err := engine.CreateInstanceWithStartingElements(ctx, t.processDefinitionKey, []string{t.elementId}, instanceVariables, nil); err != nil {

--- a/pkg/bpmn/start_event_instance_creation_handler_test.go
+++ b/pkg/bpmn/start_event_instance_creation_handler_test.go
@@ -140,13 +140,69 @@ func TestProcessTimerTriggerOnInstanceCreation_DoesNotRenewTimer(t *testing.T) {
 		"the original timer (looked up by key) must be Triggered")
 }
 
+// TestPublishMessageOnInstanceCreation_FailedOutputMappingKeepsSubscriptionActive verifies that a
+// message start event whose output mapping cannot be evaluated does NOT consume the subscription.
+// The mapping is a deterministic, definition-level error: consuming the trigger would drop the
+// message payload while creating neither a process instance nor an incident, leaving nothing for an
+// operator to replay. Leaving the subscription Active keeps the message publishable after a fix.
+func TestPublishMessageOnInstanceCreation_FailedOutputMappingKeepsSubscriptionActive(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+	err := engine.Start(t.Context())
+	require.NoError(t, err)
+	defer engine.Stop()
+
+	h := engine.NewTaskHandler().
+		Type("input-task-for-message-start-event-test").
+		Handler(func(_ ActivatedJob) {})
+	defer engine.RemoveHandler(h)
+
+	bpmnData, err := os.ReadFile("./test-cases/process_definition_start_event/message-start-event-process.bpmn")
+	require.NoError(t, err)
+	// Attach an unparseable output mapping to the message start event. An undefined variable would not
+	// do: the FEEL runtime resolves those to nil rather than failing.
+	const startEventExtensionElements = `<bpmn:extensionElements />`
+	require.Contains(t, string(bpmnData), startEventExtensionElements)
+	xmlData := []byte(strings.Replace(string(bpmnData), startEventExtensionElements, `<bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=iban: &#34;DE456&#34;	" target="mapped" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>`, 1))
+
+	def, err := engine.LoadFromBytes(t.Context(), xmlData, engine.generateKey())
+	require.NoError(t, err)
+	require.NoError(t, engine.RegisterProcessDefinitionSubscriptions(t.Context(), def.Key))
+
+	subsBefore := definitionMessageSubscriptionsForDefinition(store, def.Key)
+	require.Len(t, subsBefore, 1)
+	originalKey := subsBefore[0].MessageSubscription().Key
+
+	err = engine.PublishMessageByName(t.Context(), "messageStartEventProcessRef", nil, map[string]any{"payload": "kept"})
+	require.Error(t, err, "an unevaluatable start-event output mapping must surface to the publisher")
+	assert.ErrorContains(t, err, "failed to apply output mappings")
+
+	subsAfter := definitionMessageSubscriptionsForDefinition(store, def.Key)
+	require.Len(t, subsAfter, 1, "a failed mapping must neither consume nor renew the subscription")
+	assert.Equal(t, originalKey, subsAfter[0].MessageSubscription().Key)
+	assert.Equal(t, runtime.ActivityStateActive, subsAfter[0].MessageSubscription().State,
+		"the subscription must stay Active so the message can be republished once the mapping is fixed")
+
+	for _, pi := range store.ProcessInstances {
+		piData := pi.ProcessInstance()
+		if piData.Definition != nil && piData.Definition.Key == def.Key {
+			t.Fatalf("no process instance must be created when the start event output mapping fails")
+		}
+	}
+}
+
 // TestHandleStartEventInstanceCreation_SkipRefreshSkipsRenewal verifies that when the refresh
 // callback reports the trigger should be skipped (e.g. the subscription has already been
 // consumed by a concurrent publisher), neither markConsumed nor the renewal run.
 func TestHandleStartEventInstanceCreation_SkipRefreshSkipsRenewal(t *testing.T) {
 	store := inmemory.NewStorage()
 	engine := NewEngine(EngineWithStorage(store))
-	engine.Start(t.Context())
+	err := engine.Start(t.Context())
+	require.NoError(t, err)
 	defer engine.Stop()
 
 	def, err := engine.LoadFromFile(t.Context(), "./test-cases/process_definition_start_event/message-start-event-process.bpmn")

--- a/pkg/bpmn/test-cases/simple-intermediate-message-catch-event.bpmn
+++ b/pkg/bpmn/test-cases/simple-intermediate-message-catch-event.bpmn
@@ -8,6 +8,7 @@
     <bpmn:intermediateCatchEvent id="msg" name="msg">
       <bpmn:extensionElements>
         <zenbpm:ioMapping>
+          <zenbpm:input source="= inputFoo" target="mappedInputFoo" />
           <zenbpm:output source="= foo" target="mappedFoo" />
         </zenbpm:ioMapping>
       </bpmn:extensionElements>

--- a/pkg/storage/inmemory/in_memory_repository.go
+++ b/pkg/storage/inmemory/in_memory_repository.go
@@ -1060,6 +1060,11 @@ var _ storage.FlowElementInstanceWriter = &Storage{}
 func (mem *Storage) SaveFlowElementInstance(ctx context.Context, flowElementInstance bpmnruntime.FlowElementInstance) error {
 	mem.mu.Lock()
 	defer mem.mu.Unlock()
+	if existing, exists := mem.FlowElementInstance[flowElementInstance.Key]; exists {
+		// Mirror SQL: INSERT ... ON CONFLICT DO UPDATE SET input_variables.
+		existing.InputVariables = flowElementInstance.InputVariables
+		flowElementInstance = existing
+	}
 	mem.FlowElementInstance[flowElementInstance.Key] = flowElementInstance
 	return nil
 }

--- a/pkg/storage/storagetest/storage.go
+++ b/pkg/storage/storagetest/storage.go
@@ -15,6 +15,7 @@ import (
 	dmnruntime "github.com/pbinitiative/zenbpm/pkg/dmn/runtime"
 	"github.com/pbinitiative/zenbpm/pkg/storage"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type StorageTestFunc func(s storage.Storage, t *testing.T) func(t *testing.T)
@@ -49,6 +50,7 @@ func (st *StorageTester) GetTests() map[string]StorageTestFunc {
 		st.TestDecisionStorageReaderGetSingle,
 		st.TestDecisionStorageReaderGetMultiple,
 		st.TestSaveFlowElementInstanceWriter,
+		st.TestFlowElementInstanceSaveUpdatesOnlyInputVariables,
 		st.TestFlowElementInstanceReaderNotFound,
 		st.TestFlowElementInstanceCompletedAt,
 		st.TestFlowElementInstanceSaveWithCompletedAt,
@@ -750,6 +752,46 @@ func (st *StorageTester) TestFlowElementInstanceReaderNotFound(s storage.Storage
 	return func(t *testing.T) {
 		_, err := s.GetFlowElementInstanceByKey(t.Context(), s.GenerateId())
 		assert.ErrorIs(t, err, storage.ErrNotFound)
+	}
+}
+
+// TestFlowElementInstanceSaveUpdatesOnlyInputVariables verifies that saving an
+// existing flow element instance preserves every field except input variables.
+func (st *StorageTester) TestFlowElementInstanceSaveUpdatesOnlyInputVariables(s storage.Storage, _ *testing.T) func(t *testing.T) {
+	return func(t *testing.T) {
+		key := s.GenerateId()
+		createdAt := time.Now().Truncate(time.Millisecond)
+		completedAt := createdAt.Add(time.Second)
+		saved := bpmnruntime.FlowElementInstance{
+			Key:                key,
+			ProcessInstanceKey: st.processInstance.ProcessInstance().Key,
+			ElementId:          "test-elem-input-update",
+			ElementType:        "INTERMEDIATE_CATCH_EVENT",
+			CreatedAt:          createdAt,
+			ExecutionTokenKey:  s.GenerateId(),
+			InputVariables:     map[string]any{"input": "before"},
+			OutputVariables:    map[string]any{"output": "preserved"},
+			CompletedAt:        &completedAt,
+		}
+		require.NoError(t, s.SaveFlowElementInstance(t.Context(), saved))
+
+		require.NoError(t, s.SaveFlowElementInstance(t.Context(), bpmnruntime.FlowElementInstance{
+			Key:            key,
+			InputVariables: map[string]any{"input": "after"},
+		}))
+
+		updated, err := s.GetFlowElementInstanceByKey(t.Context(), key)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"input": "after"}, updated.InputVariables)
+		assert.Equal(t, saved.ProcessInstanceKey, updated.ProcessInstanceKey)
+		assert.Equal(t, saved.ElementId, updated.ElementId)
+		assert.Equal(t, saved.ElementType, updated.ElementType)
+		assert.Equal(t, saved.CreatedAt, updated.CreatedAt)
+		assert.Equal(t, saved.ExecutionTokenKey, updated.ExecutionTokenKey)
+		assert.Equal(t, saved.OutputVariables, updated.OutputVariables)
+		if assert.NotNil(t, updated.CompletedAt) {
+			assert.Equal(t, *saved.CompletedAt, *updated.CompletedAt)
+		}
 	}
 }
 

--- a/test/e2e/business_rule_message_boundary_flow_test.go
+++ b/test/e2e/business_rule_message_boundary_flow_test.go
@@ -1,0 +1,103 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBusinessRuleMessageBoundaryFlow(t *testing.T) {
+	t.Run("Interrupting boundary message cancels the business rule task and completes the boundary path", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployInterruptingMessageBoundaryDefinition(
+			t,
+			"testdata/business_rule/business_rule_task_external_with_message_boundary_event_without_output_mapping.bpmn",
+			"business-rule-message-boundary-event-without-output-mapping",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "business_rule")
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "business_rule", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "business_rule", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_business_rule",
+			"business_rule",
+		})
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForProcessInstanceJobByElementId(t, instance.Key, "business_rule", public.JobStateTerminated)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_boundary")
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_main", 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "business_rule", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "business_rule", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_business_rule",
+			"business_rule",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+		})
+	})
+
+	t.Run("Non-interrupting boundary message keeps the business rule task active and completes both paths", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/business_rule/business_rule_task_external_with_message_boundary_event_without_output_mapping.bpmn",
+			"business-rule-message-boundary-event-without-output-mapping",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "business_rule")
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "business_rule", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "business_rule", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_business_rule",
+			"business_rule",
+		})
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "business_rule")
+		assertProcessInstanceTokenState(t, instance.Key, "business_rule", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "business_rule", zenclient.EventSubscriptionStateCompleted, 1)
+		assertMessageSubscriptionStateCount(t, instance.Key, "business_rule", zenclient.EventSubscriptionStateActive, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_business_rule",
+			"business_rule",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+		})
+
+		completeJobForElementId(t, instance.Key, "business_rule", nil)
+
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_main", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "business_rule", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "business_rule", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_business_rule",
+			"business_rule",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+			"flow_to_main_end",
+			"end_event_main",
+		})
+	})
+}

--- a/test/e2e/business_rule_message_boundary_variables_test.go
+++ b/test/e2e/business_rule_message_boundary_variables_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBusinessRuleMessageBoundaryVariables(t *testing.T) {
+	t.Run("Message boundary without output mapping propagates all message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/business_rule/business_rule_task_external_with_message_boundary_event_without_output_mapping.bpmn",
+			"business-rule-message-boundary-event-without-output-mapping",
+		)
+		processVariables := map[string]any{
+			"existing":    "process-value",
+			"overwritten": "initial-value",
+		}
+		instance := createMessageBoundaryVariablesInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "business_rule")
+		assertMessageSubscriptionState(t, instance.Key, "business_rule", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"overwritten": "message-value",
+			"unmapped":    "unmapped-value",
+			"numeric":     float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", messageVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(processVariables, messageVariables))
+
+		completeJobForElementId(t, instance.Key, "business_rule", nil)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+	})
+
+	t.Run("Message boundary with output mapping propagates only mapped message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/business_rule/business_rule_task_external_with_message_boundary_event_with_output_mapping.bpmn",
+			"business-rule-message-boundary-event-with-output-mapping",
+		)
+		processVariables := map[string]any{"existing": "process-value"}
+		instance := createMessageBoundaryVariablesInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "business_rule")
+		assertMessageSubscriptionState(t, instance.Key, "business_rule", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"payload":  "mapped-value",
+			"unmapped": "ignored-value",
+			"numeric":  float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		expectedMappedVariables := map[string]any{"payload": "mapped-value"}
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", expectedMappedVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(processVariables, expectedMappedVariables))
+
+		completeJobForElementId(t, instance.Key, "business_rule", nil)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+	})
+}

--- a/test/e2e/call_activity_message_boundary_flow_test.go
+++ b/test/e2e/call_activity_message_boundary_flow_test.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	callActivityMessageBoundaryParentHistoryBeforeMessage = []string{
+		"start_event",
+		"flow_to_call_activity",
+		"call_activity",
+	}
+	callActivityMessageBoundaryParentHistoryAfterMessage = []string{
+		"start_event",
+		"flow_to_call_activity",
+		"call_activity",
+		"boundary_message_event",
+		"flow_to_boundary_end",
+		"end_event_boundary",
+	}
+	callActivityMessageBoundaryChildHistoryBeforeCompletion = []string{
+		"StartEvent_1",
+		"Flow_0xt1d7q",
+		"id",
+	}
+)
+
+func TestCallActivityMessageBoundaryFlow(t *testing.T) {
+	t.Run("Interrupting boundary message terminates the child and completes the boundary path", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployInterruptingCallActivityMessageBoundaryDefinitions(
+			t,
+			"testdata/call_activity/call_activity_with_message_boundary_event_without_output_mapping.bpmn",
+			"call-activity-message-boundary-event-without-output-mapping",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+		childInstance := waitForChildProcessInstance(t, instance.Key, 0)
+
+		waitForProcessInstanceActiveJobByElementId(t, childInstance.Key, "id")
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateActive, childInstance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "call_activity", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "call_activity", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, callActivityMessageBoundaryParentHistoryBeforeMessage)
+		assertExactProcessInstanceHistory(t, childInstance.Key, callActivityMessageBoundaryChildHistoryBeforeCompletion)
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateCompleted, childInstance.Key, zenclient.ProcessInstanceStateTerminated)
+		waitForProcessInstanceJobByElementId(t, childInstance.Key, "id", public.JobStateTerminated)
+		assertProcessInstanceTokenState(t, childInstance.Key, "id", runtime.TokenStateCanceled)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_boundary")
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_main", 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "call_activity", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "call_activity", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, childInstance.Key, callActivityMessageBoundaryChildHistoryBeforeCompletion)
+		assertExactProcessInstanceHistory(t, instance.Key, callActivityMessageBoundaryParentHistoryAfterMessage)
+	})
+
+	t.Run("Non-interrupting boundary message keeps the child active and completes both paths", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployCallActivityMessageBoundaryDefinitions(
+			t,
+			"testdata/call_activity/call_activity_with_message_boundary_event_without_output_mapping.bpmn",
+			"call-activity-message-boundary-event-without-output-mapping",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+		childInstance := waitForChildProcessInstance(t, instance.Key, 0)
+
+		waitForProcessInstanceActiveJobByElementId(t, childInstance.Key, "id")
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateActive, childInstance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "call_activity", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "call_activity", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, callActivityMessageBoundaryParentHistoryBeforeMessage)
+		assertExactProcessInstanceHistory(t, childInstance.Key, callActivityMessageBoundaryChildHistoryBeforeCompletion)
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateActive, childInstance.Key, zenclient.ProcessInstanceStateActive)
+		waitForProcessInstanceActiveJobByElementId(t, childInstance.Key, "id")
+		assertProcessInstanceTokenState(t, instance.Key, "call_activity", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "call_activity", zenclient.EventSubscriptionStateCompleted, 1)
+		assertMessageSubscriptionStateCount(t, instance.Key, "call_activity", zenclient.EventSubscriptionStateActive, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, callActivityMessageBoundaryParentHistoryAfterMessage)
+
+		completeJobForElementId(t, childInstance.Key, "id", map[string]any{"variable_name": "child-value"})
+
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateCompleted, childInstance.Key, zenclient.ProcessInstanceStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_main", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "call_activity", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "call_activity", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, childInstance.Key, []string{
+			"StartEvent_1",
+			"Flow_0xt1d7q",
+			"id",
+			"Flow_1vz4oo2",
+			"End_Event",
+		})
+		assertExactProcessInstanceHistory(t, instance.Key, append(append([]string{}, callActivityMessageBoundaryParentHistoryAfterMessage...), "flow_to_main_end", "end_event_main"))
+	})
+}

--- a/test/e2e/call_activity_message_boundary_variables_test.go
+++ b/test/e2e/call_activity_message_boundary_variables_test.go
@@ -1,0 +1,116 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallActivityMessageBoundaryVariables(t *testing.T) {
+	t.Run("Message boundary without output mapping propagates all message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployCallActivityMessageBoundaryDefinitions(
+			t,
+			"testdata/call_activity/call_activity_with_message_boundary_event_without_output_mapping.bpmn",
+			"call-activity-message-boundary-event-without-output-mapping",
+		)
+		processVariables := map[string]any{
+			"existing":    "process-value",
+			"overwritten": "initial-value",
+		}
+		instance := createMessageBoundaryVariablesInstance(t, definitionKey, processVariables)
+		childInstance := waitForChildProcessInstance(t, instance.Key, 0)
+
+		waitForProcessInstanceActiveJobByElementId(t, childInstance.Key, "id")
+		assertMessageSubscriptionState(t, instance.Key, "call_activity", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"overwritten": "message-value",
+			"unmapped":    "unmapped-value",
+			"numeric":     float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", messageVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(processVariables, messageVariables))
+
+		completeJobForElementId(t, childInstance.Key, "id", map[string]any{"variable_name": "child-value"})
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateCompleted, childInstance.Key, zenclient.ProcessInstanceStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_main", runtime.TokenStateCompleted)
+	})
+
+	t.Run("Message boundary with output mapping propagates only mapped message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployCallActivityMessageBoundaryDefinitions(
+			t,
+			"testdata/call_activity/call_activity_with_message_boundary_event_with_output_mapping.bpmn",
+			"call-activity-message-boundary-event-with-output-mapping",
+		)
+		processVariables := map[string]any{"existing": "process-value"}
+		instance := createMessageBoundaryVariablesInstance(t, definitionKey, processVariables)
+		childInstance := waitForChildProcessInstance(t, instance.Key, 0)
+
+		waitForProcessInstanceActiveJobByElementId(t, childInstance.Key, "id")
+		assertMessageSubscriptionState(t, instance.Key, "call_activity", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"payload":  "mapped-value",
+			"unmapped": "ignored-value",
+			"numeric":  float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		expectedMappedVariables := map[string]any{"payload": "mapped-value"}
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", expectedMappedVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(processVariables, expectedMappedVariables))
+
+		completeJobForElementId(t, childInstance.Key, "id", map[string]any{"variable_name": "child-value"})
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateCompleted, childInstance.Key, zenclient.ProcessInstanceStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_main", runtime.TokenStateCompleted)
+	})
+}
+
+func deployCallActivityMessageBoundaryDefinitions(t testing.TB, parentFilename string, baseProcessID string) (int64, string, string) {
+	return deployCallActivityMessageBoundaryDefinitionsWithInterrupting(t, parentFilename, baseProcessID, false)
+}
+
+func deployInterruptingCallActivityMessageBoundaryDefinitions(t testing.TB, parentFilename string, baseProcessID string) (int64, string, string) {
+	return deployCallActivityMessageBoundaryDefinitionsWithInterrupting(t, parentFilename, baseProcessID, true)
+}
+
+func deployCallActivityMessageBoundaryDefinitionsWithInterrupting(t testing.TB, parentFilename string, baseProcessID string, interrupting bool) (int64, string, string) {
+	t.Helper()
+
+	suffix := messageEventTestSuffix()
+	childProcessID := fmt.Sprintf("%s-%d", callActivityErrorBoundaryChildProcessId, suffix)
+	childJobType := fmt.Sprintf("call-activity-message-boundary-child-%d", suffix)
+	_, err := deployTestDataDefinitionWithJobType(
+		t,
+		"testdata/call_activity/call_activity_with_error_boundary_event_child_process.bpmn",
+		childProcessID,
+		map[string]string{"TestType": childJobType},
+	)
+	require.NoError(t, err)
+
+	processID := fmt.Sprintf("%s-%d", baseProcessID, suffix)
+	messageName := fmt.Sprintf("%s-ref-%d", baseProcessID, suffix)
+	correlationKey := fmt.Sprintf("%s-key-%d", baseProcessID, suffix)
+	content := string(readBPMNTestCaseFile(t, parentFilename))
+	if interrupting {
+		content = strings.Replace(content, `cancelActivity="false"`, `cancelActivity="true"`, 1)
+	}
+	content = strings.NewReplacer(
+		fmt.Sprintf(`bpmn:process id="%s"`, baseProcessID), fmt.Sprintf(`bpmn:process id="%s"`, processID),
+		fmt.Sprintf(`calledElement processId="%s"`, callActivityErrorBoundaryChildProcessId), fmt.Sprintf(`calledElement processId="%s"`, childProcessID),
+		`name="message"`, fmt.Sprintf(`name="%s"`, messageName),
+		`correlationKey="=correlationKey"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKey),
+	).Replace(content)
+
+	return deployBPMNTestCaseContent(t, parentFilename, []byte(content)), messageName, correlationKey
+}

--- a/test/e2e/call_activity_message_boundary_variables_test.go
+++ b/test/e2e/call_activity_message_boundary_variables_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
@@ -103,14 +102,17 @@ func deployCallActivityMessageBoundaryDefinitionsWithInterrupting(t testing.TB, 
 	correlationKey := fmt.Sprintf("%s-key-%d", baseProcessID, suffix)
 	content := string(readBPMNTestCaseFile(t, parentFilename))
 	if interrupting {
-		content = strings.Replace(content, `cancelActivity="false"`, `cancelActivity="true"`, 1)
+		content = requireInterruptingBoundary(t, parentFilename, content)
 	}
-	content = strings.NewReplacer(
-		fmt.Sprintf(`bpmn:process id="%s"`, baseProcessID), fmt.Sprintf(`bpmn:process id="%s"`, processID),
-		fmt.Sprintf(`calledElement processId="%s"`, callActivityErrorBoundaryChildProcessId), fmt.Sprintf(`calledElement processId="%s"`, childProcessID),
-		`name="message"`, fmt.Sprintf(`name="%s"`, messageName),
-		`correlationKey="=correlationKey"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKey),
-	).Replace(content)
+	content = replaceInBPMNFixture(t, parentFilename, content,
+		fmt.Sprintf(`bpmn:process id="%s"`, baseProcessID), fmt.Sprintf(`bpmn:process id="%s"`, processID))
+	content = replaceInBPMNFixture(t, parentFilename, content,
+		fmt.Sprintf(`calledElement processId="%s"`, callActivityErrorBoundaryChildProcessId),
+		fmt.Sprintf(`calledElement processId="%s"`, childProcessID))
+	content = replaceInBPMNFixture(t, parentFilename, content,
+		`name="message"`, fmt.Sprintf(`name="%s"`, messageName))
+	content = replaceInBPMNFixture(t, parentFilename, content,
+		`correlationKey="=correlationKey"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKey))
 
 	return deployBPMNTestCaseContent(t, parentFilename, []byte(content)), messageName, correlationKey
 }

--- a/test/e2e/event_subscriptions_test.go
+++ b/test/e2e/event_subscriptions_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestGetProcessInstanceMessageSubscriptions(t *testing.T) {
-	//t.Parallel()
-
 	definition, err := deployGetDefinition(t, "simple-intermediate-message-catch-event.bpmn", "simple-intermediate-message-catch-event")
 	require.NoError(t, err)
 
@@ -38,8 +36,14 @@ func TestGetProcessInstanceMessageSubscriptions(t *testing.T) {
 	assert.Equal(t, 1, resp.JSON200.TotalCount)
 	require.Len(t, resp.JSON200.Items, 1)
 	item := resp.JSON200.Items[0]
+	assert.NotZero(t, item.Key)
+	assert.False(t, item.CreatedAt.IsZero())
+	assert.Equal(t, "msg", item.ElementId)
 	assert.Equal(t, "msg", item.MessageName)
+	require.NotNil(t, item.CorrelationKey)
+	assert.Equal(t, "key", *item.CorrelationKey)
 	assert.Equal(t, zenclient.EventSubscriptionStateActive, item.State)
+	assert.Equal(t, definition.Key, item.ProcessDefinitionKey)
 	assert.Equal(t, instance.Key, item.ProcessInstanceKey)
 	require.NotNil(t, item.ElementInstanceKey)
 

--- a/test/e2e/gateway_event_based_variables_test.go
+++ b/test/e2e/gateway_event_based_variables_test.go
@@ -62,6 +62,11 @@ func TestEventBasedGatewayVariables(t *testing.T) {
 			"mapped_process_seed":    "seed-value",
 			"mapped_static_message":  "static-message",
 		}
+		assertFlowElementInputVariables(t, processInstance.Key, eventBasedGatewayMessageElementId, map[string]any{
+			"correlationKey":    correlationKey,
+			"input_scoped_seed": "seed-value",
+			"process_seed":      "seed-value",
+		})
 		assertFlowElementInputVariables(t, processInstance.Key, eventBasedGatewayMessageTaskId, expectedVariables)
 		assertProcessInstanceVariables(t, processInstance.Key, expectedVariables)
 	})
@@ -102,8 +107,9 @@ func deployEventBasedGatewayMappingDefinition(t testing.TB) int64 {
 		`<bpmn:intermediateCatchEvent id="catch_message">
       <bpmn:extensionElements>
         <zenbpm:ioMapping>
+          <zenbpm:input source="=process_seed" target="input_scoped_seed" />
           <zenbpm:output source="=event_payload" target="mapped_message_payload" />
-          <zenbpm:output source="=process_seed" target="mapped_process_seed" />
+          <zenbpm:output source="=input_scoped_seed" target="mapped_process_seed" />
           <zenbpm:output source="=&#34;static-message&#34;" target="mapped_static_message" />
         </zenbpm:ioMapping>
       </bpmn:extensionElements>`,

--- a/test/e2e/message_catch_event_correlation_test.go
+++ b/test/e2e/message_catch_event_correlation_test.go
@@ -1,0 +1,137 @@
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageCatchEventCorrelation(t *testing.T) {
+	definitionKey, messageName := deployMessageCatchCorrelationDefinition(t)
+	firstCorrelationKey := fmt.Sprintf("%s-first", messageName)
+	secondCorrelationKey := fmt.Sprintf("%s-second", messageName)
+
+	firstInstance := createMessageCatchCorrelationInstance(t, definitionKey, firstCorrelationKey)
+	secondInstance := createMessageCatchCorrelationInstance(t, definitionKey, secondCorrelationKey)
+
+	assertMessageCatchStillWaiting(t, firstInstance.Key)
+	assertMessageCatchStillWaiting(t, secondInstance.Key)
+
+	t.Run("wrong message name does not consume a matching correlation key", func(t *testing.T) {
+		response, err := publishMessageWithResponse(t, messageName+"-wrong", firstCorrelationKey, &map[string]any{
+			"winner": "wrong-name",
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, response.StatusCode())
+
+		assertMessageCatchStillWaiting(t, firstInstance.Key)
+		assertMessageCatchStillWaiting(t, secondInstance.Key)
+	})
+
+	t.Run("wrong correlation key does not consume a matching message name", func(t *testing.T) {
+		response, err := publishMessageWithResponse(t, messageName, secondCorrelationKey+"-wrong", &map[string]any{
+			"winner": "wrong-key",
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, response.StatusCode())
+
+		assertMessageCatchStillWaiting(t, firstInstance.Key)
+		assertMessageCatchStillWaiting(t, secondInstance.Key)
+	})
+
+	t.Run("message is delivered only to the instance with the matching key", func(t *testing.T) {
+		err := publishMessage(t, messageName, secondCorrelationKey, &map[string]any{
+			"winner": "second",
+		})
+		require.NoError(t, err)
+
+		assertProcessInstanceIsCompleted(t, secondInstance.Key, "Event_1jn3jqk")
+		assertMessageSubscriptionStateCount(t, secondInstance.Key, "id-1", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, secondInstance.Key, "id-1", zenclient.EventSubscriptionStateCompleted, 1)
+		assertProcessInstanceVariables(t, secondInstance.Key, map[string]any{
+			"correlationKey": secondCorrelationKey,
+			"winner":         "second",
+		})
+
+		assertMessageCatchStillWaiting(t, firstInstance.Key)
+		assertProcessInstanceVariables(t, firstInstance.Key, map[string]any{
+			"correlationKey": firstCorrelationKey,
+		})
+	})
+
+	t.Run("duplicate message after subscription cleanup is rejected", func(t *testing.T) {
+		response, err := publishMessageWithResponse(t, messageName, secondCorrelationKey, &map[string]any{
+			"winner": "duplicate",
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, response.StatusCode())
+
+		assertProcessInstanceIsCompleted(t, secondInstance.Key, "Event_1jn3jqk")
+		assertMessageSubscriptionStateCount(t, secondInstance.Key, "id-1", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, secondInstance.Key, "id-1", zenclient.EventSubscriptionStateCompleted, 1)
+		assertProcessInstanceVariables(t, secondInstance.Key, map[string]any{
+			"correlationKey": secondCorrelationKey,
+			"winner":         "second",
+		})
+	})
+
+	t.Run("remaining instance can still be correlated afterwards", func(t *testing.T) {
+		err := publishMessage(t, messageName, firstCorrelationKey, &map[string]any{
+			"winner": "first",
+		})
+		require.NoError(t, err)
+
+		assertProcessInstanceIsCompleted(t, firstInstance.Key, "Event_1jn3jqk")
+		assertProcessInstanceVariables(t, firstInstance.Key, map[string]any{
+			"correlationKey": firstCorrelationKey,
+			"winner":         "first",
+		})
+	})
+}
+
+func deployMessageCatchCorrelationDefinition(t testing.TB) (int64, string) {
+	t.Helper()
+
+	suffix := messageEventTestSuffix()
+	processID := fmt.Sprintf("message-intermediate-catch-correlation-%d", suffix)
+	messageName := fmt.Sprintf("message-intermediate-catch-correlation-ref-%d", suffix)
+	bpmnData, err := readE2ETestDataBPMN("message_event/message-intermediate-catch-event.bpmn")
+	require.NoError(t, err)
+	content := strings.NewReplacer(
+		`bpmn:process id="message-intermediate-catch-event"`,
+		fmt.Sprintf(`bpmn:process id="%s"`, processID),
+		`name="globalMsgRef"`,
+		fmt.Sprintf(`name="%s"`, messageName),
+		`correlationKey="=&#34;correlation-key-one&#34;"`,
+		`correlationKey="=correlationKey"`,
+	).Replace(string(bpmnData))
+
+	return deployBPMNTestCaseContent(t, "message-intermediate-catch-event-correlation.bpmn", []byte(content)), messageName
+}
+
+func createMessageCatchCorrelationInstance(t testing.TB, definitionKey int64, correlationKey string) zenclient.ProcessInstance {
+	t.Helper()
+
+	processInstance, err := createProcessInstance(t, &definitionKey, map[string]any{
+		"correlationKey": correlationKey,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupOwnedProcessInstance(t, processInstance.Key)
+	})
+	return processInstance
+}
+
+func assertMessageCatchStillWaiting(t testing.TB, processInstanceKey int64) {
+	t.Helper()
+
+	waitForProcessInstanceState(t, processInstanceKey, zenclient.ProcessInstanceStateActive)
+	assertProcessInstanceTokenState(t, processInstanceKey, "id-1", runtime.TokenStateWaiting)
+	assertMessageSubscriptionState(t, processInstanceKey, "id-1", zenclient.EventSubscriptionStateActive)
+	assertProcessInstanceHasNoActiveJobByElementId(t, processInstanceKey, "Event_1jn3jqk")
+}

--- a/test/e2e/message_catch_event_flow_test.go
+++ b/test/e2e/message_catch_event_flow_test.go
@@ -1,0 +1,49 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageCatchEventFlow(t *testing.T) {
+	t.Run("Process waits on the intermediate message catch event and continues after message receipt", func(t *testing.T) {
+		definition, err := deployGetDefinition(t, "simple-intermediate-message-catch-event.bpmn", "simple-intermediate-message-catch-event")
+		require.NoError(t, err)
+
+		processInstance, err := createProcessInstance(t, &definition.Key, map[string]any{})
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, processInstance.Key, "msg", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, processInstance.Key, "msg", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, processInstance.Key, []string{
+			"StartEvent_1",
+			"Flow_0h5js9r",
+			"msg",
+		})
+
+		err = publishMessage(t, "msg", "key", &map[string]any{
+			"foo": "mapped-value",
+		})
+		require.NoError(t, err)
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "EndEvent_1")
+		assertProcessInstanceTokenCount(t, processInstance.Key, "msg", 0)
+		assertMessageSubscriptionStateCount(t, processInstance.Key, "msg", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, processInstance.Key, "msg", zenclient.EventSubscriptionStateCompleted, 1)
+		assertExactProcessInstanceHistory(t, processInstance.Key, []string{
+			"StartEvent_1",
+			"Flow_0h5js9r",
+			"msg",
+			"Flow_03f7s7e",
+			"EndEvent_1",
+		})
+	})
+}

--- a/test/e2e/message_catch_event_variables_test.go
+++ b/test/e2e/message_catch_event_variables_test.go
@@ -1,0 +1,74 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageCatchEventVariables(t *testing.T) {
+	t.Run("Without output mapping all message variables are propagated", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, "testdata/message_event/message-intermediate-catch-event.bpmn")
+		createInstanceVariables := map[string]any{
+			"existing":    "process-value",
+			"overwritten": "initial-value",
+		}
+		processInstance, err := createProcessInstance(t, &definitionKey, createInstanceVariables)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		assertMessageSubscriptionState(t, processInstance.Key, "id-1", zenclient.EventSubscriptionStateActive)
+		assertFlowElementInputVariables(t, processInstance.Key, "id-1", createInstanceVariables)
+
+		messageVariables := map[string]any{
+			"overwritten": "message-value",
+			"unmapped":    "unmapped-value",
+			"numeric":     float64(42),
+		}
+		err = publishMessage(t, "globalMsgRef", "correlation-key-one", &messageVariables)
+		require.NoError(t, err)
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "Event_1jn3jqk")
+		assertFlowElementOutputVariables(t, processInstance.Key, "id-1", messageVariables)
+		assertProcessInstanceVariables(t, processInstance.Key, mergeMaps(createInstanceVariables, messageVariables))
+	})
+
+	t.Run("Input mapping is local and output mapping propagates only mapped message variables", func(t *testing.T) {
+		definition, err := deployGetDefinition(t, "simple-intermediate-message-catch-event.bpmn", "simple-intermediate-message-catch-event")
+		require.NoError(t, err)
+
+		createInstanceVariables := map[string]any{
+			"inputFoo":  "input-value",
+			"unchanged": "process-value",
+		}
+		processInstance, err := createProcessInstance(t, &definition.Key, createInstanceVariables)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		assertMessageSubscriptionState(t, processInstance.Key, "msg", zenclient.EventSubscriptionStateActive)
+		assertFlowElementInputVariables(t, processInstance.Key, "msg", mergeMaps(createInstanceVariables, map[string]any{
+			"mappedInputFoo": "input-value",
+		}))
+
+		err = publishMessage(t, "msg", "key", &map[string]any{
+			"foo":     "mapped-value",
+			"ignored": "ignored-value",
+		})
+		require.NoError(t, err)
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "EndEvent_1")
+		assertFlowElementOutputVariables(t, processInstance.Key, "msg", map[string]any{
+			"mappedFoo": "mapped-value",
+		})
+		assertProcessInstanceVariables(t, processInstance.Key, mergeMaps(createInstanceVariables, map[string]any{
+			"mappedFoo": "mapped-value",
+		}))
+	})
+}

--- a/test/e2e/message_end_event_flow_test.go
+++ b/test/e2e/message_end_event_flow_test.go
@@ -1,0 +1,184 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient/proto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type messageEndEventGrpcDelivery struct {
+	job       *proto.WaitingJob
+	variables map[string]any
+	err       error
+}
+
+func TestMessageEndEventFlow(t *testing.T) {
+	t.Run("Publication job is delivered to the gRPC worker only after the event is reached", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, messageEndEventPayloadPath)
+		businessKey := uniqueMessageEndEventBusinessKey("single-publication")
+		receivedJob := make(chan messageEndEventGrpcDelivery, 1)
+
+		conn, err := grpc.NewClient(app.grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, conn.Close())
+		})
+
+		grpcClient := zenclient.NewGrpc(conn)
+		worker, err := grpcClient.RegisterWorker(
+			t.Context(),
+			businessKey,
+			func(_ context.Context, job *proto.WaitingJob) (map[string]any, *zenclient.WorkerError) {
+				variables := map[string]any{}
+				decodeErr := json.Unmarshal(job.GetInputVariables(), &variables)
+				receivedJob <- messageEndEventGrpcDelivery{
+					job:       job,
+					variables: variables,
+					err:       decodeErr,
+				}
+				return map[string]any{}, nil
+			},
+			messageEndEventPublicationJob,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, worker)
+
+		instance := createMessageEndEventProcessInstance(t, definitionKey, businessKey, messageEndEventPayloadVariables(
+			businessKey,
+			"4f0ed402-4281-40f2-b724-4c6e4017b315",
+			"order-1001",
+			"Žluťoučký kůň 🐎 / 東京",
+			"2026-07-16T08:45:30+02:00",
+		))
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, instance.Key)
+		})
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "prepare_publication")
+		assertProcessInstanceHasNoActiveJobByElementId(t, instance.Key, messageEndEventElementID)
+		select {
+		case delivery := <-receivedJob:
+			t.Fatalf("message end event job was delivered before the event was reached: %d", delivery.job.GetKey())
+		default:
+		}
+
+		completeJobForElementId(t, instance.Key, "prepare_publication", nil)
+
+		var delivery messageEndEventGrpcDelivery
+		select {
+		case delivery = <-receivedJob:
+		case <-time.After(10 * time.Second):
+			t.Fatal("message end event job was not delivered to the gRPC worker")
+		}
+
+		require.NoError(t, delivery.err)
+		require.NotNil(t, delivery.job)
+		require.Equal(t, messageEndEventPublicationJob, delivery.job.GetType())
+		require.Equal(t, messageEndEventElementID, delivery.job.GetElementId())
+		require.Equal(t, instance.Key, delivery.job.GetInstanceKey())
+		require.Equal(t, "order-1001", delivery.variables["orderId"])
+		require.Equal(t, businessKey, delivery.variables["correlationId"])
+
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateCompleted)
+		completedJob := waitForProcessInstanceJobByElementId(t, instance.Key, messageEndEventElementID, public.JobStateCompleted)
+		require.Equal(t, delivery.job.GetKey(), completedJob.Key)
+		assertExactlyOneMessageEndEventJob(t, instance.Key, messageEndEventElementID)
+		assertProcessInstanceTokenState(t, instance.Key, messageEndEventElementID, runtime.TokenStateCompleted)
+	})
+
+	t.Run("Completing the publication job ends the branch and leaves no active activity", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, messageEndEventPayloadPath)
+		businessKey := uniqueMessageEndEventBusinessKey("branch-completion")
+		instance := createMessageEndEventProcessInstance(t, definitionKey, businessKey, messageEndEventPayloadVariables(
+			businessKey,
+			"58124e41-504d-4039-8518-44e92e8a41d0",
+			"order-branch",
+			"Branch Customer",
+			"2026-07-16T09:00:00Z",
+		))
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, instance.Key)
+		})
+
+		completeJobForElementId(t, instance.Key, "prepare_publication", nil)
+		publicationJob := waitForProcessInstanceActiveJobByElementId(t, instance.Key, messageEndEventElementID)
+		require.NoError(t, completeJob(t, publicationJob.Key, nil))
+
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, messageEndEventElementID, runtime.TokenStateCompleted)
+		assertProcessInstanceHasNoActiveJobs(t, instance.Key)
+		completedJob := waitForProcessInstanceJobByElementId(t, instance.Key, messageEndEventElementID, public.JobStateCompleted)
+		require.Equal(t, publicationJob.Key, completedJob.Key)
+		assertExactlyOneMessageEndEventJob(t, instance.Key, messageEndEventElementID)
+	})
+
+	t.Run("Completing a message end event does not terminate another parallel branch", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, messageEndEventParallelPath)
+		businessKey := uniqueMessageEndEventBusinessKey("parallel")
+		instance := createMessageEndEventProcessInstance(t, definitionKey, businessKey, map[string]any{
+			"businessKey": businessKey,
+			"messageId":   "7d8ae85b-8b63-4944-b952-d35662a4ad1d",
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, instance.Key)
+		})
+
+		publicationJob := waitForProcessInstanceActiveJobByElementId(t, instance.Key, messageEndEventElementID)
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "parallel_task")
+		require.Equal(t, "orders.completed.parallel", publicationJob.Type)
+		require.NoError(t, completeJob(t, publicationJob.Key, nil))
+
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, messageEndEventElementID, runtime.TokenStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, "parallel_task", runtime.TokenStateWaiting)
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "parallel_task")
+
+		completeJobForElementId(t, instance.Key, "parallel_task", nil)
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, "parallel_end_event", runtime.TokenStateCompleted)
+	})
+
+	t.Run("Message end event inside a subprocess lets the parent continue", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, messageEndEventSubprocessPath)
+		businessKey := uniqueMessageEndEventBusinessKey("subprocess")
+		instance := createMessageEndEventProcessInstance(t, definitionKey, businessKey, map[string]any{
+			"businessKey": businessKey,
+			"messageId":   "4880d126-ab74-4899-8f34-8a8bb145306b",
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, instance.Key)
+		})
+
+		child := waitForChildProcessInstance(t, instance.Key, 0)
+		publicationJob := waitForProcessInstanceActiveJobByElementId(t, child.Key, "subprocess_message_end")
+		require.Equal(t, "orders.completed.subprocess", publicationJob.Type)
+		assertProcessInstanceTokenState(t, instance.Key, "message_subprocess", runtime.TokenStateWaiting)
+
+		require.NoError(t, completeJob(t, publicationJob.Key, nil))
+
+		waitForProcessInstanceState(t, child.Key, zenclient.ProcessInstanceStateCompleted)
+		assertProcessInstanceTokenState(t, child.Key, "subprocess_message_end", runtime.TokenStateCompleted)
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "parent_followup")
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceHistory(t, instance.Key, []string{
+			"parent_start",
+			"Flow_parent_start_to_subprocess",
+			"message_subprocess",
+			"Flow_subprocess_to_followup",
+			"parent_followup",
+		})
+
+		completeJobForElementId(t, instance.Key, "parent_followup", nil)
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, "parent_end", runtime.TokenStateCompleted)
+	})
+}

--- a/test/e2e/message_end_event_helpers_test.go
+++ b/test/e2e/message_end_event_helpers_test.go
@@ -1,0 +1,110 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	messageEndEventBasicPath      = "testdata/message_end_event/message_end_event.bpmn"
+	messageEndEventPayloadPath    = "testdata/message_end_event/message_end_event_payload.bpmn"
+	messageEndEventParallelPath   = "testdata/message_end_event/message_end_event_parallel.bpmn"
+	messageEndEventSubprocessPath = "testdata/message_end_event/message_end_event_subprocess.bpmn"
+
+	messageEndEventElementID      = "message_end_event"
+	messageEndEventPublicationJob = "orders.completed"
+)
+
+func createMessageEndEventProcessInstance(
+	t testing.TB,
+	definitionKey int64,
+	businessKey string,
+	variables map[string]any,
+) zenclient.ProcessInstance {
+	t.Helper()
+
+	response, err := app.restClient.CreateProcessInstanceWithResponse(t.Context(), zenclient.CreateProcessInstanceJSONRequestBody{
+		BusinessKey:          &businessKey,
+		ProcessDefinitionKey: &definitionKey,
+		Variables:            &variables,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 201, response.StatusCode())
+	require.NotNil(t, response.JSON201)
+	return *response.JSON201
+}
+
+func messageEndEventPayloadVariables(businessKey string, messageID string, orderID string, customerName string, occurredAt string) map[string]any {
+	return map[string]any{
+		"businessKey":  businessKey,
+		"messageId":    messageID,
+		"orderId":      orderID,
+		"amount":       42.5,
+		"approved":     true,
+		"customerName": customerName,
+		"occurredAt":   occurredAt,
+	}
+}
+
+func uniqueMessageEndEventBusinessKey(prefix string) string {
+	return fmt.Sprintf("message-end-event-%s-%d", prefix, time.Now().UnixNano())
+}
+
+func assertExactlyOneMessageEndEventJob(t testing.TB, processInstanceKey int64, elementID string) {
+	t.Helper()
+
+	var requestErr error
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		jobs, err := getProcessInstanceJobs(t, processInstanceKey)
+		if !assert.NoError(collect, err) {
+			return
+		}
+
+		count := 0
+		for _, job := range jobs {
+			if job.ElementId == elementID {
+				count++
+			}
+		}
+		assert.Equal(collect, 1, count)
+	}, 5*time.Second, 50*time.Millisecond)
+
+	require.Never(t, func() bool {
+		jobs, err := getProcessInstanceJobs(t, processInstanceKey)
+		if err != nil {
+			requestErr = err
+			return false
+		}
+		requestErr = nil
+
+		count := 0
+		for _, job := range jobs {
+			if job.ElementId == elementID {
+				count++
+			}
+		}
+		return count > 1
+	}, 750*time.Millisecond, 50*time.Millisecond, "message end event must not create a duplicate publication job")
+	require.NoError(t, requestErr)
+}
+
+func assertProcessInstanceHasNoActiveJobs(t testing.TB, processInstanceKey int64) {
+	t.Helper()
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		jobs, err := getProcessInstanceJobs(t, processInstanceKey)
+		if !assert.NoError(collect, err) {
+			return
+		}
+
+		for _, job := range jobs {
+			assert.NotEqual(collect, public.JobStateActive, job.State)
+		}
+	}, 5*time.Second, 50*time.Millisecond, "completed process instance must not expose active jobs")
+}

--- a/test/e2e/message_end_event_incident_test.go
+++ b/test/e2e/message_end_event_incident_test.go
@@ -1,0 +1,45 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageEndEventIncident(t *testing.T) {
+	t.Run("failing the message end event job creates an incident and keeps the token waiting", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, messageEndEventBasicPath)
+
+		processInstance, err := createProcessInstance(t, &definitionKey, map[string]any{
+			"instVar": "instVarValue",
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		waitForProcessInstanceActiveJobByElementId(t, processInstance.Key, "Event_11flm9z")
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, processInstance.Key, "Event_11flm9z", runtime.TokenStateWaiting)
+		assertProcessInstanceIncidentsLength(t, processInstance.Key, 0)
+
+		failJobForElementId(t, processInstance.Key, "Event_11flm9z", nil, map[string]any{
+			"sendError": "transport-unavailable",
+		})
+
+		waitForProcessInstanceJobByElementId(t, processInstance.Key, "Event_11flm9z", public.JobStateFailed)
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, processInstance.Key, "Event_11flm9z", runtime.TokenStateWaiting)
+
+		incidents, err := getProcessInstanceIncidents(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Len(t, incidents, 1)
+		require.Equal(t, "Event_11flm9z", incidents[0].ElementId)
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"instVar": "instVarValue",
+		})
+	})
+}

--- a/test/e2e/message_end_event_test.go
+++ b/test/e2e/message_end_event_test.go
@@ -11,10 +11,11 @@ import (
 func TestMessageEndEvent(t *testing.T) {
 	var instance zenclient.ProcessInstance
 	var jobToComplete zenclient.Job
-	definition, err := deployGetDefinition(t, "message_end_event.bpmn", "message_end_event")
+	var err error
+	definitionKey := deployTestDataProcessDefinitionKey(t, messageEndEventBasicPath)
 
 	t.Run("create process instance with message end event", func(t *testing.T) {
-		instance, err = createProcessInstance(t, &definition.Key, map[string]any{
+		instance, err = createProcessInstance(t, &definitionKey, map[string]any{
 			"instVar": "instVarValue",
 		})
 		assert.NoError(t, err)

--- a/test/e2e/message_end_event_variables_test.go
+++ b/test/e2e/message_end_event_variables_test.go
@@ -1,0 +1,107 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageEndEventVariables(t *testing.T) {
+	t.Run("Input mapping preserves required types, optional values, Unicode, identifiers and timestamps", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, messageEndEventPayloadPath)
+		businessKey := uniqueMessageEndEventBusinessKey("payload")
+		messageID := "db1ef6b5-af74-4df9-a364-e528c1af0d71"
+		customerName := "Příliš žluťoučký kůň 🐎 – 東京"
+		occurredAt := "2026-01-15T19:21:42.123+01:00"
+		instance := createMessageEndEventProcessInstance(t, definitionKey, businessKey, messageEndEventPayloadVariables(
+			businessKey,
+			messageID,
+			"order-žluťoučký-東京",
+			customerName,
+			occurredAt,
+		))
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, instance.Key)
+		})
+
+		completeJobForElementId(t, instance.Key, "prepare_publication", nil)
+		publicationJob := waitForProcessInstanceActiveJobByElementId(t, instance.Key, messageEndEventElementID)
+
+		require.Equal(t, "order-žluťoučký-東京", publicationJob.InputVariables["orderId"])
+		require.Equal(t, float64(42.5), publicationJob.InputVariables["amount"])
+		require.Equal(t, true, publicationJob.InputVariables["approved"])
+		require.Equal(t, "order.completed", publicationJob.InputVariables["messageType"])
+		require.Equal(t, businessKey, publicationJob.InputVariables["correlationId"])
+		require.Equal(t, messageID, publicationJob.InputVariables["messageId"])
+		require.Equal(t, customerName, publicationJob.InputVariables["customerName"])
+		require.Equal(t, occurredAt, publicationJob.InputVariables["occurredAt"])
+		require.Contains(t, publicationJob.InputVariables, "optionalNote")
+		require.Nil(t, publicationJob.InputVariables["optionalNote"])
+		require.Regexp(t, `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`, publicationJob.InputVariables["messageId"])
+
+		emittedAt, ok := publicationJob.InputVariables["emittedAt"].(string)
+		require.True(t, ok, "emittedAt must be serialized as a string")
+		require.Equal(t, occurredAt, emittedAt)
+		_, err := time.Parse(time.RFC3339Nano, emittedAt)
+		require.NoError(t, err, "emittedAt must contain an RFC3339 timestamp with an offset")
+		_, err = time.Parse(time.RFC3339Nano, publicationJob.InputVariables["occurredAt"].(string))
+		require.NoError(t, err, "occurredAt must preserve its RFC3339 timestamp and offset")
+
+		require.NoError(t, completeJob(t, publicationJob.Key, nil))
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateCompleted)
+	})
+
+	t.Run("Two instances keep input and correlation variables isolated", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, messageEndEventPayloadPath)
+		firstBusinessKey := uniqueMessageEndEventBusinessKey("multi-first")
+		secondBusinessKey := uniqueMessageEndEventBusinessKey("multi-second")
+		firstMessageID := "773d4dc7-bcd6-4426-aa75-a4999a9ff982"
+		secondMessageID := "b0b7fc9d-e40a-4822-b3ae-94f3ff925e70"
+
+		first := createMessageEndEventProcessInstance(t, definitionKey, firstBusinessKey, messageEndEventPayloadVariables(
+			firstBusinessKey,
+			firstMessageID,
+			"order-first",
+			"První zákazník",
+			"2026-07-16T07:00:00Z",
+		))
+		second := createMessageEndEventProcessInstance(t, definitionKey, secondBusinessKey, messageEndEventPayloadVariables(
+			secondBusinessKey,
+			secondMessageID,
+			"order-second",
+			"Second Customer",
+			"2026-07-16T08:00:00+01:00",
+		))
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, first.Key)
+			cleanupOwnedProcessInstance(t, second.Key)
+		})
+
+		completeJobForElementId(t, first.Key, "prepare_publication", nil)
+		completeJobForElementId(t, second.Key, "prepare_publication", nil)
+		firstJob := waitForProcessInstanceActiveJobByElementId(t, first.Key, messageEndEventElementID)
+		secondJob := waitForProcessInstanceActiveJobByElementId(t, second.Key, messageEndEventElementID)
+
+		require.NotEqual(t, firstJob.Key, secondJob.Key)
+		require.Equal(t, "order-first", firstJob.InputVariables["orderId"])
+		require.Equal(t, firstBusinessKey, firstJob.InputVariables["correlationId"])
+		require.Equal(t, firstMessageID, firstJob.InputVariables["messageId"])
+		require.Equal(t, "order-second", secondJob.InputVariables["orderId"])
+		require.Equal(t, secondBusinessKey, secondJob.InputVariables["correlationId"])
+		require.Equal(t, secondMessageID, secondJob.InputVariables["messageId"])
+		require.NotEqual(t, firstJob.InputVariables["messageId"], secondJob.InputVariables["messageId"])
+
+		firstInstance, err := getProcessInstance(t, first.Key)
+		require.NoError(t, err)
+		secondInstance, err := getProcessInstance(t, second.Key)
+		require.NoError(t, err)
+		require.Equal(t, firstBusinessKey, *firstInstance.BusinessKey)
+		require.Equal(t, secondBusinessKey, *secondInstance.BusinessKey)
+
+		require.NoError(t, completeJob(t, firstJob.Key, nil))
+		require.NoError(t, completeJob(t, secondJob.Key, nil))
+		waitForTwoProcessInstanceStates(t, first.Key, zenclient.ProcessInstanceStateCompleted, second.Key, zenclient.ProcessInstanceStateCompleted)
+	})
+}

--- a/test/e2e/message_event_regression_helpers_test.go
+++ b/test/e2e/message_event_regression_helpers_test.go
@@ -1,0 +1,74 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func messageEventTestSuffix() int64 {
+	return time.Now().UnixNano()
+}
+
+func readBPMNTestCaseFile(t testing.TB, filepathn string) []byte {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	loc := filepath.Join(wd, filepathn)
+
+	content, err := os.ReadFile(loc)
+	require.NoError(t, err)
+	return content
+}
+
+func deployBPMNTestCaseContent(t testing.TB, filename string, content []byte) int64 {
+	t.Helper()
+
+	response, err := deployDefinitionFromBytes(t, content, filename)
+	require.NoError(t, err)
+
+	if response.JSON201 != nil {
+		require.NotZero(t, response.JSON201.ProcessDefinitionKey)
+		return response.JSON201.ProcessDefinitionKey
+	}
+	require.NotNil(t, response.JSON200)
+	require.NotZero(t, response.JSON200.ProcessDefinitionKey)
+	return response.JSON200.ProcessDefinitionKey
+}
+
+func waitForProcessInstancesByBPMNProcessID(t testing.TB, bpmnProcessID string, expectedCount int) []zenclient.ProcessInstancesSimple {
+	t.Helper()
+
+	var instances []zenclient.ProcessInstancesSimple
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		instances = processInstancesByBPMNProcessID(t, bpmnProcessID)
+		assert.Len(collect, instances, expectedCount)
+	}, 10*time.Second, 100*time.Millisecond, "expected %d process instances for BPMN process id %s", expectedCount, bpmnProcessID)
+
+	return instances
+}
+
+func processInstancesByBPMNProcessID(t testing.TB, bpmnProcessID string) []zenclient.ProcessInstancesSimple {
+	t.Helper()
+
+	size := int32(100)
+	response, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
+		BpmnProcessId: &bpmnProcessID,
+		Size:          &size,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, response.JSON200)
+
+	instances := make([]zenclient.ProcessInstancesSimple, 0, response.JSON200.TotalCount)
+	for _, partition := range response.JSON200.Partitions {
+		instances = append(instances, partition.Items...)
+	}
+	return instances
+}

--- a/test/e2e/message_event_regression_helpers_test.go
+++ b/test/e2e/message_event_regression_helpers_test.go
@@ -1,8 +1,11 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,8 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var lastMessageEventTestSuffix atomic.Int64
+
 func messageEventTestSuffix() int64 {
-	return time.Now().UnixNano()
+	for {
+		previous := lastMessageEventTestSuffix.Load()
+		next := max(time.Now().UnixNano(), previous+1)
+		if lastMessageEventTestSuffix.CompareAndSwap(previous, next) {
+			return next
+		}
+	}
 }
 
 func readBPMNTestCaseFile(t testing.TB, filepathn string) []byte {
@@ -26,6 +37,99 @@ func readBPMNTestCaseFile(t testing.TB, filepathn string) []byte {
 	content, err := os.ReadFile(loc)
 	require.NoError(t, err)
 	return content
+}
+
+// replaceInBPMNFixture rewrites a fixture and fails the test if the key is missing.
+//
+// These tests rewrite fixtures to get per-run unique process ids, message names and correlation keys.
+// A plain strings.Replace silently does nothing once a fixture is reformatted, its attribute order
+// changes, or an editor re-escapes the XML — leaving the test correlating against a name that is not
+// in the deployed model, or asserting against a different process than it thinks. Requiring the key
+// to be present turns those silent false positives into a loud failure at the point of the change.
+func replaceInBPMNFixture(t testing.TB, filename string, content string, oldValue string, newValue string) string {
+	t.Helper()
+
+	require.Contains(t, content, oldValue,
+		"fixture %s must contain %q so it can be rewritten for this test", filename, oldValue)
+	return strings.ReplaceAll(content, oldValue, newValue)
+}
+
+// requireInterruptingBoundary flips the fixture's single non-interrupting boundary event to an
+// interrupting one. The exact count is asserted because silently flipping zero of them would leave the
+// test asserting non-interrupting behaviour under an "interrupting" name, and flipping one of several
+// would pick an arbitrary boundary event.
+func requireInterruptingBoundary(t testing.TB, filename string, content string) string {
+	t.Helper()
+
+	const nonInterrupting = `cancelActivity="false"`
+	require.Equal(t, 1, strings.Count(content, nonInterrupting),
+		"fixture %s must contain exactly one %s to be deployed as an interrupting variant", filename, nonInterrupting)
+	return strings.Replace(content, nonInterrupting, `cancelActivity="true"`, 1)
+}
+
+func deployMessageBoundaryDefinition(t testing.TB, filename string, baseProcessID string) (int64, string, string) {
+	return deployMessageBoundaryDefinitionWithInterrupting(t, filename, baseProcessID, false)
+}
+
+func deployInterruptingMessageBoundaryDefinition(t testing.TB, filename string, baseProcessID string) (int64, string, string) {
+	return deployMessageBoundaryDefinitionWithInterrupting(t, filename, baseProcessID, true)
+}
+
+func deployMessageBoundaryDefinitionWithInterrupting(t testing.TB, filename string, baseProcessID string, interrupting bool) (int64, string, string) {
+	t.Helper()
+
+	suffix := messageEventTestSuffix()
+	processID := fmt.Sprintf("%s-%d", baseProcessID, suffix)
+	messageName := fmt.Sprintf("%s-ref-%d", baseProcessID, suffix)
+	correlationKey := fmt.Sprintf("%s-key-%d", baseProcessID, suffix)
+	content := string(readBPMNTestCaseFile(t, filename))
+	if interrupting {
+		content = requireInterruptingBoundary(t, filename, content)
+	}
+	content = replaceInBPMNFixture(t, filename, content,
+		fmt.Sprintf(`bpmn:process id="%s"`, baseProcessID), fmt.Sprintf(`bpmn:process id="%s"`, processID))
+	content = replaceInBPMNFixture(t, filename, content,
+		`name="message"`, fmt.Sprintf(`name="%s"`, messageName))
+	content = replaceInBPMNFixture(t, filename, content,
+		`correlationKey="=correlationKey"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKey))
+
+	return deployBPMNTestCaseContent(t, filename, []byte(content)), messageName, correlationKey
+}
+
+func deployTwoMessageBoundaryDefinition(t testing.TB, filename string, baseProcessID string) (int64, string, string, string, string) {
+	t.Helper()
+
+	suffix := messageEventTestSuffix()
+	processID := fmt.Sprintf("%s-%d", baseProcessID, suffix)
+	messageAName := fmt.Sprintf("%s-a-ref-%d", baseProcessID, suffix)
+	messageBName := fmt.Sprintf("%s-b-ref-%d", baseProcessID, suffix)
+	correlationKeyA := fmt.Sprintf("%s-a-key-%d", baseProcessID, suffix)
+	correlationKeyB := fmt.Sprintf("%s-b-key-%d", baseProcessID, suffix)
+	content := string(readBPMNTestCaseFile(t, filename))
+	content = replaceInBPMNFixture(t, filename, content,
+		fmt.Sprintf(`bpmn:process id="%s"`, baseProcessID), fmt.Sprintf(`bpmn:process id="%s"`, processID))
+	content = replaceInBPMNFixture(t, filename, content,
+		`name="messageA"`, fmt.Sprintf(`name="%s"`, messageAName))
+	content = replaceInBPMNFixture(t, filename, content,
+		`name="messageB"`, fmt.Sprintf(`name="%s"`, messageBName))
+	content = replaceInBPMNFixture(t, filename, content,
+		`correlationKey="=correlationKeyA"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKeyA))
+	content = replaceInBPMNFixture(t, filename, content,
+		`correlationKey="=correlationKeyB"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKeyB))
+
+	definitionKey := deployBPMNTestCaseContent(t, filename, []byte(content))
+	return definitionKey, messageAName, correlationKeyA, messageBName, correlationKeyB
+}
+
+func createMessageBoundaryInstance(t testing.TB, definitionKey int64) zenclient.ProcessInstance {
+	t.Helper()
+
+	processInstance, err := createProcessInstance(t, &definitionKey, map[string]any{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupOwnedProcessInstance(t, processInstance.Key)
+	})
+	return processInstance
 }
 
 func deployBPMNTestCaseContent(t testing.TB, filename string, content []byte) int64 {

--- a/test/e2e/message_start_event_correlation_test.go
+++ b/test/e2e/message_start_event_correlation_test.go
@@ -1,0 +1,82 @@
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageStartEventCorrelation(t *testing.T) {
+	t.Run("wrong message name does not start a process instance", func(t *testing.T) {
+		suffix := messageEventTestSuffix()
+		processID := fmt.Sprintf("message-start-wrong-name-%d", suffix)
+		messageName := fmt.Sprintf("message-start-ref-%d", suffix)
+		deployMessageStartDefinitionVersion(t, processID, messageName, fmt.Sprintf("message-start-wrong-name-job-%d", suffix))
+
+		response, err := app.restClient.PublishMessageWithResponse(t.Context(), zenclient.PublishMessageJSONRequestBody{
+			CorrelationKey: nil,
+			MessageName:    messageName + "-wrong",
+			Variables:      &map[string]any{"messagePayloadVar": "ignored"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, response.StatusCode())
+
+		waitForProcessInstancesByBPMNProcessID(t, processID, 0)
+	})
+
+	t.Run("correlation key is ignored for a definition-level message start subscription", func(t *testing.T) {
+		definition := deployUniqueMessageStartEventDefinition(t, "correlation-key")
+		correlationKey := "instance-only-correlation-key"
+
+		response, err := app.restClient.PublishMessageWithResponse(t.Context(), zenclient.PublishMessageJSONRequestBody{
+			CorrelationKey: &correlationKey,
+			MessageName:    definition.messageName,
+			Variables:      &map[string]any{"messagePayloadVar": "delivered"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, response.StatusCode())
+
+		instances := waitForProcessInstancesByBPMNProcessID(t, definition.processID, 1)
+		instance := instances[0]
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, instance.Key)
+		})
+		assertProcessInstanceVariables(t, instance.Key, map[string]any{
+			"messagePayloadVar": "delivered",
+		})
+	})
+
+	t.Run("message start uses the latest deployed process definition version", func(t *testing.T) {
+		suffix := messageEventTestSuffix()
+		processID := fmt.Sprintf("message-start-latest-version-%d", suffix)
+		messageName := fmt.Sprintf("message-start-latest-version-ref-%d", suffix)
+		firstDefinitionKey := deployMessageStartDefinitionVersion(t, processID, messageName, fmt.Sprintf("message-start-latest-version-job-%d-v1", suffix))
+		secondDefinitionKey := deployMessageStartDefinitionVersion(t, processID, messageName, fmt.Sprintf("message-start-latest-version-job-%d-v2", suffix))
+		require.NotEqual(t, firstDefinitionKey, secondDefinitionKey)
+
+		response, err := app.restClient.PublishMessageWithResponse(t.Context(), zenclient.PublishMessageJSONRequestBody{
+			CorrelationKey: nil,
+			MessageName:    messageName,
+			Variables:      &map[string]any{"messagePayloadVar": "latest"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, response.StatusCode())
+
+		instances := waitForProcessInstancesByBPMNProcessID(t, processID, 1)
+		require.Equal(t, secondDefinitionKey, instances[0].ProcessDefinitionKey)
+		require.Equal(t, zenclient.ProcessInstanceStateActive, instances[0].State)
+		require.NotEqual(t, firstDefinitionKey, instances[0].ProcessDefinitionKey)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, instances[0].Key)
+		})
+	})
+}
+
+func deployMessageStartDefinitionVersion(t testing.TB, processID string, messageName string, jobType string) int64 {
+	t.Helper()
+
+	return deployMessageStartDefinition(t, processID, messageName, jobType)
+}

--- a/test/e2e/message_start_event_flow_test.go
+++ b/test/e2e/message_start_event_flow_test.go
@@ -1,0 +1,104 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageStartEventFlow(t *testing.T) {
+	t.Run("Published message creates one process instance on the message start branch", func(t *testing.T) {
+		definition := deployUniqueMessageStartEventDefinition(t, "flow")
+		require.Empty(t, waitForProcessInstancesByBPMNProcessID(t, definition.processID, 0))
+
+		publishMessageStartEvent(t, definition.messageName, map[string]any{
+			"messageId": "d2d04b17-ebd6-4a64-a0c4-27d39aa7d724",
+		})
+
+		instances := waitForProcessInstancesByBPMNProcessID(t, definition.processID, 1)
+		instance := instances[0]
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, instance.Key)
+		})
+
+		require.Equal(t, definition.key, instance.ProcessDefinitionKey)
+		require.Equal(t, zenclient.ProcessInstanceStateActive, instance.State)
+		assertProcessInstanceTokenState(t, instance.Key, messageStartEventTaskID, runtime.TokenStateWaiting)
+		assertProcessInstanceTokenElements(t, instance.Key,
+			[]string{messageStartEventTaskID},
+			[]string{messageStartEventElementID, "plainStartEvent_0mtr7my"},
+		)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			messageStartEventElementID,
+			"Flow_1xx1ap4",
+			messageStartEventTaskID,
+		})
+
+		taskJob := waitForProcessInstanceActiveJobByElementId(t, instance.Key, messageStartEventTaskID)
+		require.Equal(t, definition.jobType, taskJob.Type)
+		require.NoError(t, completeJob(t, taskJob.Key, nil))
+
+		assertProcessInstanceIsCompleted(t, instance.Key, messageStartEventEndID)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			messageStartEventElementID,
+			"Flow_1xx1ap4",
+			messageStartEventTaskID,
+			"Flow_0rvswpk",
+			messageStartEventEndID,
+		})
+		assertProcessInstanceHasNoActiveJobs(t, instance.Key)
+	})
+
+	t.Run("Renewed subscription starts a separate process instance for the next message", func(t *testing.T) {
+		definition := deployUniqueMessageStartEventDefinition(t, "renewal")
+
+		publishMessageStartEvent(t, definition.messageName, map[string]any{
+			"delivery": "first",
+		})
+		firstBatch := waitForProcessInstancesByBPMNProcessID(t, definition.processID, 1)
+		first := firstBatch[0]
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, first.Key)
+		})
+
+		publishMessageStartEvent(t, definition.messageName, map[string]any{
+			"delivery": "second",
+		})
+		instances := waitForProcessInstancesByBPMNProcessID(t, definition.processID, 2)
+
+		var second zenclient.ProcessInstancesSimple
+		for _, instance := range instances {
+			if instance.Key != first.Key {
+				second = instance
+				break
+			}
+		}
+		require.NotZero(t, second.Key)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, second.Key)
+		})
+
+		require.NotEqual(t, first.Key, second.Key)
+		require.Equal(t, definition.key, first.ProcessDefinitionKey)
+		require.Equal(t, definition.key, second.ProcessDefinitionKey)
+		waitForTwoProcessInstanceStates(
+			t,
+			first.Key, zenclient.ProcessInstanceStateActive,
+			second.Key, zenclient.ProcessInstanceStateActive,
+		)
+
+		firstJob := waitForProcessInstanceActiveJobByElementId(t, first.Key, messageStartEventTaskID)
+		secondJob := waitForProcessInstanceActiveJobByElementId(t, second.Key, messageStartEventTaskID)
+		require.NotEqual(t, firstJob.Key, secondJob.Key)
+
+		require.NoError(t, completeJob(t, firstJob.Key, nil))
+		require.NoError(t, completeJob(t, secondJob.Key, nil))
+		waitForTwoProcessInstanceStates(
+			t,
+			first.Key, zenclient.ProcessInstanceStateCompleted,
+			second.Key, zenclient.ProcessInstanceStateCompleted,
+		)
+	})
+}

--- a/test/e2e/message_start_event_helpers_test.go
+++ b/test/e2e/message_start_event_helpers_test.go
@@ -1,0 +1,91 @@
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	messageStartEventFixturePath = "message_event/message-start-event-process.bpmn"
+	messageStartEventElementID   = "messageStartEvent_1234"
+	messageStartEventTaskID      = "service-task-1"
+	messageStartEventEndID       = "Event_0461t71"
+)
+
+type messageStartEventTestDefinition struct {
+	key         int64
+	processID   string
+	messageName string
+	jobType     string
+}
+
+func deployUniqueMessageStartEventDefinition(t testing.TB, prefix string) messageStartEventTestDefinition {
+	t.Helper()
+
+	return deployUniqueMessageStartEventDefinitionWithContent(t, prefix, "")
+}
+
+func deployUniqueMessageStartEventDefinitionWithContent(t testing.TB, prefix string, startEventExtensionElements string) messageStartEventTestDefinition {
+	t.Helper()
+
+	suffix := messageEventTestSuffix()
+	definition := messageStartEventTestDefinition{
+		processID:   fmt.Sprintf("message-start-event-%s-%d", prefix, suffix),
+		messageName: fmt.Sprintf("message-start-event-%s-ref-%d", prefix, suffix),
+		jobType:     fmt.Sprintf("message-start-event-%s-job-%d", prefix, suffix),
+	}
+	definition.key = deployMessageStartDefinitionWithContent(
+		t,
+		definition.processID,
+		definition.messageName,
+		definition.jobType,
+		startEventExtensionElements,
+	)
+	return definition
+}
+
+func deployMessageStartDefinition(t testing.TB, processID string, messageName string, jobType string) int64 {
+	t.Helper()
+
+	return deployMessageStartDefinitionWithContent(t, processID, messageName, jobType, "")
+}
+
+func deployMessageStartDefinitionWithContent(
+	t testing.TB,
+	processID string,
+	messageName string,
+	jobType string,
+	startEventExtensionElements string,
+) int64 {
+	t.Helper()
+
+	bpmnData, err := readE2ETestDataBPMN(messageStartEventFixturePath)
+	require.NoError(t, err)
+	content := strings.NewReplacer(
+		"message-start-event-process-1", processID,
+		"messageStartEventProcessRef", messageName,
+		"input-task-for-message-start-event-test", jobType,
+	).Replace(string(bpmnData))
+	if startEventExtensionElements != "" {
+		content = strings.Replace(content, "<bpmn:extensionElements />", startEventExtensionElements, 1)
+	}
+
+	return deployBPMNTestCaseContent(t, "message-start-event-process.bpmn", []byte(content))
+}
+
+func publishMessageStartEvent(t testing.TB, messageName string, variables map[string]any) {
+	t.Helper()
+
+	response, err := app.restClient.PublishMessageWithResponse(t.Context(), zenclient.PublishMessageJSONRequestBody{
+		CorrelationKey: nil,
+		MessageName:    messageName,
+		Variables:      &variables,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, response.StatusCode())
+}

--- a/test/e2e/message_start_event_variables_test.go
+++ b/test/e2e/message_start_event_variables_test.go
@@ -1,0 +1,145 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageStartEventVariables(t *testing.T) {
+	t.Run("Message start without output mapping propagates the complete payload", func(t *testing.T) {
+		definition := deployUniqueMessageStartEventDefinition(t, "payload")
+		messageID := "f12e89aa-dc71-4794-aa5f-5944ff6f74ce"
+		occurredAt := "2026-07-17T10:42:31.123+02:00"
+		variables := map[string]any{
+			"messageId":    messageID,
+			"orderId":      "objednávka-žluťoučký-東京",
+			"amount":       42.5,
+			"approved":     true,
+			"customerName": "Příliš žluťoučký kůň 🐎 – 東京",
+			"occurredAt":   occurredAt,
+			"optionalNote": nil,
+		}
+
+		publishMessageStartEvent(t, definition.messageName, variables)
+		instances := waitForProcessInstancesByBPMNProcessID(t, definition.processID, 1)
+		instance := instances[0]
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, instance.Key)
+		})
+
+		assertProcessInstanceVariables(t, instance.Key, variables)
+		assertFlowElementOutputVariables(t, instance.Key, messageStartEventElementID, variables)
+
+		taskJob := waitForProcessInstanceActiveJobByElementId(t, instance.Key, messageStartEventTaskID)
+		require.Equal(t, messageID, taskJob.InputVariables["messageId"])
+		require.Equal(t, "objednávka-žluťoučký-東京", taskJob.InputVariables["orderId"])
+		require.Equal(t, 42.5, taskJob.InputVariables["amount"])
+		require.Equal(t, true, taskJob.InputVariables["approved"])
+		require.Equal(t, "Příliš žluťoučký kůň 🐎 – 東京", taskJob.InputVariables["customerName"])
+		require.Contains(t, taskJob.InputVariables, "optionalNote")
+		require.Nil(t, taskJob.InputVariables["optionalNote"])
+
+		jobOccurredAt, ok := taskJob.InputVariables["occurredAt"].(string)
+		require.True(t, ok, "occurredAt must be serialized as a string")
+		require.Equal(t, occurredAt, jobOccurredAt)
+		_, err := time.Parse(time.RFC3339Nano, jobOccurredAt)
+		require.NoError(t, err, "occurredAt must preserve a valid RFC3339 timestamp with an offset")
+
+		require.NoError(t, completeJob(t, taskJob.Key, nil))
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateCompleted)
+	})
+
+	t.Run("Message start with output mapping propagates only mapped payload variables", func(t *testing.T) {
+
+		outputMapping := `<bpmn:extensionElements>
+			<zenbpm:ioMapping>
+			  <zenbpm:output source="=payload" target="mappedPayload" />
+			</zenbpm:ioMapping>
+		  </bpmn:extensionElements>`
+
+		definition := deployUniqueMessageStartEventDefinitionWithContent(t, "output-mapping", outputMapping)
+		messageVariables := map[string]any{
+			"payload":  "mapped-value",
+			"unmapped": "ignored-value",
+			"numeric":  float64(42),
+		}
+
+		publishMessageStartEvent(t, definition.messageName, messageVariables)
+		instances := waitForProcessInstancesByBPMNProcessID(t, definition.processID, 1)
+		instance := instances[0]
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, instance.Key)
+		})
+
+		expectedMappedVariables := map[string]any{
+			"mappedPayload": "mapped-value",
+		}
+		assertProcessInstanceVariables(t, instance.Key, expectedMappedVariables)
+		assertFlowElementOutputVariables(t, instance.Key, messageStartEventElementID, expectedMappedVariables)
+
+		taskJob := waitForProcessInstanceActiveJobByElementId(t, instance.Key, messageStartEventTaskID)
+		require.Equal(t, "mapped-value", taskJob.InputVariables["mappedPayload"])
+		require.NotContains(t, taskJob.InputVariables, "payload")
+		require.NotContains(t, taskJob.InputVariables, "unmapped")
+		require.NotContains(t, taskJob.InputVariables, "numeric")
+
+		require.NoError(t, completeJob(t, taskJob.Key, nil))
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateCompleted)
+	})
+
+	t.Run("Two messages keep their payload variables isolated", func(t *testing.T) {
+		definition := deployUniqueMessageStartEventDefinition(t, "isolation")
+		firstVariables := map[string]any{
+			"messageId":    "f1d5d3bd-3a6f-49d3-a1c2-1fa1192d3328",
+			"orderId":      "order-first",
+			"customerName": "První zákazník",
+		}
+		secondVariables := map[string]any{
+			"messageId":    "5033cc57-09bc-4f64-bdaf-d1f5542d2cca",
+			"orderId":      "order-second",
+			"customerName": "Second Customer",
+		}
+
+		publishMessageStartEvent(t, definition.messageName, firstVariables)
+		firstInstances := waitForProcessInstancesByBPMNProcessID(t, definition.processID, 1)
+		first := firstInstances[0]
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, first.Key)
+		})
+
+		publishMessageStartEvent(t, definition.messageName, secondVariables)
+		instances := waitForProcessInstancesByBPMNProcessID(t, definition.processID, 2)
+
+		var second zenclient.ProcessInstancesSimple
+		for _, instance := range instances {
+			if instance.Key != first.Key {
+				second = instance
+				break
+			}
+		}
+		require.NotZero(t, second.Key)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, second.Key)
+		})
+
+		assertProcessInstanceVariables(t, first.Key, firstVariables)
+		assertProcessInstanceVariables(t, second.Key, secondVariables)
+
+		firstJob := waitForProcessInstanceActiveJobByElementId(t, first.Key, messageStartEventTaskID)
+		secondJob := waitForProcessInstanceActiveJobByElementId(t, second.Key, messageStartEventTaskID)
+		require.Equal(t, firstVariables["messageId"], firstJob.InputVariables["messageId"])
+		require.Equal(t, secondVariables["messageId"], secondJob.InputVariables["messageId"])
+		require.NotEqual(t, firstJob.InputVariables["messageId"], secondJob.InputVariables["messageId"])
+
+		require.NoError(t, completeJob(t, firstJob.Key, nil))
+		require.NoError(t, completeJob(t, secondJob.Key, nil))
+		waitForTwoProcessInstanceStates(
+			t,
+			first.Key, zenclient.ProcessInstanceStateCompleted,
+			second.Key, zenclient.ProcessInstanceStateCompleted,
+		)
+	})
+}

--- a/test/e2e/message_start_event_variables_test.go
+++ b/test/e2e/message_start_event_variables_test.go
@@ -31,7 +31,7 @@ func TestMessageStartEventVariables(t *testing.T) {
 		})
 
 		assertProcessInstanceVariables(t, instance.Key, variables)
-		assertFlowElementOutputVariables(t, instance.Key, messageStartEventElementID, variables)
+		assertFlowElementOutputVariables(t, instance.Key, messageStartEventElementID, nil)
 
 		taskJob := waitForProcessInstanceActiveJobByElementId(t, instance.Key, messageStartEventTaskID)
 		require.Equal(t, messageID, taskJob.InputVariables["messageId"])

--- a/test/e2e/message_throw_event_flow_test.go
+++ b/test/e2e/message_throw_event_flow_test.go
@@ -1,0 +1,56 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageThrowEventFlow(t *testing.T) {
+	t.Run("Process waits for message publication and continues after the job is completed", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, "testdata/message_event/message-intermediate-throw-event-without-output-mapping.bpmn")
+		processVariables := map[string]any{
+			"payload":       "message-payload",
+			"correlationId": "correlation-123",
+			"unchanged":     "process-value",
+		}
+		processInstance, err := createProcessInstance(t, &definitionKey, processVariables)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, processInstance.Key, "message_throw_event", runtime.TokenStateWaiting)
+		publicationJob := waitForProcessInstanceActiveJobByElementId(t, processInstance.Key, "message_throw_event")
+		require.Equal(t, "message-intermediate-throw", publicationJob.Type)
+		require.Equal(t, mergeMaps(processVariables, map[string]any{
+			"messagePayload":       "message-payload",
+			"messageCorrelationId": "correlation-123",
+		}), publicationJob.InputVariables)
+		assertExactProcessInstanceHistory(t, processInstance.Key, []string{
+			"start_event",
+			"Flow_start_to_throw",
+			"message_throw_event",
+		})
+
+		require.NoError(t, completeJob(t, publicationJob.Key, map[string]any{
+			"deliveryId": "delivery-123",
+		}))
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertProcessInstanceTokenCount(t, processInstance.Key, "message_throw_event", 0)
+		completedJob := waitForProcessInstanceJobByElementId(t, processInstance.Key, "message_throw_event", public.JobStateCompleted)
+		require.Equal(t, publicationJob.Key, completedJob.Key)
+		assertExactProcessInstanceHistory(t, processInstance.Key, []string{
+			"start_event",
+			"Flow_start_to_throw",
+			"message_throw_event",
+			"Flow_throw_to_end",
+			"end_event",
+		})
+	})
+}

--- a/test/e2e/message_throw_event_incident_test.go
+++ b/test/e2e/message_throw_event_incident_test.go
@@ -1,0 +1,42 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageThrowEventIncident(t *testing.T) {
+	t.Run("Failing the publication job creates an incident and keeps the event waiting", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, "testdata/message_event/message-intermediate-throw-event-without-output-mapping.bpmn")
+		processVariables := map[string]any{
+			"payload":       "message-payload",
+			"correlationId": "correlation-incident",
+		}
+		processInstance, err := createProcessInstance(t, &definitionKey, processVariables)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		waitForProcessInstanceActiveJobByElementId(t, processInstance.Key, "message_throw_event")
+		assertProcessInstanceIncidentsLength(t, processInstance.Key, 0)
+
+		failJobForElementId(t, processInstance.Key, "message_throw_event", nil, map[string]any{
+			"sendError": "transport-unavailable",
+		})
+
+		waitForProcessInstanceJobByElementId(t, processInstance.Key, "message_throw_event", public.JobStateFailed)
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, processInstance.Key, "message_throw_event", runtime.TokenStateWaiting)
+
+		incidents, err := getProcessInstanceIncidents(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Len(t, incidents, 1)
+		require.Equal(t, "message_throw_event", incidents[0].ElementId)
+		assertProcessInstanceVariables(t, processInstance.Key, processVariables)
+	})
+}

--- a/test/e2e/message_throw_event_variables_test.go
+++ b/test/e2e/message_throw_event_variables_test.go
@@ -1,0 +1,81 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageThrowEventVariables(t *testing.T) {
+	t.Run("Without output mapping completion variables stay local", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, "testdata/message_event/message-intermediate-throw-event-without-output-mapping.bpmn")
+		processVariables := map[string]any{
+			"payload":       "message-payload",
+			"correlationId": "correlation-123",
+			"unchanged":     "process-value",
+		}
+		processInstance, err := createProcessInstance(t, &definitionKey, processVariables)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		publicationJob := waitForProcessInstanceActiveJobByElementId(t, processInstance.Key, "message_throw_event")
+		expectedInputVariables := mergeMaps(processVariables, map[string]any{
+			"messagePayload":       "message-payload",
+			"messageCorrelationId": "correlation-123",
+		})
+		require.Equal(t, expectedInputVariables, publicationJob.InputVariables)
+		assertFlowElementInputVariables(t, processInstance.Key, "message_throw_event", processVariables)
+
+		completionVariables := map[string]any{
+			"deliveryId": "delivery-123",
+			"ignored":    "ignored-value",
+		}
+		require.NoError(t, completeJob(t, publicationJob.Key, completionVariables))
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertFlowElementOutputVariables(t, processInstance.Key, "message_throw_event", map[string]any{})
+		assertProcessInstanceVariables(t, processInstance.Key, processVariables)
+		completedJob := waitForProcessInstanceJobByElementId(t, processInstance.Key, "message_throw_event", public.JobStateCompleted)
+		require.Equal(t, completionVariables, *completedJob.OutputVariables)
+	})
+
+	t.Run("With output mapping only mapped completion variables are propagated", func(t *testing.T) {
+		definitionKey := deployTestDataProcessDefinitionKey(t, "testdata/message_event/message-intermediate-throw-event-with-output-mapping.bpmn")
+		processVariables := map[string]any{
+			"payload":       "message-payload",
+			"correlationId": "correlation-456",
+			"unchanged":     "process-value",
+		}
+		processInstance, err := createProcessInstance(t, &definitionKey, processVariables)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		publicationJob := waitForProcessInstanceActiveJobByElementId(t, processInstance.Key, "message_throw_event")
+		expectedInputVariables := mergeMaps(processVariables, map[string]any{
+			"messagePayload":       "message-payload",
+			"messageCorrelationId": "correlation-456",
+		})
+		require.Equal(t, expectedInputVariables, publicationJob.InputVariables)
+		assertFlowElementInputVariables(t, processInstance.Key, "message_throw_event", processVariables)
+
+		completionVariables := map[string]any{
+			"deliveryId": "delivery-456",
+			"ignored":    "ignored-value",
+		}
+		require.NoError(t, completeJob(t, publicationJob.Key, completionVariables))
+
+		expectedOutputVariables := map[string]any{
+			"publicationResult": "delivery-456",
+		}
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertFlowElementOutputVariables(t, processInstance.Key, "message_throw_event", expectedOutputVariables)
+		assertProcessInstanceVariables(t, processInstance.Key, mergeMaps(processVariables, expectedOutputVariables))
+		completedJob := waitForProcessInstanceJobByElementId(t, processInstance.Key, "message_throw_event", public.JobStateCompleted)
+		require.Equal(t, completionVariables, *completedJob.OutputVariables)
+	})
+}

--- a/test/e2e/multi_instance_service_task_parallel_message_boundary_flow_test.go
+++ b/test/e2e/multi_instance_service_task_parallel_message_boundary_flow_test.go
@@ -1,0 +1,133 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParallelMultiInstanceMessageBoundaryFlow(t *testing.T) {
+	t.Run("Interrupting boundary message terminates all parallel iterations and completes the boundary path", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployInterruptingMessageBoundaryDefinition(
+			t,
+			"testdata/multi_instance/parallel_multi_instance_service_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"parallel-multi-instance-message-boundary-event-without-output-mapping",
+		)
+		instance, multiInstanceProcess := createMultiInstanceMessageBoundaryVariablesProcessInstance(t, definitionKey, multiInstanceMessageBoundaryCreateVariables())
+
+		waitForProcessInstanceActiveJobsByElementId(t, multiInstanceProcess.Key, "service_task", 3)
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateActive, multiInstanceProcess.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenStates(t, multiInstanceProcess.Key, "service_task", runtime.TokenStateWaiting, 3)
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_service_task",
+			"service_task",
+		})
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{
+			"service_task",
+			"service_task",
+			"service_task",
+		})
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateCompleted, multiInstanceProcess.Key, zenclient.ProcessInstanceStateTerminated)
+		waitForProcessInstanceJobByElementId(t, multiInstanceProcess.Key, "service_task", public.JobStateTerminated)
+		assertProcessInstanceHasNoActiveJobByElementId(t, multiInstanceProcess.Key, "service_task")
+		assertProcessInstanceTokenStates(t, multiInstanceProcess.Key, "service_task", runtime.TokenStateCanceled, 3)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_boundary")
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_main", 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{
+			"service_task",
+			"service_task",
+			"service_task",
+		})
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_service_task",
+			"service_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+		})
+	})
+
+	t.Run("Non-interrupting boundary message keeps parallel iterations active and completes both paths", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/multi_instance/parallel_multi_instance_service_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"parallel-multi-instance-message-boundary-event-without-output-mapping",
+		)
+		instance, multiInstanceProcess := createMultiInstanceMessageBoundaryVariablesProcessInstance(t, definitionKey, multiInstanceMessageBoundaryCreateVariables())
+
+		waitForProcessInstanceActiveJobsByElementId(t, multiInstanceProcess.Key, "service_task", 3)
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateActive, multiInstanceProcess.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenStates(t, multiInstanceProcess.Key, "service_task", runtime.TokenStateWaiting, 3)
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_service_task",
+			"service_task",
+		})
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{
+			"service_task",
+			"service_task",
+			"service_task",
+		})
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateActive, multiInstanceProcess.Key, zenclient.ProcessInstanceStateActive)
+		waitForProcessInstanceActiveJobsByElementId(t, multiInstanceProcess.Key, "service_task", 3)
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateCompleted, 1)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_service_task",
+			"service_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+		})
+
+		jobs := waitForProcessInstanceActiveJobsByElementId(t, multiInstanceProcess.Key, "service_task", 3)
+		for i, job := range jobs {
+			err = completeJob(t, job.Key, map[string]any{"testJobOutput": fmt.Sprintf("output-%d", i)})
+			require.NoError(t, err)
+		}
+
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateCompleted, multiInstanceProcess.Key, zenclient.ProcessInstanceStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_main", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{
+			"service_task",
+			"service_task",
+			"service_task",
+			"service_task",
+		})
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_service_task",
+			"service_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+			"flow_to_main_end",
+			"end_event_main",
+		})
+	})
+}

--- a/test/e2e/multi_instance_service_task_parallel_message_boundary_flow_test.go
+++ b/test/e2e/multi_instance_service_task_parallel_message_boundary_flow_test.go
@@ -117,7 +117,6 @@ func TestParallelMultiInstanceMessageBoundaryFlow(t *testing.T) {
 			"service_task",
 			"service_task",
 			"service_task",
-			"service_task",
 		})
 		assertExactProcessInstanceHistory(t, instance.Key, []string{
 			"start_event",

--- a/test/e2e/multi_instance_service_task_parallel_message_boundary_variables_test.go
+++ b/test/e2e/multi_instance_service_task_parallel_message_boundary_variables_test.go
@@ -1,0 +1,89 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParallelMultiInstanceMessageBoundaryVariables(t *testing.T) {
+	t.Run("Message boundary without output mapping propagates all message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/multi_instance/parallel_multi_instance_service_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"parallel-multi-instance-message-boundary-event-without-output-mapping",
+		)
+		processVariables := multiInstanceMessageBoundaryCreateVariables()
+		instance, multiInstanceProcess := createMultiInstanceMessageBoundaryVariablesProcessInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobsByElementId(t, multiInstanceProcess.Key, "service_task", 3)
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"overwritten": "message-value",
+			"unmapped":    "unmapped-value",
+			"numeric":     float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", messageVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(multiInstanceMessageBoundaryExpectedBaseVariables(), messageVariables))
+	})
+
+	t.Run("Message boundary with output mapping propagates only mapped message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/multi_instance/parallel_multi_instance_service_task_with_message_boundary_event_with_output_mapping.bpmn",
+			"parallel-multi-instance-message-boundary-event-with-output-mapping",
+		)
+		processVariables := multiInstanceMessageBoundaryCreateVariables()
+		instance, multiInstanceProcess := createMultiInstanceMessageBoundaryVariablesProcessInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobsByElementId(t, multiInstanceProcess.Key, "service_task", 3)
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"payload":  "mapped-value",
+			"unmapped": "ignored-value",
+			"numeric":  float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		expectedMappedVariables := map[string]any{"payload": "mapped-value"}
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", expectedMappedVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(multiInstanceMessageBoundaryExpectedBaseVariables(), expectedMappedVariables))
+	})
+}
+
+func createMultiInstanceMessageBoundaryVariablesProcessInstance(t testing.TB, definitionKey int64, variables map[string]any) (zenclient.ProcessInstance, zenclient.ProcessInstancesSimple) {
+	t.Helper()
+
+	processInstance := createProcessInstanceWithVariables(t, definitionKey, variables)
+	t.Cleanup(func() {
+		cleanupOwnedProcessInstance(t, processInstance.Key)
+	})
+	multiInstanceProcess := waitForChildProcessInstance(t, processInstance.Key, 0)
+	return processInstance, multiInstanceProcess
+}
+
+func multiInstanceMessageBoundaryCreateVariables() map[string]any {
+	return map[string]any{
+		"existing":            "process-value",
+		"overwritten":         "initial-value",
+		"testInputCollection": []string{"test1", "test2", "test3"},
+	}
+}
+
+func multiInstanceMessageBoundaryExpectedBaseVariables() map[string]any {
+	return map[string]any{
+		"existing":            "process-value",
+		"overwritten":         "initial-value",
+		"testInputCollection": []any{"test1", "test2", "test3"},
+	}
+}

--- a/test/e2e/multi_instance_service_task_sequential_message_boundary_flow_test.go
+++ b/test/e2e/multi_instance_service_task_sequential_message_boundary_flow_test.go
@@ -1,0 +1,119 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSequentialMultiInstanceMessageBoundaryFlow(t *testing.T) {
+	t.Run("Interrupting boundary message terminates the active sequential iteration and completes the boundary path", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployInterruptingMessageBoundaryDefinition(
+			t,
+			"testdata/multi_instance/sequential_multi_instance_service_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"sequential-multi-instance-message-boundary-event-without-output-mapping",
+		)
+		instance, multiInstanceProcess := createMultiInstanceMessageBoundaryVariablesProcessInstance(t, definitionKey, multiInstanceMessageBoundaryCreateVariables())
+
+		waitForProcessInstanceActiveJobByElementId(t, multiInstanceProcess.Key, "service_task")
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateActive, multiInstanceProcess.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, multiInstanceProcess.Key, "service_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_service_task",
+			"service_task",
+		})
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{"service_task"})
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateCompleted, multiInstanceProcess.Key, zenclient.ProcessInstanceStateTerminated)
+		waitForProcessInstanceJobByElementId(t, multiInstanceProcess.Key, "service_task", public.JobStateTerminated)
+		assertProcessInstanceHasNoActiveJobByElementId(t, multiInstanceProcess.Key, "service_task")
+		assertProcessInstanceTokenState(t, multiInstanceProcess.Key, "service_task", runtime.TokenStateCanceled)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_boundary")
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_main", 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{"service_task"})
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_service_task",
+			"service_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+		})
+	})
+
+	t.Run("Non-interrupting boundary message keeps sequential iterations active and completes both paths", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/multi_instance/sequential_multi_instance_service_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"sequential-multi-instance-message-boundary-event-without-output-mapping",
+		)
+		instance, multiInstanceProcess := createMultiInstanceMessageBoundaryVariablesProcessInstance(t, definitionKey, multiInstanceMessageBoundaryCreateVariables())
+
+		waitForProcessInstanceActiveJobByElementId(t, multiInstanceProcess.Key, "service_task")
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateActive, multiInstanceProcess.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, multiInstanceProcess.Key, "service_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_service_task",
+			"service_task",
+		})
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{"service_task"})
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateActive, multiInstanceProcess.Key, zenclient.ProcessInstanceStateActive)
+		waitForProcessInstanceActiveJobByElementId(t, multiInstanceProcess.Key, "service_task")
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateCompleted, 1)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_service_task",
+			"service_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+		})
+
+		for i := range 3 {
+			completeJobForElementId(t, multiInstanceProcess.Key, "service_task", map[string]any{"testJobOutput": fmt.Sprintf("output-%d", i)})
+		}
+
+		waitForTwoProcessInstanceStates(t, instance.Key, zenclient.ProcessInstanceStateCompleted, multiInstanceProcess.Key, zenclient.ProcessInstanceStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_main", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{
+			"service_task",
+			"service_task",
+			"service_task",
+			"service_task",
+		})
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_service_task",
+			"service_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+			"flow_to_main_end",
+			"end_event_main",
+		})
+	})
+}

--- a/test/e2e/multi_instance_service_task_sequential_message_boundary_flow_test.go
+++ b/test/e2e/multi_instance_service_task_sequential_message_boundary_flow_test.go
@@ -103,7 +103,6 @@ func TestSequentialMultiInstanceMessageBoundaryFlow(t *testing.T) {
 			"service_task",
 			"service_task",
 			"service_task",
-			"service_task",
 		})
 		assertExactProcessInstanceHistory(t, instance.Key, []string{
 			"start_event",

--- a/test/e2e/multi_instance_service_task_sequential_message_boundary_variables_test.go
+++ b/test/e2e/multi_instance_service_task_sequential_message_boundary_variables_test.go
@@ -1,0 +1,62 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSequentialMultiInstanceMessageBoundaryVariables(t *testing.T) {
+	t.Run("Message boundary without output mapping propagates all message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/multi_instance/sequential_multi_instance_service_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"sequential-multi-instance-message-boundary-event-without-output-mapping",
+		)
+		processVariables := multiInstanceMessageBoundaryCreateVariables()
+		instance, multiInstanceProcess := createMultiInstanceMessageBoundaryVariablesProcessInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobByElementId(t, multiInstanceProcess.Key, "service_task")
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"overwritten": "message-value",
+			"unmapped":    "unmapped-value",
+			"numeric":     float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", messageVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(multiInstanceMessageBoundaryExpectedBaseVariables(), messageVariables))
+	})
+
+	t.Run("Message boundary with output mapping propagates only mapped message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/multi_instance/sequential_multi_instance_service_task_with_message_boundary_event_with_output_mapping.bpmn",
+			"sequential-multi-instance-message-boundary-event-with-output-mapping",
+		)
+		processVariables := multiInstanceMessageBoundaryCreateVariables()
+		instance, multiInstanceProcess := createMultiInstanceMessageBoundaryVariablesProcessInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobByElementId(t, multiInstanceProcess.Key, "service_task")
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"payload":  "mapped-value",
+			"unmapped": "ignored-value",
+			"numeric":  float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		expectedMappedVariables := map[string]any{"payload": "mapped-value"}
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", expectedMappedVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(multiInstanceMessageBoundaryExpectedBaseVariables(), expectedMappedVariables))
+	})
+}

--- a/test/e2e/process_definition_test.go
+++ b/test/e2e/process_definition_test.go
@@ -348,14 +348,28 @@ func deployProcessDefinition(t testing.TB, filepath string) (replacedDefinitionI
 }
 
 func listProcessDefinitions(t testing.TB) ([]zenclient.ProcessDefinitionSimple, error) {
+	const pageSize int32 = 100
+	page := int32(1)
+	definitions := make([]zenclient.ProcessDefinitionSimple, 0)
 
-	resp, err := app.restClient.GetProcessDefinitionsWithResponse(t.Context(), &zenclient.GetProcessDefinitionsParams{
-		Size: new(int32(100)),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list process definitions: %w", err)
+	for {
+		resp, err := app.restClient.GetProcessDefinitionsWithResponse(t.Context(), &zenclient.GetProcessDefinitionsParams{
+			Page: &page,
+			Size: new(pageSize),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list process definitions page %d: %w", page, err)
+		}
+		if resp.JSON200 == nil {
+			return nil, fmt.Errorf("failed to list process definitions page %d: unexpected status %d", page, resp.StatusCode())
+		}
+
+		definitions = append(definitions, resp.JSON200.Items...)
+		if len(definitions) >= resp.JSON200.TotalCount || len(resp.JSON200.Items) == 0 {
+			return definitions, nil
+		}
+		page++
 	}
-	return resp.JSON200.Items, nil
 }
 
 func deployDefinitionFromBytes(t testing.TB, content []byte, filename string) (*zenclient.CreateProcessDefinitionResponse, error) {

--- a/test/e2e/send_task_message_boundary_flow_test.go
+++ b/test/e2e/send_task_message_boundary_flow_test.go
@@ -1,0 +1,103 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendTaskMessageBoundaryFlow(t *testing.T) {
+	t.Run("Interrupting boundary message cancels the send task and completes the boundary path", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployInterruptingMessageBoundaryDefinition(
+			t,
+			"testdata/send_task/send_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"send-task-message-boundary-event-without-output-mapping",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "send_task")
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "send_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "send_task", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_send_task",
+			"send_task",
+		})
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForProcessInstanceJobByElementId(t, instance.Key, "send_task", public.JobStateTerminated)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_boundary")
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_main", 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "send_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "send_task", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_send_task",
+			"send_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+		})
+	})
+
+	t.Run("Non-interrupting boundary message keeps the send task active and completes both paths", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/send_task/send_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"send-task-message-boundary-event-without-output-mapping",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "send_task")
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "send_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "send_task", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_send_task",
+			"send_task",
+		})
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "send_task")
+		assertProcessInstanceTokenState(t, instance.Key, "send_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "send_task", zenclient.EventSubscriptionStateCompleted, 1)
+		assertMessageSubscriptionStateCount(t, instance.Key, "send_task", zenclient.EventSubscriptionStateActive, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_send_task",
+			"send_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+		})
+
+		completeJobForElementId(t, instance.Key, "send_task", nil)
+
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_main", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "send_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "send_task", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_send_task",
+			"send_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+			"flow_to_main_end",
+			"end_event_main",
+		})
+	})
+}

--- a/test/e2e/send_task_message_boundary_variables_test.go
+++ b/test/e2e/send_task_message_boundary_variables_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendTaskMessageBoundaryVariables(t *testing.T) {
+	t.Run("Message boundary without output mapping propagates all message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/send_task/send_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"send-task-message-boundary-event-without-output-mapping",
+		)
+		processVariables := map[string]any{
+			"existing":    "process-value",
+			"overwritten": "initial-value",
+		}
+		instance := createMessageBoundaryVariablesInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "send_task")
+		assertMessageSubscriptionState(t, instance.Key, "send_task", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"overwritten": "message-value",
+			"unmapped":    "unmapped-value",
+			"numeric":     float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", messageVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(processVariables, messageVariables))
+
+		completeJobForElementId(t, instance.Key, "send_task", nil)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+	})
+
+	t.Run("Message boundary with output mapping propagates only mapped message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/send_task/send_task_with_message_boundary_event_with_output_mapping.bpmn",
+			"send-task-message-boundary-event-with-output-mapping",
+		)
+		processVariables := map[string]any{"existing": "process-value"}
+		instance := createMessageBoundaryVariablesInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "send_task")
+		assertMessageSubscriptionState(t, instance.Key, "send_task", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"payload":  "mapped-value",
+			"unmapped": "ignored-value",
+			"numeric":  float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		expectedMappedVariables := map[string]any{"payload": "mapped-value"}
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", expectedMappedVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(processVariables, expectedMappedVariables))
+
+		completeJobForElementId(t, instance.Key, "send_task", nil)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+	})
+}

--- a/test/e2e/service_task_message_boundary_event_flow_test.go
+++ b/test/e2e/service_task_message_boundary_event_flow_test.go
@@ -1,0 +1,363 @@
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageBoundaryEventFlow(t *testing.T) {
+	t.Run("interrupting boundary message cancels the activity and completes the boundary path", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(t, "testdata/service_task/service_task_with_message_boundary_event_interrupting.bpmn", "message-boundary-event-interrupting")
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "service_task")
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{"payload": "interrupting-boundary"})
+		require.NoError(t, err)
+
+		waitForProcessInstanceJobByElementId(t, instance.Key, "service_task", public.JobStateTerminated)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_boundary")
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 0)
+		assertProcessInstanceVariables(t, instance.Key, map[string]any{"payload": "interrupting-boundary"})
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+
+		response, err := publishMessageWithResponse(t, messageName, correlationKey, &map[string]any{"payload": "duplicate-boundary"})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, response.StatusCode())
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"StartEvent_1",
+			"Flow_17cg00h",
+			"service_task",
+			"message_boundary_event",
+			"Flow_14sh6sh",
+			"end_event_boundary",
+		})
+	})
+
+	t.Run("message A completes interrupting boundary B and cancels boundary A", func(t *testing.T) {
+		definitionKey, messageAName, correlationKeyA, messageBName, correlationKeyB := deployTwoMessageBoundaryDefinition(
+			t,
+			"testdata/service_task/service_task_with_message_boundary_event_two_interrupting.bpmn",
+			"two-message-boundary-event-interrupting",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "service_task")
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 2)
+
+		err := publishMessage(t, messageAName, correlationKeyA, &map[string]any{"payloadB": "message-a"})
+		require.NoError(t, err)
+
+		waitForProcessInstanceJobByElementId(t, instance.Key, "service_task", public.JobStateTerminated)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_boundary_b")
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateCompleted, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateTerminated, 2)
+		assertProcessInstanceVariables(t, instance.Key, map[string]any{"payloadB": "message-a"})
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary_b", runtime.TokenStateCompleted)
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_boundary_a", 0)
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_main", 0)
+
+		response, err := publishMessageWithResponse(t, messageBName, correlationKeyB, &map[string]any{})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, response.StatusCode())
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"StartEvent_1",
+			"Flow_17cg00h",
+			"service_task",
+			"boundary_message_event_b",
+			"Flow_0nzuzj2",
+			"end_event_boundary_b",
+		})
+	})
+
+	t.Run("message B completes interrupting boundary A and cancels boundary B", func(t *testing.T) {
+		definitionKey, messageAName, correlationKeyA, messageBName, correlationKeyB := deployTwoMessageBoundaryDefinition(
+			t,
+			"testdata/service_task/service_task_with_message_boundary_event_two_interrupting.bpmn",
+			"two-message-boundary-event-interrupting",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "service_task")
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 2)
+
+		err := publishMessage(t, messageBName, correlationKeyB, &map[string]any{"payloadA": "message-b"})
+		require.NoError(t, err)
+
+		waitForProcessInstanceJobByElementId(t, instance.Key, "service_task", public.JobStateTerminated)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_boundary_a")
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateCompleted, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateTerminated, 2)
+		assertProcessInstanceVariables(t, instance.Key, map[string]any{"payloadA": "message-b"})
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary_a", runtime.TokenStateCompleted)
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_boundary_b", 0)
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_main", 0)
+
+		response, err := publishMessageWithResponse(t, messageAName, correlationKeyA, &map[string]any{})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, response.StatusCode())
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"StartEvent_1",
+			"Flow_17cg00h",
+			"service_task",
+			"boundary_message_event_a",
+			"Flow_14sh6sh",
+			"end_event_boundary_a",
+		})
+	})
+
+	t.Run("message after activity completion is rejected because the subscription is cancelled", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(t, "testdata/service_task/service_task_with_message_boundary_event_noninterrupting.bpmn", "message-boundary-event-noninterrupting")
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "service_task")
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+
+		completeJobForElementId(t, instance.Key, "service_task", nil)
+
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_main", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateTerminated, 1)
+
+		response, err := publishMessageWithResponse(t, messageName, correlationKey, &map[string]any{"payload": "late-boundary"})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, response.StatusCode())
+
+		assertProcessInstanceTokenCount(t, instance.Key, "boundary_message_event", 0)
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_boundary", 0)
+		assertProcessInstanceVariables(t, instance.Key, map[string]any{})
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"StartEvent_1",
+			"Flow_17cg00h",
+			"service_task",
+			"Flow_1gnes9r",
+			"end_event_main",
+		})
+	})
+
+	t.Run("non-interrupting boundary message can fire repeatedly while the activity remains active", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(t, "testdata/service_task/service_task_with_message_boundary_event_noninterrupting.bpmn", "message-boundary-event-noninterrupting")
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "service_task")
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 1)
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{"payload": "first-boundary"})
+		require.NoError(t, err)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "service_task")
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenStates(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted, 1)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateCompleted, 1)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 1)
+		assertProcessInstanceVariables(t, instance.Key, map[string]any{"payload": "first-boundary"})
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"StartEvent_1",
+			"Flow_17cg00h",
+			"service_task",
+			"boundary_message_event",
+			"Flow_14sh6sh",
+			"end_event_boundary",
+		})
+
+		err = publishMessage(t, messageName, correlationKey, &map[string]any{"payload": "second-boundary"})
+		require.NoError(t, err)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "service_task")
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenStates(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted, 2)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateCompleted, 2)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 1)
+		assertProcessInstanceVariables(t, instance.Key, map[string]any{"payload": "second-boundary"})
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"StartEvent_1",
+			"Flow_17cg00h",
+			"service_task",
+			"boundary_message_event",
+			"Flow_14sh6sh",
+			"end_event_boundary",
+			"boundary_message_event",
+			"Flow_14sh6sh",
+			"end_event_boundary",
+		})
+
+		completeJobForElementId(t, instance.Key, "service_task", nil)
+
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateTerminated, 1)
+		assertProcessInstanceTokenStates(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted, 2)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_main", runtime.TokenStateCompleted)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"StartEvent_1",
+			"Flow_17cg00h",
+			"service_task",
+			"boundary_message_event",
+			"Flow_14sh6sh",
+			"end_event_boundary",
+			"boundary_message_event",
+			"Flow_14sh6sh",
+			"end_event_boundary",
+			"Flow_1gnes9r",
+			"end_event_main",
+		})
+	})
+
+	t.Run("multiple non-interrupting boundary messages can fire independently while the activity remains active", func(t *testing.T) {
+		definitionKey, messageAName, correlationKeyA, messageBName, correlationKeyB := deployTwoMessageBoundaryDefinition(
+			t,
+			"testdata/service_task/service_task_with_message_boundary_event_two_noninterrupting.bpmn",
+			"two-message-boundary-event-noninterrupting",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "service_task")
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 2)
+
+		// first boundary message (A)
+		err := publishMessage(t, messageAName, correlationKeyA, &map[string]any{"payloadB": "message-a"})
+		require.NoError(t, err)
+
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary_b", runtime.TokenStateCompleted)
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_boundary_a", 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateCompleted, 1)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 2)
+		assertProcessInstanceVariables(t, instance.Key, map[string]any{"payloadB": "message-a"})
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"StartEvent_1",
+			"Flow_17cg00h",
+			"service_task",
+			"boundary_message_event_b",
+			"Flow_0nzuzj2",
+			"end_event_boundary_b",
+		})
+
+		// first boundary message (B)
+		err = publishMessage(t, messageBName, correlationKeyB, &map[string]any{"payloadA": "message-b"})
+		require.NoError(t, err)
+
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "service_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary_a", runtime.TokenStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary_b", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateCompleted, 2)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 2)
+		assertProcessInstanceVariables(t, instance.Key, map[string]any{
+			"payloadA": "message-b",
+			"payloadB": "message-a",
+		})
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"StartEvent_1",
+			"Flow_17cg00h",
+			"service_task",
+			"boundary_message_event_b",
+			"Flow_0nzuzj2",
+			"end_event_boundary_b",
+			"boundary_message_event_a",
+			"Flow_14sh6sh",
+			"end_event_boundary_a",
+		})
+
+		completeJobForElementId(t, instance.Key, "service_task", nil)
+
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "service_task", zenclient.EventSubscriptionStateTerminated, 2)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary_a", runtime.TokenStateCompleted)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary_b", runtime.TokenStateCompleted)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"StartEvent_1",
+			"Flow_17cg00h",
+			"service_task",
+			"boundary_message_event_b",
+			"Flow_0nzuzj2",
+			"end_event_boundary_b",
+			"boundary_message_event_a",
+			"Flow_14sh6sh",
+			"end_event_boundary_a",
+			"Flow_1gnes9r",
+			"end_event_main",
+		})
+	})
+}
+
+func deployMessageBoundaryDefinition(t testing.TB, filename string, baseProcessID string) (int64, string, string) {
+	return deployMessageBoundaryDefinitionWithInterrupting(t, filename, baseProcessID, false)
+}
+
+func deployInterruptingMessageBoundaryDefinition(t testing.TB, filename string, baseProcessID string) (int64, string, string) {
+	return deployMessageBoundaryDefinitionWithInterrupting(t, filename, baseProcessID, true)
+}
+
+func deployMessageBoundaryDefinitionWithInterrupting(t testing.TB, filename string, baseProcessID string, interrupting bool) (int64, string, string) {
+	t.Helper()
+
+	suffix := messageEventTestSuffix()
+	processID := fmt.Sprintf("%s-%d", baseProcessID, suffix)
+	messageName := fmt.Sprintf("%s-ref-%d", baseProcessID, suffix)
+	correlationKey := fmt.Sprintf("%s-key-%d", baseProcessID, suffix)
+	content := string(readBPMNTestCaseFile(t, filename))
+	if interrupting {
+		content = strings.Replace(content, `cancelActivity="false"`, `cancelActivity="true"`, 1)
+	}
+	content = strings.NewReplacer(
+		fmt.Sprintf(`bpmn:process id="%s"`, baseProcessID), fmt.Sprintf(`bpmn:process id="%s"`, processID),
+		`name="message"`, fmt.Sprintf(`name="%s"`, messageName),
+		`correlationKey="=&#34;message-boundary-event-interruptingCorrelationKey&#34;"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKey),
+		`correlationKey="=correlationKey"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKey),
+	).Replace(content)
+
+	return deployBPMNTestCaseContent(t, filename, []byte(content)), messageName, correlationKey
+}
+
+func deployTwoMessageBoundaryDefinition(t testing.TB, filename string, baseProcessID string) (int64, string, string, string, string) {
+	t.Helper()
+
+	suffix := messageEventTestSuffix()
+	processID := fmt.Sprintf("%s-%d", baseProcessID, suffix)
+	messageAName := fmt.Sprintf("%s-a-ref-%d", baseProcessID, suffix)
+	messageBName := fmt.Sprintf("%s-b-ref-%d", baseProcessID, suffix)
+	correlationKeyA := fmt.Sprintf("%s-a-key-%d", baseProcessID, suffix)
+	correlationKeyB := fmt.Sprintf("%s-b-key-%d", baseProcessID, suffix)
+	content := strings.NewReplacer(
+		fmt.Sprintf(`bpmn:process id="%s"`, baseProcessID), fmt.Sprintf(`bpmn:process id="%s"`, processID),
+		`name="messageA"`, fmt.Sprintf(`name="%s"`, messageAName),
+		`name="messageB"`, fmt.Sprintf(`name="%s"`, messageBName),
+		`correlationKey="=correlationKeyA"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKeyA),
+		`correlationKey="=correlationKeyB"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKeyB),
+	).Replace(string(readBPMNTestCaseFile(t, filename)))
+
+	definitionKey := deployBPMNTestCaseContent(t, filename, []byte(content))
+	return definitionKey, messageAName, correlationKeyA, messageBName, correlationKeyB
+}
+
+func createMessageBoundaryInstance(t testing.TB, definitionKey int64) zenclient.ProcessInstance {
+	t.Helper()
+
+	processInstance, err := createProcessInstance(t, &definitionKey, map[string]any{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupOwnedProcessInstance(t, processInstance.Key)
+	})
+	return processInstance
+}

--- a/test/e2e/service_task_message_boundary_event_flow_test.go
+++ b/test/e2e/service_task_message_boundary_event_flow_test.go
@@ -1,9 +1,7 @@
 package e2e
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/pbinitiative/zenbpm/internal/rest/public"
@@ -299,65 +297,4 @@ func TestMessageBoundaryEventFlow(t *testing.T) {
 			"end_event_main",
 		})
 	})
-}
-
-func deployMessageBoundaryDefinition(t testing.TB, filename string, baseProcessID string) (int64, string, string) {
-	return deployMessageBoundaryDefinitionWithInterrupting(t, filename, baseProcessID, false)
-}
-
-func deployInterruptingMessageBoundaryDefinition(t testing.TB, filename string, baseProcessID string) (int64, string, string) {
-	return deployMessageBoundaryDefinitionWithInterrupting(t, filename, baseProcessID, true)
-}
-
-func deployMessageBoundaryDefinitionWithInterrupting(t testing.TB, filename string, baseProcessID string, interrupting bool) (int64, string, string) {
-	t.Helper()
-
-	suffix := messageEventTestSuffix()
-	processID := fmt.Sprintf("%s-%d", baseProcessID, suffix)
-	messageName := fmt.Sprintf("%s-ref-%d", baseProcessID, suffix)
-	correlationKey := fmt.Sprintf("%s-key-%d", baseProcessID, suffix)
-	content := string(readBPMNTestCaseFile(t, filename))
-	if interrupting {
-		content = strings.Replace(content, `cancelActivity="false"`, `cancelActivity="true"`, 1)
-	}
-	content = strings.NewReplacer(
-		fmt.Sprintf(`bpmn:process id="%s"`, baseProcessID), fmt.Sprintf(`bpmn:process id="%s"`, processID),
-		`name="message"`, fmt.Sprintf(`name="%s"`, messageName),
-		`correlationKey="=&#34;message-boundary-event-interruptingCorrelationKey&#34;"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKey),
-		`correlationKey="=correlationKey"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKey),
-	).Replace(content)
-
-	return deployBPMNTestCaseContent(t, filename, []byte(content)), messageName, correlationKey
-}
-
-func deployTwoMessageBoundaryDefinition(t testing.TB, filename string, baseProcessID string) (int64, string, string, string, string) {
-	t.Helper()
-
-	suffix := messageEventTestSuffix()
-	processID := fmt.Sprintf("%s-%d", baseProcessID, suffix)
-	messageAName := fmt.Sprintf("%s-a-ref-%d", baseProcessID, suffix)
-	messageBName := fmt.Sprintf("%s-b-ref-%d", baseProcessID, suffix)
-	correlationKeyA := fmt.Sprintf("%s-a-key-%d", baseProcessID, suffix)
-	correlationKeyB := fmt.Sprintf("%s-b-key-%d", baseProcessID, suffix)
-	content := strings.NewReplacer(
-		fmt.Sprintf(`bpmn:process id="%s"`, baseProcessID), fmt.Sprintf(`bpmn:process id="%s"`, processID),
-		`name="messageA"`, fmt.Sprintf(`name="%s"`, messageAName),
-		`name="messageB"`, fmt.Sprintf(`name="%s"`, messageBName),
-		`correlationKey="=correlationKeyA"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKeyA),
-		`correlationKey="=correlationKeyB"`, fmt.Sprintf(`correlationKey="=&#34;%s&#34;"`, correlationKeyB),
-	).Replace(string(readBPMNTestCaseFile(t, filename)))
-
-	definitionKey := deployBPMNTestCaseContent(t, filename, []byte(content))
-	return definitionKey, messageAName, correlationKeyA, messageBName, correlationKeyB
-}
-
-func createMessageBoundaryInstance(t testing.TB, definitionKey int64) zenclient.ProcessInstance {
-	t.Helper()
-
-	processInstance, err := createProcessInstance(t, &definitionKey, map[string]any{})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		cleanupOwnedProcessInstance(t, processInstance.Key)
-	})
-	return processInstance
 }

--- a/test/e2e/service_task_message_boundary_variables_test.go
+++ b/test/e2e/service_task_message_boundary_variables_test.go
@@ -1,0 +1,82 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceTaskMessageBoundaryVariables(t *testing.T) {
+	t.Run("Message boundary without output mapping propagates all message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/service_task/service_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"message-boundary-event-without-output-mapping",
+		)
+		processVariables := map[string]any{
+			"existing":    "process-value",
+			"overwritten": "initial-value",
+		}
+		instance := createMessageBoundaryVariablesInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "service_task")
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"overwritten": "message-value",
+			"unmapped":    "unmapped-value",
+			"numeric":     float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", messageVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(processVariables, messageVariables))
+
+		completeJobForElementId(t, instance.Key, "service_task", nil)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+	})
+
+	t.Run("Message boundary with output mapping propagates only mapped message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/service_task/service_task_with_message_boundary_event_noninterrupting.bpmn",
+			"message-boundary-event-noninterrupting",
+		)
+		processVariables := map[string]any{"existing": "process-value"}
+		instance := createMessageBoundaryVariablesInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "service_task")
+		assertMessageSubscriptionState(t, instance.Key, "service_task", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"payload":  "mapped-value",
+			"unmapped": "ignored-value",
+			"numeric":  float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		expectedMappedVariables := map[string]any{"payload": "mapped-value"}
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", expectedMappedVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(processVariables, expectedMappedVariables))
+
+		completeJobForElementId(t, instance.Key, "service_task", nil)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+	})
+}
+
+func createMessageBoundaryVariablesInstance(t testing.TB, definitionKey int64, variables map[string]any) zenclient.ProcessInstance {
+	t.Helper()
+
+	processInstance, err := createProcessInstance(t, &definitionKey, variables)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupOwnedProcessInstance(t, processInstance.Key)
+	})
+	return processInstance
+}

--- a/test/e2e/testdata/business_rule/business_rule_task_external_with_message_boundary_event_with_output_mapping.bpmn
+++ b/test/e2e/testdata/business_rule/business_rule_task_external_with_message_boundary_event_with_output_mapping.bpmn
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_business_rule_message_boundary_with_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="business-rule-message-boundary-event-with-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_business_rule</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_business_rule" sourceRef="start_event" targetRef="business_rule" />
+    <bpmn:businessRuleTask id="business_rule">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="business-rule-message-boundary-test" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_business_rule</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="business_rule" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="business_rule">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=payload" target="payload" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="business-rule-message-boundary-event-with-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="business_rule_di" bpmnElement="business_rule">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_business_rule_di" bpmnElement="flow_to_business_rule">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/business_rule/business_rule_task_external_with_message_boundary_event_without_output_mapping.bpmn
+++ b/test/e2e/testdata/business_rule/business_rule_task_external_with_message_boundary_event_without_output_mapping.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_business_rule_message_boundary_without_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="business-rule-message-boundary-event-without-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_business_rule</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_business_rule" sourceRef="start_event" targetRef="business_rule" />
+    <bpmn:businessRuleTask id="business_rule">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="business-rule-message-boundary-test" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_business_rule</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="business_rule" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="business_rule">
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="business-rule-message-boundary-event-without-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="business_rule_di" bpmnElement="business_rule">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_business_rule_di" bpmnElement="flow_to_business_rule">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/call_activity/call_activity_with_message_boundary_event_with_output_mapping.bpmn
+++ b/test/e2e/testdata/call_activity/call_activity_with_message_boundary_event_with_output_mapping.bpmn
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_call_activity_message_boundary_with_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="call-activity-message-boundary-event-with-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_call_activity</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_call_activity" sourceRef="start_event" targetRef="call_activity" />
+    <bpmn:callActivity id="call_activity">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="simple_task_for_call_activity_error_boundary_event" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_call_activity</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="call_activity" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="call_activity">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=payload" target="payload" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="call-activity-message-boundary-event-with-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="call_activity_di" bpmnElement="call_activity">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_call_activity_di" bpmnElement="flow_to_call_activity">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/call_activity/call_activity_with_message_boundary_event_without_output_mapping.bpmn
+++ b/test/e2e/testdata/call_activity/call_activity_with_message_boundary_event_without_output_mapping.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_call_activity_message_boundary_without_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="call-activity-message-boundary-event-without-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_call_activity</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_call_activity" sourceRef="start_event" targetRef="call_activity" />
+    <bpmn:callActivity id="call_activity">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="simple_task_for_call_activity_error_boundary_event" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_call_activity</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="call_activity" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="call_activity">
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="call-activity-message-boundary-event-without-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="call_activity_di" bpmnElement="call_activity">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_call_activity_di" bpmnElement="flow_to_call_activity">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/message_end_event/message_end_event.bpmn
+++ b/test/e2e/testdata/message_end_event/message_end_event.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_message_end_event" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="message_end_event" name="message_end_event" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0cgyiyy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0cgyiyy" sourceRef="StartEvent_1" targetRef="Event_11flm9z" />
+    <bpmn:endEvent id="Event_11flm9z">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="message-end-event-task-1" retries="5" />
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=&#34;beijing&#34;" target="city" />
+          <zenbpm:output source="=city" target="newCity" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0cgyiyy</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_19u9ka1" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_message_end_event">
+    <bpmndi:BPMNPlane id="BPMNPlane_message_end_event" bpmnElement="message_end_event">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11flm9z_di" bpmnElement="Event_11flm9z">
+        <dc:Bounds x="342" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0cgyiyy_di" bpmnElement="Flow_0cgyiyy">
+        <di:waypoint x="218" y="100" />
+        <di:waypoint x="342" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/message_end_event/message_end_event_parallel.bpmn
+++ b/test/e2e/testdata/message_end_event/message_end_event_parallel.bpmn
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_message_end_event_parallel" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="message_end_event_parallel" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_start_to_split</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_to_split" sourceRef="start_event" targetRef="parallel_split" />
+    <bpmn:parallelGateway id="parallel_split">
+      <bpmn:incoming>Flow_start_to_split</bpmn:incoming>
+      <bpmn:outgoing>Flow_split_to_message_end</bpmn:outgoing>
+      <bpmn:outgoing>Flow_split_to_parallel_task</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_split_to_message_end" sourceRef="parallel_split" targetRef="message_end_event" />
+    <bpmn:endEvent id="message_end_event">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="orders.completed.parallel" />
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=businessKey" target="correlationId" />
+          <zenbpm:input source="=messageId" target="messageId" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_split_to_message_end</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_parallel" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_split_to_parallel_task" sourceRef="parallel_split" targetRef="parallel_task" />
+    <bpmn:serviceTask id="parallel_task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="message-end-event-parallel-task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_split_to_parallel_task</bpmn:incoming>
+      <bpmn:outgoing>Flow_parallel_task_to_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_parallel_task_to_end" sourceRef="parallel_task" targetRef="parallel_end_event" />
+    <bpmn:endEvent id="parallel_end_event">
+      <bpmn:incoming>Flow_parallel_task_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_message_end_event_parallel">
+    <bpmndi:BPMNPlane id="BPMNPlane_message_end_event_parallel" bpmnElement="message_end_event_parallel">
+      <bpmndi:BPMNShape id="parallel_start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="120" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="parallel_split_di" bpmnElement="parallel_split">
+        <dc:Bounds x="220" y="153" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="parallel_message_end_event_di" bpmnElement="message_end_event">
+        <dc:Bounds x="420" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="parallel_task_di" bpmnElement="parallel_task">
+        <dc:Bounds x="350" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="parallel_end_event_di" bpmnElement="parallel_end_event">
+        <dc:Bounds x="520" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_start_to_split_di" bpmnElement="Flow_start_to_split">
+        <di:waypoint x="156" y="178" />
+        <di:waypoint x="220" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_split_to_message_end_di" bpmnElement="Flow_split_to_message_end">
+        <di:waypoint x="245" y="153" />
+        <di:waypoint x="245" y="120" />
+        <di:waypoint x="420" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_split_to_parallel_task_di" bpmnElement="Flow_split_to_parallel_task">
+        <di:waypoint x="245" y="203" />
+        <di:waypoint x="245" y="260" />
+        <di:waypoint x="350" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_parallel_task_to_end_di" bpmnElement="Flow_parallel_task_to_end">
+        <di:waypoint x="450" y="260" />
+        <di:waypoint x="520" y="260" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/message_end_event/message_end_event_payload.bpmn
+++ b/test/e2e/testdata/message_end_event/message_end_event_payload.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_message_end_event_payload" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="message_end_event_payload" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_start_to_prepare</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_to_prepare" sourceRef="start_event" targetRef="prepare_publication" />
+    <bpmn:serviceTask id="prepare_publication">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="message-end-event-prepare" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_to_prepare</bpmn:incoming>
+      <bpmn:outgoing>Flow_prepare_to_message_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_prepare_to_message_end" sourceRef="prepare_publication" targetRef="message_end_event" />
+    <bpmn:endEvent id="message_end_event">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="orders.completed" retries="3" />
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=orderId" target="orderId" />
+          <zenbpm:input source="=amount" target="amount" />
+          <zenbpm:input source="=approved" target="approved" />
+          <zenbpm:input source="=businessKey" target="correlationId" />
+          <zenbpm:input source="=messageId" target="messageId" />
+          <zenbpm:input source="=customerName" target="customerName" />
+          <zenbpm:input source="=occurredAt" target="occurredAt" />
+          <zenbpm:input source="=optionalNote" target="optionalNote" />
+          <zenbpm:input source="=&#34;order.completed&#34;" target="messageType" />
+          <zenbpm:input source="=occurredAt" target="emittedAt" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_prepare_to_message_end</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_payload" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_message_end_event_payload">
+    <bpmndi:BPMNPlane id="BPMNPlane_message_end_event_payload" bpmnElement="message_end_event_payload">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="120" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="prepare_publication_di" bpmnElement="prepare_publication">
+        <dc:Bounds x="250" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="message_end_event_di" bpmnElement="message_end_event">
+        <dc:Bounds x="410" y="120" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_start_to_prepare_di" bpmnElement="Flow_start_to_prepare">
+        <di:waypoint x="186" y="138" />
+        <di:waypoint x="250" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_prepare_to_message_end_di" bpmnElement="Flow_prepare_to_message_end">
+        <di:waypoint x="350" y="138" />
+        <di:waypoint x="410" y="138" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/message_end_event/message_end_event_subprocess.bpmn
+++ b/test/e2e/testdata/message_end_event/message_end_event_subprocess.bpmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_message_end_event_subprocess" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="message_end_event_subprocess" isExecutable="true">
+    <bpmn:startEvent id="parent_start">
+      <bpmn:outgoing>Flow_parent_start_to_subprocess</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_parent_start_to_subprocess" sourceRef="parent_start" targetRef="message_subprocess" />
+    <bpmn:subProcess id="message_subprocess">
+      <bpmn:incoming>Flow_parent_start_to_subprocess</bpmn:incoming>
+      <bpmn:outgoing>Flow_subprocess_to_followup</bpmn:outgoing>
+      <bpmn:startEvent id="subprocess_start">
+        <bpmn:outgoing>Flow_subprocess_start_to_message_end</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_subprocess_start_to_message_end" sourceRef="subprocess_start" targetRef="subprocess_message_end" />
+      <bpmn:endEvent id="subprocess_message_end">
+        <bpmn:extensionElements>
+          <zenbpm:taskDefinition type="orders.completed.subprocess" />
+          <zenbpm:ioMapping>
+            <zenbpm:input source="=businessKey" target="correlationId" />
+            <zenbpm:input source="=messageId" target="messageId" />
+          </zenbpm:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_subprocess_start_to_message_end</bpmn:incoming>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_subprocess" />
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_subprocess_to_followup" sourceRef="message_subprocess" targetRef="parent_followup" />
+    <bpmn:serviceTask id="parent_followup">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="message-end-event-parent-followup" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_subprocess_to_followup</bpmn:incoming>
+      <bpmn:outgoing>Flow_followup_to_parent_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_followup_to_parent_end" sourceRef="parent_followup" targetRef="parent_end" />
+    <bpmn:endEvent id="parent_end">
+      <bpmn:incoming>Flow_followup_to_parent_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_message_end_event_subprocess">
+    <bpmndi:BPMNPlane id="BPMNPlane_message_end_event_subprocess" bpmnElement="message_end_event_subprocess">
+      <bpmndi:BPMNShape id="parent_start_di" bpmnElement="parent_start">
+        <dc:Bounds x="120" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="message_subprocess_di" bpmnElement="message_subprocess" isExpanded="true">
+        <dc:Bounds x="220" y="80" width="350" height="220" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess_start_di" bpmnElement="subprocess_start">
+        <dc:Bounds x="260" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess_message_end_di" bpmnElement="subprocess_message_end">
+        <dc:Bounds x="460" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="parent_followup_di" bpmnElement="parent_followup">
+        <dc:Bounds x="650" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="parent_end_di" bpmnElement="parent_end">
+        <dc:Bounds x="830" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_parent_start_to_subprocess_di" bpmnElement="Flow_parent_start_to_subprocess">
+        <di:waypoint x="156" y="190" />
+        <di:waypoint x="220" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_subprocess_start_to_message_end_di" bpmnElement="Flow_subprocess_start_to_message_end">
+        <di:waypoint x="296" y="190" />
+        <di:waypoint x="460" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_subprocess_to_followup_di" bpmnElement="Flow_subprocess_to_followup">
+        <di:waypoint x="570" y="190" />
+        <di:waypoint x="650" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_followup_to_parent_end_di" bpmnElement="Flow_followup_to_parent_end">
+        <di:waypoint x="750" y="190" />
+        <di:waypoint x="830" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/message_event/message-intermediate-catch-event.bpmn
+++ b/test/e2e/testdata/message_event/message-intermediate-catch-event.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_1yacw8n" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="message-intermediate-catch-event" name="message-intermediate-catch-event" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1emdqir</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1emdqir" sourceRef="StartEvent_1" targetRef="id-1" />
+    <bpmn:endEvent id="Event_1jn3jqk">
+      <bpmn:incoming>Flow_17o1t76</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_17o1t76" sourceRef="id-1" targetRef="Event_1jn3jqk" />
+    <bpmn:intermediateCatchEvent id="id-1" name="event-1">
+      <bpmn:incoming>Flow_1emdqir</bpmn:incoming>
+      <bpmn:outgoing>Flow_17o1t76</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0rlwnn9" messageRef="Message_20u95p8" />
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_20u95p8" name="globalMsgRef">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=&#34;correlation-key-one&#34;" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="message-intermediate-catch-event">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1jn3jqk_di" bpmnElement="Event_1jn3jqk">
+        <dc:Bounds x="372" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0aiqv3r_di" bpmnElement="id-1">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="122" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1emdqir_di" bpmnElement="Flow_1emdqir">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="272" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17o1t76_di" bpmnElement="Flow_17o1t76">
+        <di:waypoint x="308" y="97" />
+        <di:waypoint x="372" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/message_event/message-intermediate-throw-event-with-output-mapping.bpmn
+++ b/test/e2e/testdata/message_event/message-intermediate-throw-event-with-output-mapping.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_message_intermediate_throw_with_output" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="message-intermediate-throw-with-output" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_start_to_throw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_to_throw" sourceRef="start_event" targetRef="message_throw_event" />
+    <bpmn:intermediateThrowEvent id="message_throw_event">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="message-intermediate-throw" retries="3" />
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=payload" target="messagePayload" />
+          <zenbpm:input source="=correlationId" target="messageCorrelationId" />
+          <zenbpm:output source="=deliveryId" target="publicationResult" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_to_throw</bpmn:incoming>
+      <bpmn:outgoing>Flow_throw_to_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_definition" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_throw_to_end" sourceRef="message_throw_event" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>Flow_throw_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_message_intermediate_throw_with_output">
+    <bpmndi:BPMNPlane id="BPMNPlane_message_intermediate_throw_with_output" bpmnElement="message-intermediate-throw-with-output">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="160" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="message_throw_event_di" bpmnElement="message_throw_event">
+        <dc:Bounds x="270" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_di" bpmnElement="end_event">
+        <dc:Bounds x="380" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_start_to_throw_di" bpmnElement="Flow_start_to_throw">
+        <di:waypoint x="196" y="118" />
+        <di:waypoint x="270" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_throw_to_end_di" bpmnElement="Flow_throw_to_end">
+        <di:waypoint x="306" y="118" />
+        <di:waypoint x="380" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/message_event/message-intermediate-throw-event-without-output-mapping.bpmn
+++ b/test/e2e/testdata/message_event/message-intermediate-throw-event-without-output-mapping.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_message_intermediate_throw_without_output" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="message-intermediate-throw-without-output" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_start_to_throw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_to_throw" sourceRef="start_event" targetRef="message_throw_event" />
+    <bpmn:intermediateThrowEvent id="message_throw_event">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="message-intermediate-throw" retries="3" />
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=payload" target="messagePayload" />
+          <zenbpm:input source="=correlationId" target="messageCorrelationId" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_to_throw</bpmn:incoming>
+      <bpmn:outgoing>Flow_throw_to_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_definition" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_throw_to_end" sourceRef="message_throw_event" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>Flow_throw_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_message_intermediate_throw_without_output">
+    <bpmndi:BPMNPlane id="BPMNPlane_message_intermediate_throw_without_output" bpmnElement="message-intermediate-throw-without-output">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="160" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="message_throw_event_di" bpmnElement="message_throw_event">
+        <dc:Bounds x="270" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_di" bpmnElement="end_event">
+        <dc:Bounds x="380" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_start_to_throw_di" bpmnElement="Flow_start_to_throw">
+        <di:waypoint x="196" y="118" />
+        <di:waypoint x="270" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_throw_to_end_di" bpmnElement="Flow_throw_to_end">
+        <di:waypoint x="306" y="118" />
+        <di:waypoint x="380" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/message_event/message-start-event-process.bpmn
+++ b/test/e2e/testdata/message_event/message-start-event-process.bpmn
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_0govd51" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="message-start-event-process-1" isExecutable="true">
+    <bpmn:endEvent id="Event_0461t71">
+      <bpmn:incoming>Flow_0rvswpk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1xx1ap4" sourceRef="messageStartEvent_1234" targetRef="service-task-1" />
+    <bpmn:startEvent id="messageStartEvent_1234">
+      <bpmn:extensionElements />
+      <bpmn:outgoing>Flow_1xx1ap4</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1oofo2d" messageRef="Message_0d37bgs" />
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="service-task-1" name="service-task-1">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=&#34;task-1&#34;" target="name" />
+          <zenbpm:input source="=1" target="id" />
+          <zenbpm:input source="=&#34;beijing&#34;" target="city" />
+          <zenbpm:output source="={&#34;name&#34;: &#34;order1&#34;, &#34;id&#34;: &#34;1234&#34;}" target="order" />
+          <zenbpm:output source="=1234" target="orderId" />
+          <zenbpm:output source="=city" target="dstcity" />
+        </zenbpm:ioMapping>
+        <zenbpm:taskDefinition type="input-task-for-message-start-event-test" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1xx1ap4</bpmn:incoming>
+      <bpmn:incoming>Flow_109w39o</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rvswpk</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0rvswpk" sourceRef="service-task-1" targetRef="Event_0461t71" />
+    <bpmn:startEvent id="plainStartEvent_0mtr7my">
+      <bpmn:outgoing>Flow_109w39o</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_109w39o" sourceRef="plainStartEvent_0mtr7my" targetRef="service-task-1" />
+  </bpmn:process>
+  <bpmn:message id="Message_0d37bgs" name="messageStartEventProcessRef" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="message-start-event-process-1">
+      <bpmndi:BPMNShape id="Event_0461t71_di" bpmnElement="Event_0461t71">
+        <dc:Bounds x="432" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ruw1xz_di" bpmnElement="messageStartEvent_1234">
+        <dc:Bounds x="182" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0296s40_di" bpmnElement="service-task-1">
+        <dc:Bounds x="280" y="60" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mtr7my_di" bpmnElement="plainStartEvent_0mtr7my">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1xx1ap4_di" bpmnElement="Flow_1xx1ap4">
+        <di:waypoint x="218" y="100" />
+        <di:waypoint x="280" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rvswpk_di" bpmnElement="Flow_0rvswpk">
+        <di:waypoint x="380" y="100" />
+        <di:waypoint x="432" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_109w39o_di" bpmnElement="Flow_109w39o">
+        <di:waypoint x="218" y="180" />
+        <di:waypoint x="330" y="180" />
+        <di:waypoint x="330" y="140" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/multi_instance/parallel_multi_instance_service_task_with_message_boundary_event_with_output_mapping.bpmn
+++ b/test/e2e/testdata/multi_instance/parallel_multi_instance_service_task_with_message_boundary_event_with_output_mapping.bpmn
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_parallel_multi_instance_message_boundary_with_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="parallel-multi-instance-message-boundary-event-with-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_service_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_service_task" sourceRef="start_event" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="TestType" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=item" target="testElementInput" />
+          <zeebe:output source="=testJobOutput" target="testElementOutput" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_service_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=testInputCollection" inputElement="item" outputCollection="testOutputCollection" outputElement="=testElementOutput" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="service_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="service_task">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=payload" target="payload" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="parallel-multi-instance-message-boundary-event-with-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="service_task_di" bpmnElement="service_task">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_service_task_di" bpmnElement="flow_to_service_task">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/multi_instance/parallel_multi_instance_service_task_with_message_boundary_event_without_output_mapping.bpmn
+++ b/test/e2e/testdata/multi_instance/parallel_multi_instance_service_task_with_message_boundary_event_without_output_mapping.bpmn
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_parallel_multi_instance_message_boundary_without_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="parallel-multi-instance-message-boundary-event-without-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_service_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_service_task" sourceRef="start_event" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="TestType" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=item" target="testElementInput" />
+          <zeebe:output source="=testJobOutput" target="testElementOutput" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_service_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=testInputCollection" inputElement="item" outputCollection="testOutputCollection" outputElement="=testElementOutput" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="service_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="service_task">
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="parallel-multi-instance-message-boundary-event-without-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="service_task_di" bpmnElement="service_task">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_service_task_di" bpmnElement="flow_to_service_task">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/multi_instance/sequential_multi_instance_service_task_with_message_boundary_event_with_output_mapping.bpmn
+++ b/test/e2e/testdata/multi_instance/sequential_multi_instance_service_task_with_message_boundary_event_with_output_mapping.bpmn
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_sequential_multi_instance_message_boundary_with_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="sequential-multi-instance-message-boundary-event-with-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_service_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_service_task" sourceRef="start_event" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="TestType" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=item" target="testElementInput" />
+          <zeebe:output source="=testJobOutput" target="testElementOutput" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_service_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=testInputCollection" inputElement="item" outputCollection="testOutputCollection" outputElement="=testElementOutput" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="service_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="service_task">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=payload" target="payload" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="sequential-multi-instance-message-boundary-event-with-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="service_task_di" bpmnElement="service_task">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_service_task_di" bpmnElement="flow_to_service_task">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/multi_instance/sequential_multi_instance_service_task_with_message_boundary_event_without_output_mapping.bpmn
+++ b/test/e2e/testdata/multi_instance/sequential_multi_instance_service_task_with_message_boundary_event_without_output_mapping.bpmn
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_sequential_multi_instance_message_boundary_without_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="sequential-multi-instance-message-boundary-event-without-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_service_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_service_task" sourceRef="start_event" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="TestType" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=item" target="testElementInput" />
+          <zeebe:output source="=testJobOutput" target="testElementOutput" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_service_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=testInputCollection" inputElement="item" outputCollection="testOutputCollection" outputElement="=testElementOutput" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="service_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="service_task">
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="sequential-multi-instance-message-boundary-event-without-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="service_task_di" bpmnElement="service_task">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_service_task_di" bpmnElement="flow_to_service_task">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/send_task/send_task_with_message_boundary_event_with_output_mapping.bpmn
+++ b/test/e2e/testdata/send_task/send_task_with_message_boundary_event_with_output_mapping.bpmn
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_send_task_message_boundary_with_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="send-task-message-boundary-event-with-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_send_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_send_task" sourceRef="start_event" targetRef="send_task" />
+    <bpmn:sendTask id="send_task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="send-task-message-boundary-test" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_send_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+    </bpmn:sendTask>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="send_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="send_task">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=payload" target="payload" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="send-task-message-boundary-event-with-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="send_task_di" bpmnElement="send_task">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_send_task_di" bpmnElement="flow_to_send_task">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/send_task/send_task_with_message_boundary_event_without_output_mapping.bpmn
+++ b/test/e2e/testdata/send_task/send_task_with_message_boundary_event_without_output_mapping.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_send_task_message_boundary_without_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="send-task-message-boundary-event-without-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_send_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_send_task" sourceRef="start_event" targetRef="send_task" />
+    <bpmn:sendTask id="send_task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="send-task-message-boundary-test" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_send_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+    </bpmn:sendTask>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="send_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="send_task">
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="send-task-message-boundary-event-without-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="send_task_di" bpmnElement="send_task">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_send_task_di" bpmnElement="flow_to_send_task">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/service_task/service_task_with_message_boundary_event_interrupting.bpmn
+++ b/test/e2e/testdata/service_task/service_task_with_message_boundary_event_interrupting.bpmn
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0apy591" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="message-boundary-event-interrupting" name="Test interrupting boundary event " isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_17cg00h</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_17cg00h" sourceRef="StartEvent_1" targetRef="service_task" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>Flow_1gnes9r</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gnes9r" sourceRef="service_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>Flow_14sh6sh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_14sh6sh" sourceRef="message_boundary_event" targetRef="end_event_boundary" />
+    <bpmn:boundaryEvent id="message_boundary_event" attachedToRef="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=payload" target="payload" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_14sh6sh</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0tqf90u" messageRef="simple-message" />
+    </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="service_task" name="Service task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="simple-job" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17cg00h</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gnes9r</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmn:message id="simple-message" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=&#34;message-boundary-event-interruptingCorrelationKey&#34;" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="message-boundary-event-interrupting">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0256hkz_di" bpmnElement="end_event_main">
+        <dc:Bounds x="442" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02rlbpp_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="442" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lewj6k_di" bpmnElement="service_task">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ri8hvx_di" bpmnElement="message_boundary_event">
+        <dc:Bounds x="322" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17cg00h_di" bpmnElement="Flow_17cg00h">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gnes9r_di" bpmnElement="Flow_1gnes9r">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="442" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14sh6sh_di" bpmnElement="Flow_14sh6sh">
+        <di:waypoint x="340" y="178" />
+        <di:waypoint x="340" y="230" />
+        <di:waypoint x="442" y="230" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/service_task/service_task_with_message_boundary_event_interrupting.bpmn
+++ b/test/e2e/testdata/service_task/service_task_with_message_boundary_event_interrupting.bpmn
@@ -32,7 +32,7 @@
   </bpmn:process>
   <bpmn:message id="simple-message" name="message">
     <bpmn:extensionElements>
-      <zenbpm:subscription correlationKey="=&#34;message-boundary-event-interruptingCorrelationKey&#34;" />
+      <zenbpm:subscription correlationKey="=correlationKey" />
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">

--- a/test/e2e/testdata/service_task/service_task_with_message_boundary_event_noninterrupting.bpmn
+++ b/test/e2e/testdata/service_task/service_task_with_message_boundary_event_noninterrupting.bpmn
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0apy591" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="message-boundary-event-noninterrupting" name="Test noninterrupting boundary event " isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_17cg00h</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_17cg00h" sourceRef="StartEvent_1" targetRef="service_task" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>Flow_1gnes9r</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gnes9r" sourceRef="service_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>Flow_14sh6sh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_14sh6sh" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=payload" target="payload" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_14sh6sh</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0tqf90u" messageRef="simple-boundary-id" />
+    </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="service_task" name="Service task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="simple-job" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17cg00h</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gnes9r</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmn:message id="simple-boundary-id" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="message-boundary-event-noninterrupting">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0256hkz_di" bpmnElement="end_event_main">
+        <dc:Bounds x="442" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02rlbpp_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="442" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lewj6k_di" bpmnElement="service_task">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ri8hvx_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="322" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17cg00h_di" bpmnElement="Flow_17cg00h">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gnes9r_di" bpmnElement="Flow_1gnes9r">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="442" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14sh6sh_di" bpmnElement="Flow_14sh6sh">
+        <di:waypoint x="340" y="178" />
+        <di:waypoint x="340" y="230" />
+        <di:waypoint x="442" y="230" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/service_task/service_task_with_message_boundary_event_two_interrupting.bpmn
+++ b/test/e2e/testdata/service_task/service_task_with_message_boundary_event_two_interrupting.bpmn
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_two_interrupting_message_boundaries" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="two-message-boundary-event-interrupting" name="Test two interrupting boundary events" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_17cg00h</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_17cg00h" sourceRef="StartEvent_1" targetRef="service_task" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>Flow_1gnes9r</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gnes9r" sourceRef="service_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_boundary_a">
+      <bpmn:incoming>Flow_14sh6sh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_14sh6sh" sourceRef="boundary_message_event_a" targetRef="end_event_boundary_a" />
+    <bpmn:boundaryEvent id="boundary_message_event_a" cancelActivity="true" attachedToRef="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=payloadA" target="payloadA" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_14sh6sh</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_A" messageRef="message_b" />
+    </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="service_task" name="Service task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="simple-job" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17cg00h</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gnes9r</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="boundary_message_event_b" cancelActivity="true" attachedToRef="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=payloadB" target="payloadB" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0nzuzj2</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_B" messageRef="message_a" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="end_event_boundary_b">
+      <bpmn:incoming>Flow_0nzuzj2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0nzuzj2" sourceRef="boundary_message_event_b" targetRef="end_event_boundary_b" />
+  </bpmn:process>
+  <bpmn:message id="message_b" name="messageB">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKeyB" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="message_a" name="messageA">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKeyA" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="two-message-boundary-event-interrupting">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="442" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_a_di" bpmnElement="end_event_boundary_a">
+        <dc:Bounds x="322" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="service_task_di" bpmnElement="service_task">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_b_di" bpmnElement="end_event_boundary_b">
+        <dc:Bounds x="272" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_b_di" bpmnElement="boundary_message_event_b">
+        <dc:Bounds x="272" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_a_di" bpmnElement="boundary_message_event_a">
+        <dc:Bounds x="322" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17cg00h_di" bpmnElement="Flow_17cg00h">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gnes9r_di" bpmnElement="Flow_1gnes9r">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="442" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14sh6sh_di" bpmnElement="Flow_14sh6sh">
+        <di:waypoint x="340" y="178" />
+        <di:waypoint x="340" y="222" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nzuzj2_di" bpmnElement="Flow_0nzuzj2">
+        <di:waypoint x="290" y="178" />
+        <di:waypoint x="290" y="222" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/service_task/service_task_with_message_boundary_event_two_noninterrupting.bpmn
+++ b/test/e2e/testdata/service_task/service_task_with_message_boundary_event_two_noninterrupting.bpmn
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0apy591" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="two-message-boundary-event-noninterrupting" name="Test two noninterrupting boundary event " isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_17cg00h</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_17cg00h" sourceRef="StartEvent_1" targetRef="service_task" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>Flow_1gnes9r</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gnes9r" sourceRef="service_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_boundary_a">
+      <bpmn:incoming>Flow_14sh6sh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_14sh6sh" sourceRef="boundary_message_event_a" targetRef="end_event_boundary_a" />
+    <bpmn:boundaryEvent id="boundary_message_event_a" cancelActivity="false" attachedToRef="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=payloadA" target="payloadA" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_14sh6sh</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0tqf90u" messageRef="simple-boundary-id" />
+    </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="service_task" name="Service task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="simple-job" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17cg00h</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gnes9r</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="boundary_message_event_b" cancelActivity="false" attachedToRef="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=payloadB" target="payloadB" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0nzuzj2</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1scp1c9" messageRef="Message_3m7dq21" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="end_event_boundary_b">
+      <bpmn:incoming>Flow_0nzuzj2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0nzuzj2" sourceRef="boundary_message_event_b" targetRef="end_event_boundary_b" />
+  </bpmn:process>
+  <bpmn:message id="simple-boundary-id" name="messageB">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKeyB" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_3m7dq21" name="messageA">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKeyA" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="two-message-boundary-event-noninterrupting">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0256hkz_di" bpmnElement="end_event_main">
+        <dc:Bounds x="442" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02rlbpp_di" bpmnElement="end_event_boundary_a">
+        <dc:Bounds x="322" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lewj6k_di" bpmnElement="service_task">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_198n1qv_di" bpmnElement="end_event_boundary_b">
+        <dc:Bounds x="272" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b4t5u9" bpmnElement="boundary_message_event_b">
+        <dc:Bounds x="272" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ri8hvx_di" bpmnElement="boundary_message_event_a">
+        <dc:Bounds x="322" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17cg00h_di" bpmnElement="Flow_17cg00h">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gnes9r_di" bpmnElement="Flow_1gnes9r">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="442" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14sh6sh_di" bpmnElement="Flow_14sh6sh">
+        <di:waypoint x="340" y="178" />
+        <di:waypoint x="340" y="222" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nzuzj2_di" bpmnElement="Flow_0nzuzj2">
+        <di:waypoint x="290" y="178" />
+        <di:waypoint x="290" y="222" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/service_task/service_task_with_message_boundary_event_without_output_mapping.bpmn
+++ b/test/e2e/testdata/service_task/service_task_with_message_boundary_event_without_output_mapping.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_message_boundary_without_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="message-boundary-event-without-output-mapping" name="Message boundary without output mapping" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_17cg00h</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_17cg00h" sourceRef="StartEvent_1" targetRef="service_task" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>Flow_1gnes9r</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gnes9r" sourceRef="service_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>Flow_14sh6sh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_14sh6sh" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="service_task">
+      <bpmn:outgoing>Flow_14sh6sh</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0tqf90u" messageRef="simple-boundary-id" />
+    </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="service_task" name="Service task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="simple-job" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17cg00h</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gnes9r</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmn:message id="simple-boundary-id" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="message-boundary-event-without-output-mapping">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="442" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="442" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="service_task_di" bpmnElement="service_task">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="322" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17cg00h_di" bpmnElement="Flow_17cg00h">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gnes9r_di" bpmnElement="Flow_1gnes9r">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="442" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14sh6sh_di" bpmnElement="Flow_14sh6sh">
+        <di:waypoint x="340" y="178" />
+        <di:waypoint x="340" y="230" />
+        <di:waypoint x="442" y="230" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/user_task/user_task_with_message_boundary_event_with_output_mapping.bpmn
+++ b/test/e2e/testdata/user_task/user_task_with_message_boundary_event_with_output_mapping.bpmn
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_user_task_message_boundary_with_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="user-task-message-boundary-event-with-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_user_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_user_task" sourceRef="start_event" targetRef="user_task" />
+    <bpmn:userTask id="user_task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="TestType" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_user_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="user_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="user_task">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=payload" target="payload" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="user-task-message-boundary-event-with-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="user_task_di" bpmnElement="user_task">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_user_task_di" bpmnElement="flow_to_user_task">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/user_task/user_task_with_message_boundary_event_without_output_mapping.bpmn
+++ b/test/e2e/testdata/user_task/user_task_with_message_boundary_event_without_output_mapping.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_user_task_message_boundary_without_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="user-task-message-boundary-event-without-output-mapping" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_user_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_user_task" sourceRef="start_event" targetRef="user_task" />
+    <bpmn:userTask id="user_task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="TestType" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_user_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_main_end</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="flow_to_main_end" sourceRef="user_task" targetRef="end_event_main" />
+    <bpmn:endEvent id="end_event_main">
+      <bpmn:incoming>flow_to_main_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="boundary_message_event" cancelActivity="false" attachedToRef="user_task">
+      <bpmn:outgoing>flow_to_boundary_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="message_event_definition" messageRef="message_id" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="flow_to_boundary_end" sourceRef="boundary_message_event" targetRef="end_event_boundary" />
+    <bpmn:endEvent id="end_event_boundary">
+      <bpmn:incoming>flow_to_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="message_id" name="message">
+    <bpmn:extensionElements>
+      <zenbpm:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="user-task-message-boundary-event-without-output-mapping">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="150" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="user_task_di" bpmnElement="user_task">
+        <dc:Bounds x="250" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_main_di" bpmnElement="end_event_main">
+        <dc:Bounds x="470" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="boundary_message_event_di" bpmnElement="boundary_message_event">
+        <dc:Bounds x="282" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_boundary_di" bpmnElement="end_event_boundary">
+        <dc:Bounds x="470" y="270" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_user_task_di" bpmnElement="flow_to_user_task">
+        <di:waypoint x="186" y="178" />
+        <di:waypoint x="250" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_main_end_di" bpmnElement="flow_to_main_end">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="470" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_boundary_end_di" bpmnElement="flow_to_boundary_end">
+        <di:waypoint x="300" y="236" />
+        <di:waypoint x="300" y="288" />
+        <di:waypoint x="470" y="288" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/user_task_message_boundary_flow_test.go
+++ b/test/e2e/user_task_message_boundary_flow_test.go
@@ -1,0 +1,103 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserTaskMessageBoundaryFlow(t *testing.T) {
+	t.Run("Interrupting boundary message cancels the user task and completes the boundary path", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployInterruptingMessageBoundaryDefinition(
+			t,
+			"testdata/user_task/user_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"user-task-message-boundary-event-without-output-mapping",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "user_task")
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "user_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "user_task", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_user_task",
+			"user_task",
+		})
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForProcessInstanceJobByElementId(t, instance.Key, "user_task", public.JobStateTerminated)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_boundary")
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertProcessInstanceTokenCount(t, instance.Key, "end_event_main", 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "user_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "user_task", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_user_task",
+			"user_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+		})
+	})
+
+	t.Run("Non-interrupting boundary message keeps the user task active and completes both paths", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/user_task/user_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"user-task-message-boundary-event-without-output-mapping",
+		)
+		instance := createMessageBoundaryInstance(t, definitionKey)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "user_task")
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		assertProcessInstanceTokenState(t, instance.Key, "user_task", runtime.TokenStateWaiting)
+		assertMessageSubscriptionState(t, instance.Key, "user_task", zenclient.EventSubscriptionStateActive)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_user_task",
+			"user_task",
+		})
+
+		err := publishMessage(t, messageName, correlationKey, &map[string]any{})
+		require.NoError(t, err)
+
+		waitForProcessInstanceState(t, instance.Key, zenclient.ProcessInstanceStateActive)
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "user_task")
+		assertProcessInstanceTokenState(t, instance.Key, "user_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "user_task", zenclient.EventSubscriptionStateCompleted, 1)
+		assertMessageSubscriptionStateCount(t, instance.Key, "user_task", zenclient.EventSubscriptionStateActive, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_user_task",
+			"user_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+		})
+
+		completeJobForElementId(t, instance.Key, "user_task", nil)
+
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_main", runtime.TokenStateCompleted)
+		assertMessageSubscriptionStateCount(t, instance.Key, "user_task", zenclient.EventSubscriptionStateActive, 0)
+		assertMessageSubscriptionStateCount(t, instance.Key, "user_task", zenclient.EventSubscriptionStateTerminated, 1)
+		assertExactProcessInstanceHistory(t, instance.Key, []string{
+			"start_event",
+			"flow_to_user_task",
+			"user_task",
+			"boundary_message_event",
+			"flow_to_boundary_end",
+			"end_event_boundary",
+			"flow_to_main_end",
+			"end_event_main",
+		})
+	})
+}

--- a/test/e2e/user_task_message_boundary_variables_test.go
+++ b/test/e2e/user_task_message_boundary_variables_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserTaskMessageBoundaryVariables(t *testing.T) {
+	t.Run("Message boundary without output mapping propagates all message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/user_task/user_task_with_message_boundary_event_without_output_mapping.bpmn",
+			"user-task-message-boundary-event-without-output-mapping",
+		)
+		processVariables := map[string]any{
+			"existing":    "process-value",
+			"overwritten": "initial-value",
+		}
+		instance := createMessageBoundaryVariablesInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "user_task")
+		assertMessageSubscriptionState(t, instance.Key, "user_task", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"overwritten": "message-value",
+			"unmapped":    "unmapped-value",
+			"numeric":     float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", messageVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(processVariables, messageVariables))
+
+		completeJobForElementId(t, instance.Key, "user_task", nil)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+	})
+
+	t.Run("Message boundary with output mapping propagates only mapped message variables", func(t *testing.T) {
+		definitionKey, messageName, correlationKey := deployMessageBoundaryDefinition(
+			t,
+			"testdata/user_task/user_task_with_message_boundary_event_with_output_mapping.bpmn",
+			"user-task-message-boundary-event-with-output-mapping",
+		)
+		processVariables := map[string]any{"existing": "process-value"}
+		instance := createMessageBoundaryVariablesInstance(t, definitionKey, processVariables)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, "user_task")
+		assertMessageSubscriptionState(t, instance.Key, "user_task", zenclient.EventSubscriptionStateActive)
+
+		messageVariables := map[string]any{
+			"payload":  "mapped-value",
+			"unmapped": "ignored-value",
+			"numeric":  float64(42),
+		}
+		err := publishMessage(t, messageName, correlationKey, &messageVariables)
+		require.NoError(t, err)
+
+		expectedMappedVariables := map[string]any{"payload": "mapped-value"}
+		assertProcessInstanceTokenState(t, instance.Key, "end_event_boundary", runtime.TokenStateCompleted)
+		assertFlowElementOutputVariables(t, instance.Key, "boundary_message_event", expectedMappedVariables)
+		assertProcessInstanceVariables(t, instance.Key, mergeMaps(processVariables, expectedMappedVariables))
+
+		completeJobForElementId(t, instance.Key, "user_task", nil)
+		assertProcessInstanceIsCompleted(t, instance.Key, "end_event_main")
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable scoping and mapping for message start events and intermediate message catch/throw events, ensuring persisted history and output variables are saved correctly.
  * Ensured intermediate catch-event handling loads and preserves input scope, including correlation-based listener propagation.
  * Updated in-memory flow-element persistence to update only input variables on repeated saves.

* **Tests**
  * Added unit and end-to-end coverage for message event variable propagation, correlation, and history/input-output persistence, plus new storage update-only-input-variable tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->