### PR TITLE
fix(#721): reevaluate input variables when resolving incident

### DIFF
--- a/pkg/bpmn/incident_api.go
+++ b/pkg/bpmn/incident_api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/model/bpmn20"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
 	otelPkg "github.com/pbinitiative/zenbpm/pkg/otel"
 	"github.com/pbinitiative/zenbpm/pkg/ptr"
@@ -37,6 +38,41 @@ func (engine *Engine) retryEventSubprocessSubscriptionIncident(ctx context.Conte
 	}
 
 	return engine.createStartEventSubscriptions(ctx, batch, subProcess.TProcess, *processDefinition, &instance)
+}
+
+func (engine *Engine) reevaluateJobInputVariables(ctx context.Context, batch *EngineBatch, instance runtime.ProcessInstance, job *runtime.Job) error {
+	element := instance.ProcessInstance().Definition.Definitions.Process.GetFlowNodeById(job.ElementId)
+	task, ok := element.(bpmn20.InternalTask)
+	if !ok {
+		return fmt.Errorf("failed to find task %s for job %d", job.ElementId, job.Key)
+	}
+
+	flowElementInstance, err := engine.persistence.GetFlowElementInstanceByKey(ctx, job.ElementInstanceKey)
+	if err != nil {
+		return fmt.Errorf("failed to find flow element instance %d for job %d: %w", job.ElementInstanceKey, job.Key, err)
+	}
+
+	variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, nil)
+	if activity, ok := element.(bpmn20.Activity); ok && activity.GetMultiInstance() != nil {
+		inputElementName := activity.GetMultiInstance().LoopCharacteristics.InputElementName
+		inputElement, ok := flowElementInstance.InputVariables[inputElementName]
+		if !ok {
+			return fmt.Errorf("failed to find multi-instance input variable %s for job %d", inputElementName, job.Key)
+		}
+		variableHolder.SetLocalVariable(inputElementName, inputElement)
+	}
+
+	flowElementInput := variableHolder.ExecutionScopeSnapshot()
+	if err := variableHolder.EvaluateAndSetMappingsToLocalVariables(task.GetInputMapping(), engine.evaluateExpression); err != nil {
+		return fmt.Errorf("failed to evaluate input variables for job %d: %w", job.Key, err)
+	}
+	job.InputVariables = variableHolder.LocalVariables()
+
+	flowElementInstance.InputVariables = flowElementInput
+	if err := batch.SaveFlowElementInstance(ctx, flowElementInstance); err != nil {
+		return fmt.Errorf("failed to update input variables for flow element instance %d: %w", flowElementInstance.Key, err)
+	}
+	return nil
 }
 
 func (engine *Engine) ResolveIncident(ctx context.Context, key int64) (retErr error) {
@@ -131,6 +167,9 @@ func (engine *Engine) ResolveIncident(ctx context.Context, key int64) (retErr er
 
 	// TODO: the same thing has to happen for other waiting subscriptions
 	if job != nil {
+		if err := engine.reevaluateJobInputVariables(ctx, &batch, instance, job); err != nil {
+			return err
+		}
 		incident.Token.State = runtime.TokenStateWaiting
 		job.State = runtime.ActivityStateActive
 		err := batch.SaveJob(ctx, *job)

--- a/pkg/bpmn/incident_api_test.go
+++ b/pkg/bpmn/incident_api_test.go
@@ -2,6 +2,7 @@ package bpmn
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
 	"github.com/pbinitiative/zenbpm/pkg/storage"
@@ -77,6 +78,158 @@ func TestExclusiveGatewayWithExpressionsNoOutgoingResolvesIncident(t *testing.T)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, incident.ResolvedAt)
 
+}
+
+func TestResolveJobIncidentReevaluatesInputMappingsWithCurrentProcessVariables(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+
+	process, err := engine.LoadFromFile(t.Context(), "./test-cases/incident-job-input-refresh.bpmn")
+	require.NoError(t, err)
+	instance, err := engine.CreateInstanceByKey(t.Context(), process.Key, map[string]interface{}{
+		"sourceValue": "original",
+		"staleValue":  "remove-before-retry",
+	})
+	require.NoError(t, err)
+
+	jobs, err := store.FindPendingProcessInstanceJobs(t.Context(), instance.ProcessInstance().Key)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "original", jobs[0].InputVariables["workerValue"])
+
+	require.NoError(t, engine.JobFailByKey(t.Context(), jobs[0].Key, "expected incident", nil, nil))
+	incidents, err := store.FindIncidentsByProcessInstanceKey(t.Context(), instance.ProcessInstance().Key)
+	require.NoError(t, err)
+	require.Len(t, incidents, 1)
+
+	_, err = engine.DeleteInstanceVariable(t.Context(), instance.ProcessInstance().Key, "staleValue")
+	require.NoError(t, err)
+	_, _, err = engine.ModifyInstance(t.Context(), instance.ProcessInstance().Key, nil, nil, map[string]interface{}{
+		"sourceValue": "corrected",
+	})
+	require.NoError(t, err)
+	require.NoError(t, engine.ResolveIncident(t.Context(), incidents[0].Key))
+
+	flowElementInstance, err := store.GetFlowElementInstanceByKey(t.Context(), jobs[0].ElementInstanceKey)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"sourceValue": "corrected",
+	}, flowElementInstance.InputVariables)
+
+	storedJob, err := store.FindJobByJobKey(t.Context(), jobs[0].Key)
+	require.NoError(t, err)
+	assert.Equal(t, jobs[0].Key, storedJob.Key)
+	assert.Equal(t, map[string]interface{}{
+		"sourceValue": "corrected",
+		"workerValue": "corrected",
+	}, storedJob.InputVariables)
+
+	activatedJobs, err := engine.ActivateJobs(t.Context(), "incident-retry-job")
+	require.NoError(t, err)
+	require.Len(t, activatedJobs, 1)
+	assert.Equal(t, jobs[0].Key, activatedJobs[0].Key())
+	assert.Equal(t, "corrected", activatedJobs[0].Variable("workerValue"))
+
+	require.NoError(t, engine.JobCompleteByKey(t.Context(), activatedJobs[0].Key(), nil))
+	completedJob, err := store.FindJobByJobKey(t.Context(), activatedJobs[0].Key())
+	require.NoError(t, err)
+	assert.Equal(t, runtime.ActivityStateCompleted, completedJob.State)
+	resolvedIncident, err := store.FindIncidentByKey(t.Context(), incidents[0].Key)
+	require.NoError(t, err)
+	assert.NotNil(t, resolvedIncident.ResolvedAt)
+	completedInstance, err := store.FindProcessInstanceByKey(t.Context(), instance.ProcessInstance().Key)
+	require.NoError(t, err)
+	assert.Equal(t, runtime.ActivityStateCompleted, completedInstance.ProcessInstance().State)
+}
+
+func TestResolveMultiInstanceJobIncidentPreservesIterationVariable(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+
+	process, err := engine.LoadFromFile(t.Context(), "./test-cases/multi_instance_service_task.bpmn")
+	require.NoError(t, err)
+	instance, err := engine.CreateInstanceByKey(t.Context(), process.Key, map[string]interface{}{
+		"testInputCollection": []string{"first"},
+		"currentProcessValue": "original",
+	})
+	require.NoError(t, err)
+
+	var jobs []runtime.Job
+	require.Eventually(t, func() bool {
+		jobs, err = store.FindActiveJobsByType(t.Context(), "TestType")
+		return err == nil && len(jobs) == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, "first", jobs[0].InputVariables["testElementInput"])
+
+	require.NoError(t, engine.JobFailByKey(t.Context(), jobs[0].Key, "expected incident", nil, nil))
+	incidents, err := store.FindIncidentsByProcessInstanceKey(t.Context(), jobs[0].ProcessInstanceKey)
+	require.NoError(t, err)
+	require.Len(t, incidents, 1)
+
+	_, _, err = engine.ModifyInstance(t.Context(), jobs[0].ProcessInstanceKey, nil, nil, map[string]interface{}{
+		"currentProcessValue": "corrected",
+	})
+	require.NoError(t, err)
+	require.NoError(t, engine.ResolveIncident(t.Context(), incidents[0].Key))
+
+	flowElementInstance, err := store.GetFlowElementInstanceByKey(t.Context(), jobs[0].ElementInstanceKey)
+	require.NoError(t, err)
+	assert.Equal(t, "corrected", flowElementInstance.InputVariables["currentProcessValue"])
+	assert.Equal(t, "first", flowElementInstance.InputVariables["item"])
+	assert.NotContains(t, flowElementInstance.InputVariables, "testElementInput")
+
+	activatedJobs, err := engine.ActivateJobs(t.Context(), "TestType")
+	require.NoError(t, err)
+	require.Len(t, activatedJobs, 1)
+	assert.Equal(t, "first", activatedJobs[0].Variable("testElementInput"))
+	assert.Equal(t, "corrected", activatedJobs[0].Variable("currentProcessValue"))
+
+	require.NoError(t, engine.JobCompleteByKey(t.Context(), activatedJobs[0].Key(), map[string]interface{}{
+		"testJobOutput": "first-completed",
+	}))
+	require.Eventually(t, func() bool {
+		completedRoot, rootErr := store.FindProcessInstanceByKey(t.Context(), instance.ProcessInstance().Key)
+		completedIteration, iterationErr := store.FindProcessInstanceByKey(t.Context(), jobs[0].ProcessInstanceKey)
+		return rootErr == nil && iterationErr == nil &&
+			completedRoot.ProcessInstance().State == runtime.ActivityStateCompleted &&
+			completedIteration.ProcessInstance().State == runtime.ActivityStateCompleted
+	}, time.Second, 10*time.Millisecond)
+	completedJob, err := store.FindJobByJobKey(t.Context(), activatedJobs[0].Key())
+	require.NoError(t, err)
+	assert.Equal(t, runtime.ActivityStateCompleted, completedJob.State)
+	resolvedIncident, err := store.FindIncidentByKey(t.Context(), incidents[0].Key)
+	require.NoError(t, err)
+	assert.NotNil(t, resolvedIncident.ResolvedAt)
+}
+
+func TestResolveMultiInstanceJobIncidentReevaluatesMappingFromOriginalIterationVariable(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+
+	process, err := engine.LoadFromFile(t.Context(), "./test-cases/incident-multi-instance-mapped-loop-variable.bpmn")
+	require.NoError(t, err)
+	_, err = engine.CreateInstanceByKey(t.Context(), process.Key, map[string]interface{}{
+		"items": []string{"first"},
+	})
+	require.NoError(t, err)
+
+	var jobs []runtime.Job
+	require.Eventually(t, func() bool {
+		jobs, err = store.FindActiveJobsByType(t.Context(), "mapped-loop-variable-retry-job")
+		return err == nil && len(jobs) == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, "first-mapped", jobs[0].InputVariables["item"])
+
+	require.NoError(t, engine.JobFailByKey(t.Context(), jobs[0].Key, "expected incident", nil, nil))
+	incidents, err := store.FindIncidentsByProcessInstanceKey(t.Context(), jobs[0].ProcessInstanceKey)
+	require.NoError(t, err)
+	require.Len(t, incidents, 1)
+	require.NoError(t, engine.ResolveIncident(t.Context(), incidents[0].Key))
+
+	activatedJobs, err := engine.ActivateJobs(t.Context(), "mapped-loop-variable-retry-job")
+	require.NoError(t, err)
+	require.Len(t, activatedJobs, 1)
+	assert.Equal(t, "first-mapped", activatedJobs[0].Variable("item"))
 }
 
 func TestResolveIncidentReturnsErrNotFound(t *testing.T) {

--- a/pkg/bpmn/test-cases/incident-job-input-refresh.bpmn
+++ b/pkg/bpmn/test-cases/incident-job-input-refresh.bpmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_incident_job_input_refresh" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="incident-job-input-refresh" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>flow-to-task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow-to-task" sourceRef="start" targetRef="retry-task" />
+    <bpmn:serviceTask id="retry-task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="incident-retry-job" />
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=sourceValue" target="workerValue" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow-to-task</bpmn:incoming>
+      <bpmn:outgoing>flow-to-end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow-to-end" sourceRef="retry-task" targetRef="end" />
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>flow-to-end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/pkg/bpmn/test-cases/incident-multi-instance-mapped-loop-variable.bpmn
+++ b/pkg/bpmn/test-cases/incident-multi-instance-mapped-loop-variable.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_incident_multi_instance_mapped_loop_variable" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="incident-multi-instance-mapped-loop-variable" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>flow-to-task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow-to-task" sourceRef="start" targetRef="retry-task" />
+    <bpmn:serviceTask id="retry-task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="mapped-loop-variable-retry-job" />
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=item + &#34;-mapped&#34;" target="item" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow-to-task</bpmn:incoming>
+      <bpmn:outgoing>flow-to-end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zenbpm:loopCharacteristics inputCollection="=items" inputElement="item" outputCollection="results" outputElement="=item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow-to-end" sourceRef="retry-task" targetRef="end" />
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>flow-to-end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/test/e2e/service_task_job_fail_incident_test.go
+++ b/test/e2e/service_task_job_fail_incident_test.go
@@ -1,11 +1,18 @@
 package e2e
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/pbinitiative/zenbpm/internal/rest/public"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient/proto"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestServiceTaskJobFailIncident(t *testing.T) {
@@ -43,10 +50,148 @@ func TestServiceTaskJobFailIncident(t *testing.T) {
 
 		incidents, err := getProcessInstanceIncidents(t, processInstance.Key)
 		require.NoError(t, err)
+		require.Len(t, incidents, 1)
 
 		resolveIncident(t, incidents[0].Key)
 
 		incidentsAfterResolve, err := getProcessInstanceIncidents(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Len(t, incidentsAfterResolve, 1)
 		require.NotNil(t, incidentsAfterResolve[0].ResolvedAt)
+	})
+
+	t.Run("Resolved job reevaluates input mappings with updated process variables", func(t *testing.T) {
+		type jobDelivery struct {
+			key       int64
+			variables map[string]any
+			err       error
+		}
+
+		processInstance := deployAndCreateUniqueProcessDefinition(t,
+			"testdata/service_task/service_task_job_fail_incident_refresh_input_variables.bpmn",
+			map[string]any{"source_value": "original"},
+		)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		deliveries := make(chan jobDelivery, 2)
+		connection, err := grpc.NewClient(app.grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, connection.Close())
+		})
+
+		grpcClient := zenclient.NewGrpc(connection)
+		_, err = grpcClient.RegisterWorker(t.Context(), "incident-input-refresh", func(_ context.Context, job *proto.WaitingJob) (map[string]any, *zenclient.WorkerError) {
+			variables := make(map[string]any)
+			unmarshalErr := json.Unmarshal(job.GetInputVariables(), &variables)
+			deliveries <- jobDelivery{key: job.GetKey(), variables: variables, err: unmarshalErr}
+			if unmarshalErr != nil {
+				return nil, &zenclient.WorkerError{Err: unmarshalErr}
+			}
+			if variables["worker_value"] != "corrected" {
+				return nil, &zenclient.WorkerError{Err: errors.New("input variables are not corrected")}
+			}
+			return nil, nil
+		}, "incident-input-refresh")
+		require.NoError(t, err)
+
+		nextDelivery := func() jobDelivery {
+			t.Helper()
+			select {
+			case delivery := <-deliveries:
+				return delivery
+			case <-time.After(30 * time.Second):
+				t.Fatal("job was not delivered to the worker")
+				return jobDelivery{}
+			}
+		}
+
+		firstDelivery := nextDelivery()
+		require.NoError(t, firstDelivery.err)
+		require.Equal(t, map[string]any{
+			"source_value": "original",
+			"worker_value": "original",
+		}, firstDelivery.variables)
+
+		waitForProcessInstanceJobByElementId(t, processInstance.Key, "service_task", public.JobStateFailed)
+		incidents, err := getProcessInstanceIncidents(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Len(t, incidents, 1)
+		require.Nil(t, incidents[0].ResolvedAt)
+
+		require.NoError(t, updateProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"source_value": "corrected",
+		}))
+		resolveIncident(t, incidents[0].Key)
+
+		secondDelivery := nextDelivery()
+		require.NoError(t, secondDelivery.err)
+		require.Equal(t, firstDelivery.key, secondDelivery.key)
+		require.Equal(t, map[string]any{
+			"source_value": "corrected",
+			"worker_value": "corrected",
+		}, secondDelivery.variables)
+		assertFlowElementInputVariables(t, processInstance.Key, "service_task", map[string]any{
+			"source_value": "corrected",
+		})
+
+		waitForProcessInstanceJobByElementId(t, processInstance.Key, "service_task", public.JobStateCompleted)
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateCompleted)
+
+		resolvedIncidents, err := getProcessInstanceIncidents(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Len(t, resolvedIncidents, 1)
+		require.NotNil(t, resolvedIncidents[0].ResolvedAt)
+	})
+
+	t.Run("Resolved multi-instance job maps the original loop variable only once", func(t *testing.T) {
+		processInstance := deployAndCreateUniqueProcessDefinition(t,
+			"testdata/service_task/service_task_multi_instance_mapped_loop_variable_incident.bpmn",
+			map[string]any{
+				"items":         []string{"first"},
+				"current_value": "original",
+			},
+		)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		multiInstanceProcess := waitForChildProcessInstance(t, processInstance.Key, 0)
+		job := waitForProcessInstanceActiveJobByElementId(t, multiInstanceProcess.Key, "service_task")
+		require.Equal(t, "first-mapped", job.InputVariables["item"])
+
+		failJob(t, job.Key, nil, nil)
+		waitForProcessInstanceJobByElementId(t, multiInstanceProcess.Key, "service_task", public.JobStateFailed)
+		incidents, err := getProcessInstanceIncidents(t, multiInstanceProcess.Key)
+		require.NoError(t, err)
+		require.Len(t, incidents, 1)
+		require.Nil(t, incidents[0].ResolvedAt)
+
+		require.NoError(t, updateProcessInstanceVariables(t, multiInstanceProcess.Key, map[string]any{
+			"current_value": "corrected",
+		}))
+		resolveIncident(t, incidents[0].Key)
+		retryJob := waitForProcessInstanceActiveJobByElementId(t, multiInstanceProcess.Key, "service_task")
+		require.Equal(t, job.Key, retryJob.Key)
+		require.Equal(t, "first-mapped", retryJob.InputVariables["item"])
+		assertFlowElementInputVariables(t, multiInstanceProcess.Key, "service_task", map[string]any{
+			"items":         []any{"first"},
+			"current_value": "corrected",
+			"item":          "first",
+		})
+
+		require.NoError(t, completeJob(t, retryJob.Key, nil))
+		waitForProcessInstanceJobByElementId(t, multiInstanceProcess.Key, "service_task", public.JobStateCompleted)
+		waitForTwoProcessInstanceStates(t,
+			processInstance.Key, zenclient.ProcessInstanceStateCompleted,
+			multiInstanceProcess.Key, zenclient.ProcessInstanceStateCompleted,
+		)
+
+		resolvedIncidents, err := getProcessInstanceIncidents(t, multiInstanceProcess.Key)
+		require.NoError(t, err)
+		require.Len(t, resolvedIncidents, 1)
+		require.NotNil(t, resolvedIncidents[0].ResolvedAt)
 	})
 }

