### PR TITLE
#665- resolve deadlock when triggering already cancelled boundary timer

### DIFF
--- a/pkg/bpmn/timer_api.go
+++ b/pkg/bpmn/timer_api.go
@@ -57,8 +57,11 @@ func (engine *Engine) TriggerTimer(ctx context.Context, timer runtime.Timer) (
 	return engine.processTimerTriggerOnToken(ctx, timer)
 }
 
-func (engine *Engine) processTimerTriggerOnToken(ctx context.Context, timer runtime.Timer) (*runtime.ProcessInstance, []runtime.ExecutionToken, error) {
-	var tokens []runtime.ExecutionToken
+func (engine *Engine) processTimerTriggerOnToken(ctx context.Context, timer runtime.Timer) (
+	resInstance *runtime.ProcessInstance,
+	tokens []runtime.ExecutionToken,
+	retErr error,
+) {
 	instance, err := engine.persistence.FindProcessInstanceByKey(ctx, *timer.ProcessInstanceKey)
 	if err != nil {
 		return nil, nil, newEngineErrorf("failed to find process instance with key: %d", *timer.ProcessInstanceKey)
@@ -74,6 +77,17 @@ func (engine *Engine) processTimerTriggerOnToken(ctx context.Context, timer runt
 	if err != nil {
 		return nil, nil, newEngineErrorf("failed to create batch for timer %d: %s", timer.Key, err)
 	}
+	// Make sure the instance locks held by the batch are released on every error path. Clear after a successful Flush (or a previous Clear) is a no-op.
+	defer func() {
+		if r := recover(); r != nil {
+			resInstance = nil
+			tokens = nil
+			retErr = fmt.Errorf("failed to trigger timer %d, panic recovered: %v\n%s", timer.Key, r, debug.Stack())
+		}
+		if retErr != nil {
+			batch.Clear(ctx)
+		}
+	}()
 	timerRefreshed, err := engine.persistence.GetTimer(ctx, timer.Key)
 	if err != nil {
 		return nil, nil, newEngineErrorf("failed to find timer %d: %s", timer.Key, err)

--- a/pkg/bpmn/timer_api.go
+++ b/pkg/bpmn/timer_api.go
@@ -106,7 +106,6 @@ func (engine *Engine) processTimerTriggerOnToken(ctx context.Context, timer runt
 	case *bpmn20.TEventBasedGateway:
 		t, err := engine.publishEventOnEventGateway(ctx, &batch, nodeT, timer, instance, nil)
 		if err != nil {
-			batch.Clear(ctx)
 			return nil, nil, fmt.Errorf("failed to handle timer event gateway transition %+v: %w", timer, err)
 		}
 		tokens = t
@@ -137,12 +136,10 @@ func (engine *Engine) processTimerTriggerOnToken(ctx context.Context, timer runt
 		}
 		tokens, err = engine.handleElementTransition(ctx, &batch, instance, nodeT, *timer.Token)
 		if err != nil {
-			batch.Clear(ctx)
 			return nil, nil, fmt.Errorf("failed to handle timer transition %+v: %w", timer, err)
 		}
 		err = batch.Flush(ctx)
 		if err != nil {
-			batch.Clear(ctx)
 			return nil, nil, fmt.Errorf("failed to flush trigger timer batch %+v: %w", timer, err)
 		}
 	case bpmn20.Activity:
@@ -151,12 +148,10 @@ func (engine *Engine) processTimerTriggerOnToken(ctx context.Context, timer runt
 		}
 		tokens, err = engine.handleBoundaryTimer(ctx, &batch, timer, instance, *timer.Token)
 		if err != nil {
-			batch.Clear(ctx)
 			return nil, nil, fmt.Errorf("failed to handle timer transition %+v: %w", timer, err)
 		}
 		err = batch.Flush(ctx)
 		if err != nil {
-			batch.Clear(ctx)
 			return nil, nil, fmt.Errorf("failed to flush trigger timer batch %+v: %w", timer, err)
 		}
 

--- a/pkg/bpmn/timer_boundary_cancelled_lock_test.go
+++ b/pkg/bpmn/timer_boundary_cancelled_lock_test.go
@@ -53,7 +53,7 @@ func TestTriggerBoundaryTimer_AlreadyCancelled_ReleasesInstanceLock(t *testing.T
 		"process instance lock must be released after triggering an already-cancelled timer")
 	engine.runningInstances.unlockInstance(piKey)
 
-	job := findActiveJob(store, piKey, "simple-job")
+	job := findActiveJob(t, store, piKey, "simple-job")
 	require.NotNil(t, job, "the service task job must still be active")
 	require.NoError(t, engine.JobCompleteByKey(t.Context(), job.Key, nil))
 
@@ -63,9 +63,12 @@ func TestTriggerBoundaryTimer_AlreadyCancelled_ReleasesInstanceLock(t *testing.T
 	}, 5*time.Second, 100*time.Millisecond, "process instance should complete after the job is done")
 }
 
-func findActiveJob(store *inmemory.Storage, processInstanceKey int64, jobType string) *runtime.Job {
-	for _, job := range store.Jobs {
-		if job.ProcessInstanceKey == processInstanceKey && job.Type == jobType && job.State == runtime.ActivityStateActive {
+func findActiveJob(t *testing.T, store *inmemory.Storage, processInstanceKey int64, jobType string) *runtime.Job {
+	t.Helper()
+	jobs, err := store.FindPendingProcessInstanceJobs(t.Context(), processInstanceKey)
+	require.NoError(t, err)
+	for _, job := range jobs {
+		if job.Type == jobType && job.State == runtime.ActivityStateActive {
 			return &job
 		}
 	}

--- a/pkg/bpmn/timer_boundary_cancelled_lock_test.go
+++ b/pkg/bpmn/timer_boundary_cancelled_lock_test.go
@@ -1,0 +1,73 @@
+package bpmn
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTriggerBoundaryTimer_AlreadyCancelled_ReleasesInstanceLock is a regression test for a
+// deadlock where triggering a boundary timer that had already been cancelled (e.g. the job it
+// was attached to was completed just before the timer fired) returned an error from
+// processTimerTriggerOnToken without clearing the engine batch, leaving the process instance
+// lock held forever. Any subsequent operation on the instance (job completion, cancellation)
+// then blocked indefinitely, freezing the engine.
+func TestTriggerBoundaryTimer_AlreadyCancelled_ReleasesInstanceLock(t *testing.T) {
+	store := inmemory.NewStorage()
+	// Long poll delay so the engine scheduler does not race with the manual trigger below.
+	engine := NewEngine(EngineWithStorage(store), EngineWithPollTimerDelay(10*time.Second))
+	require.NoError(t, engine.Start(t.Context()))
+	defer engine.Stop()
+
+	process, err := engine.LoadFromFile(t.Context(), "./test-cases/timer-boundary-event-noninterrupting.bpmn")
+	require.NoError(t, err)
+
+	instance, err := engine.CreateInstance(t.Context(), process, nil)
+	require.NoError(t, err)
+	piKey := instance.ProcessInstance().Key
+
+	// Find the boundary timer and mark it Cancelled to simulate the race where the job was
+	// completed (cancelling the timer) right before the scheduler fired it.
+	timers, err := store.FindProcessInstanceTimers(t.Context(), piKey, runtime.TimerStateCreated)
+	require.NoError(t, err)
+	require.Len(t, timers, 1)
+	target := timers[0]
+	require.NotNil(t, target.Token, "boundary timer must carry an execution token")
+
+	target.TimerState = runtime.TimerStateCancelled
+	batch := store.NewBatch()
+	require.NoError(t, batch.SaveTimer(t.Context(), target))
+	require.NoError(t, batch.Flush(t.Context()))
+
+	// Trigger the already-cancelled timer. The engine reports it as an error but must release
+	// the process instance lock before returning.
+	_, _, err = engine.TriggerTimer(t.Context(), target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timer is already cancelled")
+
+	require.NoError(t, engine.runningInstances.tryLockInstance(t.Context(), piKey),
+		"process instance lock must be released after triggering an already-cancelled timer")
+	engine.runningInstances.unlockInstance(piKey)
+
+	job := findActiveJob(store, piKey, "simple-job")
+	require.NotNil(t, job, "the service task job must still be active")
+	require.NoError(t, engine.JobCompleteByKey(t.Context(), job.Key, nil))
+
+	require.Eventually(t, func() bool {
+		pi, err := store.FindProcessInstanceByKey(t.Context(), piKey)
+		return err == nil && pi.ProcessInstance().GetState() == runtime.ActivityStateCompleted
+	}, 5*time.Second, 100*time.Millisecond, "process instance should complete after the job is done")
+}
+
+func findActiveJob(store *inmemory.Storage, processInstanceKey int64, jobType string) *runtime.Job {
+	for _, job := range store.Jobs {
+		if job.ProcessInstanceKey == processInstanceKey && job.Type == jobType && job.State == runtime.ActivityStateActive {
+			return &job
+		}
+	}
+	return nil
+}

--- a/pkg/bpmn/timer_boundary_cancelled_lock_test.go
+++ b/pkg/bpmn/timer_boundary_cancelled_lock_test.go
@@ -67,9 +67,9 @@ func findActiveJob(t *testing.T, store *inmemory.Storage, processInstanceKey int
 	t.Helper()
 	jobs, err := store.FindPendingProcessInstanceJobs(t.Context(), processInstanceKey)
 	require.NoError(t, err)
-	for _, job := range jobs {
-		if job.Type == jobType && job.State == runtime.ActivityStateActive {
-			return &job
+	for i := range jobs {
+		if jobs[i].Type == jobType && jobs[i].State == runtime.ActivityStateActive {
+			return &jobs[i]
 		}
 	}
 	return nil

--- a/test/e2e/testdata/timer/timer-boundary-noninterrupting-cancel-race.bpmn
+++ b/test/e2e/testdata/timer/timer-boundary-noninterrupting-cancel-race.bpmn
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_cancelrace" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="timer-boundary-noninterrupting-cancel-race" name="Boundary timer cancelled right before firing" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_start_main</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_main" sourceRef="StartEvent_1" targetRef="main-task" />
+    <bpmn:serviceTask id="main-task" name="Main task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="race-main-job" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_main</bpmn:incoming>
+      <bpmn:outgoing>Flow_main_final</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="BoundaryTimer_main" cancelActivity="false" attachedToRef="main-task">
+      <bpmn:outgoing>Flow_boundary_end</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_cancelrace">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT3S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_boundary_end" sourceRef="BoundaryTimer_main" targetRef="EndEvent_boundary" />
+    <bpmn:endEvent id="EndEvent_boundary">
+      <bpmn:incoming>Flow_boundary_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_main_final" sourceRef="main-task" targetRef="final-task" />
+    <bpmn:serviceTask id="final-task" name="Final task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="race-final-job" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_main_final</bpmn:incoming>
+      <bpmn:outgoing>Flow_final_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_final_end" sourceRef="final-task" targetRef="EndEvent_main" />
+    <bpmn:endEvent id="EndEvent_main">
+      <bpmn:incoming>Flow_final_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="timer-boundary-noninterrupting-cancel-race">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_main_task_di" bpmnElement="main-task">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_boundary_timer_di" bpmnElement="BoundaryTimer_main">
+        <dc:Bounds x="322" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_end_boundary_di" bpmnElement="EndEvent_boundary">
+        <dc:Bounds x="442" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_final_task_di" bpmnElement="final-task">
+        <dc:Bounds x="430" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_end_main_di" bpmnElement="EndEvent_main">
+        <dc:Bounds x="592" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_start_main_di" bpmnElement="Flow_start_main">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_main_final_di" bpmnElement="Flow_main_final">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="430" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_boundary_end_di" bpmnElement="Flow_boundary_end">
+        <di:waypoint x="340" y="178" />
+        <di:waypoint x="340" y="230" />
+        <di:waypoint x="442" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_final_end_di" bpmnElement="Flow_final_end">
+        <di:waypoint x="530" y="120" />
+        <di:waypoint x="592" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/timer_boundary_cancel_race_test.go
+++ b/test/e2e/timer_boundary_cancel_race_test.go
@@ -1,0 +1,111 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	bpmnruntime "github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/storage"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/pbinitiative/zenbpm/pkg/zenflake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTimerBoundaryCancelledRightBeforeFiringKeepsEngineResponsive is an e2e regression test
+// for a deadlock where a non-interrupting boundary timer that was cancelled (by completing the
+// job of its attached activity) but had already been loaded into the timer manager's in-memory
+// waiting list still fired, hit the "timer is already cancelled" error path and leaked the
+// process instance lock. Every subsequent operation on the instance (completing the next job,
+// cancelling the instance) then hung and the engine appeared frozen.
+//
+// The engine polls due timers into memory one poll cycle (POLL_TIMER_DELAY_SECONDS=1 in e2e)
+// ahead of their due date, while job completion cancels boundary timers in the DB only. The
+// test drives the job completion into that last poll window (shortly before DueAt) so the
+// already-loaded timer fires against the cancelled DB state. It then verifies the engine stays
+// fully operable: the follow-up job completes and the instance reaches Completed. Several
+// instances are exercised to make hitting the race window overwhelmingly likely.
+func TestTimerBoundaryCancelledRightBeforeFiringKeepsEngineResponsive(t *testing.T) {
+	cleanProcessInstances(t)
+
+	const (
+		bpmnFile        = "testdata/timer/timer-boundary-noninterrupting-cancel-race.bpmn"
+		mainTaskElement = "main-task"
+		finalTaskElem   = "final-task"
+		attempts        = 3
+	)
+
+	definition := deployAndGetUniqueProcessDefinition(t, bpmnFile)
+	require.NotZero(t, definition.Key, "Definition key should not be zero")
+
+	for i := range attempts {
+		instance, err := createProcessInstance(t, &definition.Key, nil)
+		require.NoError(t, err)
+		require.NotZero(t, instance.Key, "Process instance key should not be zero")
+
+		store, err := app.node.GetPartitionStore(t.Context(), zenflake.GetPartitionId(instance.Key))
+		require.NoError(t, err)
+
+		mainJob := waitForProcessInstanceActiveJobByElementId(t, instance.Key, mainTaskElement)
+
+		timer := waitForCreatedProcessInstanceTimer(t, store, instance.Key)
+
+		// Complete the main job shortly before the boundary timer's due date, inside the last
+		// poll window, when the timer has most likely already been loaded into the timer
+		// manager's in-memory waiting list. The completion cancels the timer in the DB, but the
+		// in-memory copy still fires at DueAt and must handle the Cancelled state gracefully.
+		waitUntil(t, timer.DueAt.Add(-400*time.Millisecond))
+		require.NoError(t, completeJob(t, mainJob.Key, nil))
+
+		// Let the due date pass (plus a margin for the trigger to run) so the cancelled in-memory timer has fired by now.
+		waitUntil(t, timer.DueAt.Add(1500*time.Millisecond))
+
+		_, err = listProcessDefinitions(t)
+		require.NoError(t, err, "engine must keep serving process definition list after the cancelled timer fired")
+
+		// The instance must remain fully operable: the follow-up job is active and completable.
+		// Before the fix this hung on the leaked process instance lock.
+		completeJobForElementId(t, instance.Key, finalTaskElem, nil)
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			pi, err := getProcessInstance(t, instance.Key)
+			if !assert.NoError(collect, err) {
+				return
+			}
+			assert.Equal(collect, zenclient.ProcessInstanceStateCompleted, pi.State,
+				"process instance should be Completed after the final job is done")
+		}, 15*time.Second, 100*time.Millisecond,
+			"process instance %d should reach Completed state (attempt %d)", instance.Key, i)
+
+		cancelled, err := store.FindProcessInstanceTimers(t.Context(), instance.Key, bpmnruntime.TimerStateCancelled)
+		require.NoError(t, err)
+		require.Len(t, cancelled, 1, "the boundary timer should be Cancelled for instance %d", instance.Key)
+	}
+}
+
+// waitForCreatedProcessInstanceTimer waits until the process instance has exactly one timer in Created state and returns it.
+func waitForCreatedProcessInstanceTimer(t testing.TB, store storage.Storage, processInstanceKey int64) bpmnruntime.Timer {
+	t.Helper()
+
+	var timer bpmnruntime.Timer
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		timers, err := store.FindProcessInstanceTimers(t.Context(), processInstanceKey, bpmnruntime.TimerStateCreated)
+		if !assert.NoError(collect, err) {
+			return
+		}
+		if !assert.Len(collect, timers, 1, "expected exactly one Created timer for instance %d", processInstanceKey) {
+			return
+		}
+		timer = timers[0]
+	}, 5*time.Second, 50*time.Millisecond, "boundary timer should be Created for instance %d", processInstanceKey)
+	return timer
+}
+
+// waitUntil blocks until the given point in time has passed. It intentionally uses
+// require.Eventually instead of time.Sleep so the wait is bounded and cancellable.
+func waitUntil(t testing.TB, deadline time.Time) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return time.Now().After(deadline)
+	}, time.Until(deadline)+5*time.Second, 10*time.Millisecond, "expected wall clock to pass %s", deadline)
+}

--- a/test/e2e/timer_boundary_cancel_race_test.go
+++ b/test/e2e/timer_boundary_cancel_race_test.go
@@ -55,7 +55,11 @@ func TestTimerBoundaryCancelledRightBeforeFiringKeepsEngineResponsive(t *testing
 		// manager's in-memory waiting list. The completion cancels the timer in the DB, but the
 		// in-memory copy still fires at DueAt and must handle the Cancelled state gracefully.
 		raceWindow := timer.DueAt.Add(-400 * time.Millisecond)
-		require.True(t, time.Now().Before(raceWindow), "missed timer cancellation race window; retry this attempt")
+		if !time.Now().Before(raceWindow) {
+			t.Logf("missed timer cancellation race window (attempt %d); cleaning up and retrying", i)
+			cleanupOwnedProcessInstance(t, instance.Key)
+			continue
+		}
 		waitUntil(t, raceWindow)
 		require.NoError(t, completeJob(t, mainJob.Key, nil))
 

--- a/test/e2e/timer_boundary_cancel_race_test.go
+++ b/test/e2e/timer_boundary_cancel_race_test.go
@@ -54,7 +54,9 @@ func TestTimerBoundaryCancelledRightBeforeFiringKeepsEngineResponsive(t *testing
 		// poll window, when the timer has most likely already been loaded into the timer
 		// manager's in-memory waiting list. The completion cancels the timer in the DB, but the
 		// in-memory copy still fires at DueAt and must handle the Cancelled state gracefully.
-		waitUntil(t, timer.DueAt.Add(-400*time.Millisecond))
+		raceWindow := timer.DueAt.Add(-400 * time.Millisecond)
+		require.True(t, time.Now().Before(raceWindow), "missed timer cancellation race window; retry this attempt")
+		waitUntil(t, raceWindow)
 		require.NoError(t, completeJob(t, mainJob.Key, nil))
 
 		// Let the due date pass (plus a margin for the trigger to run) so the cancelled in-memory timer has fired by now.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timer execution to reliably release process instance locks on all failure paths.
  - Fixed potential deadlocks when non-interrupting boundary timers are already cancelled, including cancellation race scenarios.
  - Improved reliability so the engine stays responsive and process instances can still reach completion after boundary timer cancellation issues.

- **Tests**
  - Added a regression test covering already-cancelled non-interrupting boundary timer lock release.
  - Added an end-to-end regression test plus a BPMN scenario artifact for boundary timer cancellation race coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->