--- a/test/e2e/testdata/service_task/service_task_job_fail_incident_refresh_input_variables.bpmn
+++ b/test/e2e/testdata/service_task/service_task_job_fail_incident_refresh_input_variables.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_service_task_job_fail_incident_refresh_input_variables" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="service_task_job_fail_incident_refresh_input_variables" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_service_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_service_task" sourceRef="start_event" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="incident-input-refresh" />
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=source_value" target="worker_value" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_service_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_end" sourceRef="service_task" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="service_task_job_fail_incident_refresh_input_variables">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="service_task_di" bpmnElement="service_task">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_di" bpmnElement="end_event">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_service_task_di" bpmnElement="flow_to_service_task">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_end_di" bpmnElement="flow_to_end">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/service_task/service_task_multi_instance_mapped_loop_variable_incident.bpmn
+++ b/test/e2e/testdata/service_task/service_task_multi_instance_mapped_loop_variable_incident.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_service_task_multi_instance_mapped_loop_variable_incident" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="service_task_multi_instance_mapped_loop_variable_incident" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_service_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_service_task" sourceRef="start_event" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="mapped-loop-variable-incident" />
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=item + &#34;-mapped&#34;" target="item" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_service_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zenbpm:loopCharacteristics inputCollection="=items" inputElement="item" outputCollection="results" outputElement="=item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_end" sourceRef="service_task" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
closes #721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incident-resolved job retries now recompute task input mappings using the latest process variables before reactivating the job.
  * Refreshed inputs are applied to both retried jobs and their corresponding flow-element input state.
  * Multi-instance incident retries preserve the original per-iteration `item` while still updating process-variable-derived mappings.

* **Tests**
  * Added unit and e2e coverage for refreshed input mappings, resolved incident timestamps, and multi-instance iteration/mapping behavior.
  * Added new BPMN test artifacts for incident input refresh and multi-instance incident retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->