### PR TITLE
#733 - Refactor to apply the single approach when cancelling DB timer to also remove the TimerManager timer

### DIFF
--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -181,17 +181,8 @@ func (engine *Engine) cancelInstance(ctx context.Context, instance runtime.Proce
 func (engine *Engine) handleProcessInstanceInnerCancel(ctx context.Context, instance runtime.ProcessInstance, batch *EngineBatch, omitTokenKeys ...int64,
 ) (terminatedTokens []runtime.ExecutionToken, err error) {
 	// Cancel all message subscriptions
-	messageSubscriptions, err := engine.persistence.FindProcessInstanceMessageSubscriptions(ctx, instance.ProcessInstance().GetInstanceKey(), runtime.ActivityStateActive)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find message subscriptions for instance %d: %w", instance.ProcessInstance().Key, err)
-	}
-
-	for _, messageSubscription := range messageSubscriptions {
-		messageSubscription.MessageSubscription().State = runtime.ActivityStateTerminated
-		err = batch.SaveMessageSubscription(ctx, messageSubscription)
-		if err != nil {
-			return nil, fmt.Errorf("failed to save changes to message subscription %d: %w", messageSubscription.MessageSubscription().Key, err)
-		}
+	if err := engine.terminateProcessInstanceMessageSubscriptions(ctx, batch, instance.ProcessInstance().GetInstanceKey()); err != nil {
+		return nil, fmt.Errorf("failed to cancel message subscriptions for instance %d: %w", instance.ProcessInstance().Key, err)
 	}
 
 	// Cancel all error subscriptions
@@ -208,15 +199,8 @@ func (engine *Engine) handleProcessInstanceInnerCancel(ctx context.Context, inst
 	}
 
 	// Cancel all timer subscriptions
-	timers, err := engine.persistence.FindProcessInstanceTimers(ctx, instance.ProcessInstance().Key, runtime.TimerStateCreated)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find timers for instance %d: %w", instance.ProcessInstance().Key, err)
-	}
-	for _, timer := range timers {
-		err = engine.cancelTimer(ctx, batch, timer)
-		if err != nil {
-			return nil, fmt.Errorf("failed to save changes to timer %d: %w", timer.Key, err)
-		}
+	if err := engine.cancelProcessInstanceTimers(ctx, batch, instance.ProcessInstance().Key); err != nil {
+		return nil, fmt.Errorf("failed to cancel timers for instance %d: %w", instance.ProcessInstance().Key, err)
 	}
 
 	// Cancel all jobs
@@ -1472,26 +1456,13 @@ func (engine *Engine) handlePlainEndEvent(ctx context.Context, batch *EngineBatc
 		}
 		if !hasActiveSubProcess {
 			// Cancel all active timers for this process instance
-			timers, err := engine.persistence.FindProcessInstanceTimers(ctx, instance.ProcessInstance().Key, runtime.TimerStateCreated)
-			if err != nil {
-				return errors.Join(newEngineErrorf("failed to load active timers for key: %d", instance.ProcessInstance().Key), err)
-			}
-			for _, timer := range timers {
-				if err = engine.cancelTimer(ctx, batch, timer); err != nil {
-					return errors.Join(newEngineErrorf("failed to cancel timer %d for process instance key: %d", timer.Key, instance.ProcessInstance().Key), err)
-				}
+			if err := engine.cancelProcessInstanceTimers(ctx, batch, instance.ProcessInstance().Key); err != nil {
+				return errors.Join(newEngineErrorf("failed to cancel timers for process instance key: %d", instance.ProcessInstance().Key), err)
 			}
 
 			// Cancel all active message subscriptions for this process instance
-			messageSubscriptions, err := engine.persistence.FindProcessInstanceMessageSubscriptions(ctx, instance.ProcessInstance().Key, runtime.ActivityStateActive)
-			if err != nil {
-				return errors.Join(newEngineErrorf("failed to load active message subscriptions for key: %d", instance.ProcessInstance().Key), err)
-			}
-			for _, messageSubscription := range messageSubscriptions {
-				messageSubscription.MessageSubscription().State = runtime.ActivityStateTerminated
-				if err = batch.SaveMessageSubscription(ctx, messageSubscription); err != nil {
-					return errors.Join(newEngineErrorf("failed to cancel message subscription %d for process instance key: %d", messageSubscription.MessageSubscription().Key, instance.ProcessInstance().Key), err)
-				}
+			if err := engine.terminateProcessInstanceMessageSubscriptions(ctx, batch, instance.ProcessInstance().Key); err != nil {
+				return errors.Join(newEngineErrorf("failed to cancel message subscriptions for process instance key: %d", instance.ProcessInstance().Key), err)
 			}
 
 			instance.ProcessInstance().State = runtime.ActivityStateCompleted

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -109,10 +109,6 @@ func NewEngine(options ...EngineOption) Engine {
 	return engine
 }
 
-func EngineWithExporter(exporter exporter.EventExporter) EngineOption {
-	return func(engine *Engine) { engine.AddEventExporter(exporter) }
-}
-
 func EngineWithStorage(persistence storage.Storage) EngineOption {
 	return func(engine *Engine) {
 		engine.persistence = persistence
@@ -138,12 +134,6 @@ func EngineWithJs(jsRuntime script.JsRuntime) EngineOption {
 	return func(engine *Engine) {
 		engine.jsRuntime.Stop()
 		engine.jsRuntime = jsRuntime
-	}
-}
-
-func EngineWithLogger(logger hclog.Logger) EngineOption {
-	return func(engine *Engine) {
-		engine.logger = logger
 	}
 }
 
@@ -213,8 +203,7 @@ func (engine *Engine) handleProcessInstanceInnerCancel(ctx context.Context, inst
 		return nil, fmt.Errorf("failed to find timers for instance %d: %w", instance.ProcessInstance().Key, err)
 	}
 	for _, timer := range timers {
-		timer.TimerState = runtime.TimerStateCancelled
-		err = batch.SaveTimer(ctx, timer)
+		err = engine.cancelTimer(ctx, batch, timer)
 		if err != nil {
 			return nil, fmt.Errorf("failed to save changes to timer %d: %w", timer.Key, err)
 		}
@@ -1478,8 +1467,7 @@ func (engine *Engine) handlePlainEndEvent(ctx context.Context, batch *EngineBatc
 				return errors.Join(newEngineErrorf("failed to load active timers for key: %d", instance.ProcessInstance().Key), err)
 			}
 			for _, timer := range timers {
-				timer.TimerState = runtime.TimerStateCancelled
-				if err = batch.SaveTimer(ctx, timer); err != nil {
+				if err = engine.cancelTimer(ctx, batch, timer); err != nil {
 					return errors.Join(newEngineErrorf("failed to cancel timer %d for process instance key: %d", timer.Key, instance.ProcessInstance().Key), err)
 				}
 			}
@@ -1548,7 +1536,7 @@ func (engine *Engine) handleExternalEndEventContinuation(ctx context.Context, ba
 			if err != nil {
 				return nil, fmt.Errorf("failed to handle plain EndEvent: %w", err)
 			}
-			for i, _ := range tokens {
+			for i := range tokens {
 				if tokens[i].Key == jobToken.Key {
 					tokens[i].State = runtime.TokenStateCompleted
 				}

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -109,6 +109,10 @@ func NewEngine(options ...EngineOption) Engine {
 	return engine
 }
 
+func EngineWithExporter(exporter exporter.EventExporter) EngineOption {
+	return func(engine *Engine) { engine.AddEventExporter(exporter) }
+}
+
 func EngineWithStorage(persistence storage.Storage) EngineOption {
 	return func(engine *Engine) {
 		engine.persistence = persistence
@@ -134,6 +138,12 @@ func EngineWithJs(jsRuntime script.JsRuntime) EngineOption {
 	return func(engine *Engine) {
 		engine.jsRuntime.Stop()
 		engine.jsRuntime = jsRuntime
+	}
+}
+
+func EngineWithLogger(logger hclog.Logger) EngineOption {
+	return func(engine *Engine) {
+		engine.logger = logger
 	}
 }
 

--- a/pkg/bpmn/events.go
+++ b/pkg/bpmn/events.go
@@ -276,6 +276,22 @@ func (engine *Engine) cancelBoundarySubscriptions(ctx context.Context, batch *En
 	return nil
 }
 
+// terminateProcessInstanceMessageSubscriptions terminates every Active message subscription of the process instance.
+// it also covers token-less subscriptions such as event-subprocess message start events (InstanceMessageSubscription).
+func (engine *Engine) terminateProcessInstanceMessageSubscriptions(ctx context.Context, batch *EngineBatch, instanceKey int64) error {
+	messageSubscriptions, err := engine.persistence.FindProcessInstanceMessageSubscriptions(ctx, instanceKey, runtime.ActivityStateActive)
+	if err != nil {
+		return fmt.Errorf("failed to find message subscriptions for instance %d: %w", instanceKey, err)
+	}
+	for _, messageSubscription := range messageSubscriptions {
+		messageSubscription.MessageSubscription().State = runtime.ActivityStateTerminated
+		if err := batch.SaveMessageSubscription(ctx, messageSubscription); err != nil {
+			return fmt.Errorf("failed to save changes to message subscription %d: %w", messageSubscription.MessageSubscription().Key, err)
+		}
+	}
+	return nil
+}
+
 type GatewayEvent interface {
 	GetId() string
 	GetKey() int64

--- a/pkg/bpmn/events.go
+++ b/pkg/bpmn/events.go
@@ -255,8 +255,7 @@ func (engine *Engine) cancelBoundarySubscriptions(ctx context.Context, batch *En
 		return fmt.Errorf("failed to find timer subscriptions for instance %d: %w", processInstanceKey, err)
 	}
 	for _, timerSubscription := range timerSubscriptions {
-		timerSubscription.TimerState = runtime.TimerStateCancelled
-		err = batch.SaveTimer(ctx, timerSubscription)
+		err = engine.cancelTimer(ctx, batch, timerSubscription)
 		if err != nil {
 			return fmt.Errorf("failed to save changes to timer subscription %d: %w", timerSubscription.Key, err)
 		}
@@ -396,9 +395,7 @@ func (engine *Engine) publishEventOnEventGateway(ctx context.Context, batch *Eng
 		if event.GetKey() == sub.Key {
 			continue
 		}
-		sub.TimerState = runtime.TimerStateCancelled
-		engine.timerManager.removeTimer(sub)
-		err := batch.SaveTimer(ctx, sub)
+		err := engine.cancelTimer(ctx, batch, sub)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/bpmn/timer.go
+++ b/pkg/bpmn/timer.go
@@ -43,6 +43,25 @@ func (engine *Engine) createTimerCatchEvent(ctx context.Context, batch *EngineBa
 	return currentToken, err
 }
 
+// cancelTimer is the single place that cancels a timer.
+// If the batch later fails to flush, the DB timer stays in Created state while the in-memory copy is already gone.
+// That is recovered automatically: the timer manager puts it back into its waiting list for processing.
+func (engine *Engine) cancelTimer(ctx context.Context, batch *EngineBatch, timer runtime.Timer) error {
+	timer.TimerState = runtime.TimerStateCancelled
+	if err := batch.SaveTimer(ctx, timer); err != nil {
+		return fmt.Errorf("failed to save cancelled timer %d: %w", timer.Key, err)
+	}
+	// Remove the in-memory copy already before the flush (not only in the post-flush action) so
+	// its waiter cannot fire and contend on the instance lock while the cancelling batch is still
+	// open. The cost is the failed-flush recovery gap described above; do not defer this removal
+	// entirely to the post-flush action.
+	engine.timerManager.removeTimer(timer)
+	batch.AddPostFlushAction(ctx, func() {
+		engine.timerManager.tombstoneCancelledTimer(timer)
+	})
+	return nil
+}
+
 func (engine *Engine) createDurationTimer(
 	instance runtime.ProcessInstance,
 	timerDef bpmn20.TTimerEventDefinition,

--- a/pkg/bpmn/timer.go
+++ b/pkg/bpmn/timer.go
@@ -62,6 +62,21 @@ func (engine *Engine) cancelTimer(ctx context.Context, batch *EngineBatch, timer
 	return nil
 }
 
+// cancelProcessInstanceTimers cancels every Created timer of the process instance through cancelTimer,
+// including token-less timers such as event-subprocess timer start events.
+func (engine *Engine) cancelProcessInstanceTimers(ctx context.Context, batch *EngineBatch, instanceKey int64) error {
+	timers, err := engine.persistence.FindProcessInstanceTimers(ctx, instanceKey, runtime.TimerStateCreated)
+	if err != nil {
+		return fmt.Errorf("failed to find timers for instance %d: %w", instanceKey, err)
+	}
+	for _, timer := range timers {
+		if err := engine.cancelTimer(ctx, batch, timer); err != nil {
+			return fmt.Errorf("failed to cancel timer %d for instance %d: %w", timer.Key, instanceKey, err)
+		}
+	}
+	return nil
+}
+
 func (engine *Engine) createDurationTimer(
 	instance runtime.ProcessInstance,
 	timerDef bpmn20.TTimerEventDefinition,

--- a/pkg/bpmn/timer_boundary_cancelled_lock_test.go
+++ b/pkg/bpmn/timer_boundary_cancelled_lock_test.go
@@ -26,15 +26,9 @@ func TestTriggerBoundaryTimer_AlreadyCancelled_ReleasesInstanceLock(t *testing.T
 	process, err := engine.LoadFromFile(t.Context(), "./test-cases/timer-boundary-event-noninterrupting.bpmn")
 	require.NoError(t, err)
 
-	instance, err := engine.CreateInstance(t.Context(), process, nil)
-	require.NoError(t, err)
-	piKey := instance.ProcessInstance().Key
-
 	// Find the boundary timer and mark it Cancelled to simulate the race where the job was
 	// completed (cancelling the timer) right before the scheduler fired it.
-	timers, err := store.FindProcessInstanceTimers(t.Context(), piKey, runtime.TimerStateCreated)
-	require.NoError(t, err)
-	require.Len(t, timers, 1)
+	piKey, timers := createInstanceAndGetTimers(t, &engine, store, process)
 	target := timers[0]
 	require.NotNil(t, target.Token, "boundary timer must carry an execution token")
 
@@ -49,18 +43,13 @@ func TestTriggerBoundaryTimer_AlreadyCancelled_ReleasesInstanceLock(t *testing.T
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timer is already cancelled")
 
-	require.NoError(t, engine.runningInstances.tryLockInstance(t.Context(), piKey),
-		"process instance lock must be released after triggering an already-cancelled timer")
-	engine.runningInstances.unlockInstance(piKey)
+	requireInstanceLockReleased(t, &engine, piKey, "process instance lock must be released after triggering an already-cancelled timer")
 
 	job := findActiveJob(t, store, piKey, "simple-job")
 	require.NotNil(t, job, "the service task job must still be active")
 	require.NoError(t, engine.JobCompleteByKey(t.Context(), job.Key, nil))
 
-	require.Eventually(t, func() bool {
-		pi, err := store.FindProcessInstanceByKey(t.Context(), piKey)
-		return err == nil && pi.ProcessInstance().GetState() == runtime.ActivityStateCompleted
-	}, 5*time.Second, 100*time.Millisecond, "process instance should complete after the job is done")
+	waitForProcessInstanceState(t, store, piKey, runtime.ActivityStateCompleted)
 }
 
 func findActiveJob(t *testing.T, store *inmemory.Storage, processInstanceKey int64, jobType string) *runtime.Job {
@@ -73,4 +62,27 @@ func findActiveJob(t *testing.T, store *inmemory.Storage, processInstanceKey int
 		}
 	}
 	return nil
+}
+
+// createInstanceAndGetTimers creates a new process instance from the given definition and
+// returns its key along with the single Created boundary timer. The test fails immediately if
+// instance creation or timer lookup does not produce exactly one Created timer.
+func createInstanceAndGetTimers(t *testing.T, eng *Engine, store *inmemory.Storage, process *runtime.ProcessDefinition) (piKey int64, timers []runtime.Timer) {
+	t.Helper()
+	instance, err := eng.CreateInstance(t.Context(), process, nil)
+	require.NoError(t, err)
+	piKey = instance.ProcessInstance().Key
+
+	timers, err = store.FindProcessInstanceTimers(t.Context(), piKey, runtime.TimerStateCreated)
+	require.NoError(t, err)
+	require.Len(t, timers, 1)
+	return
+}
+
+// requireInstanceLockReleased verifies that the process instance lock is not held by asserting
+// that tryLockInstance succeeds, then immediately releasing it again.
+func requireInstanceLockReleased(t *testing.T, eng *Engine, piKey int64, msg string) {
+	t.Helper()
+	require.NoError(t, eng.runningInstances.tryLockInstance(t.Context(), piKey), msg)
+	eng.runningInstances.unlockInstance(piKey)
 }

--- a/pkg/bpmn/timer_cancel_recovery_test.go
+++ b/pkg/bpmn/timer_cancel_recovery_test.go
@@ -1,0 +1,157 @@
+package bpmn
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/storage"
+	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCancelTimer_BatchFlushFails_TimerIsRepolledIntoTimerManager verifies the recovery path of
+// engine.cancelTimer: cancelling a timer removes its in-memory copy from the timer manager
+// before the batch holding the DB state change is flushed. If that flush then fails, the DB
+// timer is left in Created state while the timer manager no longer holds it in memory. The
+// timer manager must pick the (now overdue) Created timer up again on its next poll and process
+// it, so no timer is ever lost.
+func TestCancelTimer_BatchFlushFails_TimerIsRepolledIntoTimerManager(t *testing.T) {
+	store := &flakyFlushStorage{Storage: inmemory.NewStorage()}
+	// Poll delay of 2s: the PT1S boundary timer is due before the first poll, so it is
+	// registered in-memory immediately on creation, and the recovery re-poll happens ~2s
+	// after the failed cancellation.
+	engine := NewEngine(EngineWithStorage(store), EngineWithPollTimerDelay(2*time.Second))
+	require.NoError(t, engine.Start(t.Context()))
+	defer engine.Stop()
+
+	process, err := engine.LoadFromFile(t.Context(), "./test-cases/timer-boundary-event-noninterrupting.bpmn")
+	require.NoError(t, err)
+
+	piKey, timers := createInstanceAndGetTimers(t, &engine, store.Storage, process)
+	timerKey := timers[0].Key
+
+	require.Eventually(t, func() bool {
+		return timerManagerHasWaitingTimer(engine.timerManager, timerKey)
+	}, 2*time.Second, 10*time.Millisecond, "boundary timer should be loaded into the timer manager's in-memory waiting list")
+
+	job := findActiveJob(t, store.Storage, piKey, "simple-job")
+	require.NotNil(t, job, "the service task job must be active")
+
+	// The cancellation must happen while the boundary timer is still Created and waiting in
+	// memory. If test setup already consumed the whole PT1S window (e.g. on a loaded CI runner),
+	// the timer would fire first and the race could not be exercised.
+	require.True(t, time.Now().Before(timers[0].DueAt.Add(-200*time.Millisecond)),
+		"test setup took too long; boundary timer would fire before the job completion — cannot exercise the race")
+
+	// Completing the job cancels the boundary timer: cancelTimer removes the in-memory copy and
+	// stages the Cancelled state into the batch, whose flush is set up to fail.
+	store.failFlush.Store(true)
+	err = engine.JobCompleteByKey(t.Context(), job.Key, nil)
+	require.ErrorContains(t, err, "injected flush failure")
+	store.failFlush.Store(false)
+
+	// The failed cancellation must leave a consistent, recoverable state behind.
+	dbTimer, err := store.GetTimer(t.Context(), timerKey)
+	require.NoError(t, err)
+	assert.Equal(t, runtime.TimerStateCreated, dbTimer.TimerState,
+		"DB timer must stay in Created state when the cancelling batch fails to flush")
+	assert.False(t, timerManagerHasWaitingTimer(engine.timerManager, timerKey),
+		"in-memory timer must have been removed from the timer manager by the cancellation attempt")
+	requireInstanceLockReleased(t, &engine, piKey, "process instance lock must be released after the failed job completion")
+
+	// The next poll must take the overdue Created timer back into the timer manager and process
+	// it: the non-interrupting boundary event fires and the timer ends up Triggered.
+	require.Eventually(t, func() bool {
+		dbTimer, err := store.GetTimer(t.Context(), timerKey)
+		return err == nil && dbTimer.TimerState == runtime.TimerStateTriggered
+	}, 10*time.Second, 50*time.Millisecond, "overdue Created timer should be re-polled into the timer manager and triggered")
+
+	// The engine must remain fully operable: the job is still active and can now be completed.
+	job = findActiveJob(t, store.Storage, piKey, "simple-job")
+	require.NotNil(t, job, "the service task job must still be active after the failed completion")
+	require.NoError(t, engine.JobCompleteByKey(t.Context(), job.Key, nil))
+
+	waitForProcessInstanceState(t, store, piKey, runtime.ActivityStateCompleted)
+}
+
+func TestCancelTimer_BatchFlushSucceeds_InFlightPollCannotReinsertTimer(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store), EngineWithPollTimerDelay(time.Hour))
+	require.NoError(t, engine.Start(t.Context()))
+	defer engine.Stop()
+
+	timer := runtime.Timer{
+		Key:        42,
+		TimerState: runtime.TimerStateCreated,
+		CreatedAt:  time.Now(),
+		DueAt:      time.Now().Add(time.Hour),
+	}
+	storageBatch := store.NewBatch()
+	require.NoError(t, storageBatch.SaveTimer(t.Context(), timer))
+	require.NoError(t, storageBatch.Flush(t.Context()))
+	engine.timerManager.addWaitingTimer(timer)
+
+	batch, err := engine.NewEngineBatchClean()
+	require.NoError(t, err)
+	require.NoError(t, engine.cancelTimer(t.Context(), &batch, timer))
+	require.False(t, timerManagerHasWaitingTimer(engine.timerManager, timer.Key),
+		"cancellation should immediately remove the existing in-memory timer")
+
+	// This value represents a Created result captured by a poll before the cancellation commit.
+	// Once the flush succeeds, its tombstone must reject that stale result without waiting for
+	// another database operation.
+	require.NoError(t, batch.Flush(t.Context()))
+	persisted, err := store.GetTimer(t.Context(), timer.Key)
+	require.NoError(t, err)
+	require.Equal(t, runtime.TimerStateCancelled, persisted.TimerState)
+	engine.timerManager.addWaitingTimer(timer)
+	require.False(t, timerManagerHasWaitingTimer(engine.timerManager, timer.Key),
+		"successful flush must reject a stale timer returned by an in-flight poll")
+
+	// A later successful poll observes the committed state and clears the temporary tombstone.
+	require.NoError(t, engine.timerManager.pollTimers(time.Now().Add(2*time.Hour)))
+	engine.timerManager.addWaitingTimer(timer)
+	require.True(t, timerManagerHasWaitingTimer(engine.timerManager, timer.Key),
+		"the cancellation tombstone should be cleared after a later successful poll")
+}
+
+// timerManagerHasWaitingTimer reports whether the timer with the given key is currently in the
+// timer manager's in-memory waiting list.
+func timerManagerHasWaitingTimer(tm *timerManager, timerKey int64) bool {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	for _, wt := range tm.waitingTimers {
+		if wt.timer.Key == timerKey {
+			return true
+		}
+	}
+	return false
+}
+
+// flakyFlushStorage wraps the in-memory storage and injects batch flush failures on demand.
+type flakyFlushStorage struct {
+	*inmemory.Storage
+	failFlush atomic.Bool
+}
+
+func (s *flakyFlushStorage) NewBatch() storage.Batch {
+	return &flakyFlushBatch{Batch: s.Storage.NewBatch(), store: s}
+}
+
+// flakyFlushBatch delegates everything to the wrapped batch but fails Flush while armed.
+type flakyFlushBatch struct {
+	storage.Batch
+	store *flakyFlushStorage
+}
+
+func (b *flakyFlushBatch) Flush(ctx context.Context) error {
+	if b.store.failFlush.Load() {
+		return fmt.Errorf("injected flush failure")
+	}
+	return b.Batch.Flush(ctx)
+}

--- a/pkg/bpmn/timer_cancel_recovery_test.go
+++ b/pkg/bpmn/timer_cancel_recovery_test.go
@@ -48,14 +48,11 @@ func TestCancelTimer_BatchFlushFails_TimerIsRepolledIntoTimerManager(t *testing.
 	require.True(t, time.Now().Before(timers[0].DueAt.Add(-200*time.Millisecond)),
 		"test setup took too long; boundary timer would fire before the job completion — cannot exercise the race")
 
-	// Completing the job cancels the boundary timer: cancelTimer removes the in-memory copy and
-	// stages the Cancelled state into the batch, whose flush is set up to fail.
 	store.failFlush.Store(true)
 	err = engine.JobCompleteByKey(t.Context(), job.Key, nil)
 	require.ErrorContains(t, err, "injected flush failure")
 	store.failFlush.Store(false)
 
-	// The failed cancellation must leave a consistent, recoverable state behind.
 	dbTimer, err := store.GetTimer(t.Context(), timerKey)
 	require.NoError(t, err)
 	assert.Equal(t, runtime.TimerStateCreated, dbTimer.TimerState,
@@ -64,14 +61,11 @@ func TestCancelTimer_BatchFlushFails_TimerIsRepolledIntoTimerManager(t *testing.
 		"in-memory timer must have been removed from the timer manager by the cancellation attempt")
 	requireInstanceLockReleased(t, &engine, piKey, "process instance lock must be released after the failed job completion")
 
-	// The next poll must take the overdue Created timer back into the timer manager and process
-	// it: the non-interrupting boundary event fires and the timer ends up Triggered.
 	require.Eventually(t, func() bool {
 		dbTimer, err := store.GetTimer(t.Context(), timerKey)
 		return err == nil && dbTimer.TimerState == runtime.TimerStateTriggered
 	}, 10*time.Second, 50*time.Millisecond, "overdue Created timer should be re-polled into the timer manager and triggered")
 
-	// The engine must remain fully operable: the job is still active and can now be completed.
 	job = findActiveJob(t, store.Storage, piKey, "simple-job")
 	require.NotNil(t, job, "the service task job must still be active after the failed completion")
 	require.NoError(t, engine.JobCompleteByKey(t.Context(), job.Key, nil))
@@ -113,7 +107,6 @@ func TestCancelTimer_BatchFlushSucceeds_InFlightPollCannotReinsertTimer(t *testi
 	require.False(t, timerManagerHasWaitingTimer(engine.timerManager, timer.Key),
 		"successful flush must reject a stale timer returned by an in-flight poll")
 
-	// A later successful poll observes the committed state and clears the temporary tombstone.
 	require.NoError(t, engine.timerManager.pollTimers(time.Now().Add(2*time.Hour)))
 	engine.timerManager.addWaitingTimer(timer)
 	require.True(t, timerManagerHasWaitingTimer(engine.timerManager, timer.Key),

--- a/pkg/bpmn/timer_manager.go
+++ b/pkg/bpmn/timer_manager.go
@@ -17,7 +17,10 @@ import (
 type processTimerFunc func(ctx context.Context, timer runtime.Timer)
 
 // pollTimerFunc must return an array of timers that are in active state and should fire before end
-// timerManager does the de-duplication of already running timers and timers returned by this function
+// timerManager does the de-duplication of already running timers and timers returned by this function.
+// The read must observe all previously committed timer state changes (read-your-writes / at least
+// weak consistency) — the timer manager clears cancellation tombstones after each successful poll
+// on the assumption that the poll saw every cancellation committed before it started.
 type pollTimerFunc func(ctx context.Context, end time.Time) ([]runtime.Timer, error)
 
 type waitingTimer struct {
@@ -39,6 +42,7 @@ type timerManager struct {
 	waitingTimers    []waitingTimer
 	waitingTimersWg  *sync.WaitGroup
 	runWg            *sync.WaitGroup
+	cancelledKeys    map[int64]struct{}
 	shuttingDown     bool
 }
 
@@ -56,6 +60,7 @@ func newTimerManager(processTimerFunc processTimerFunc, pollTimeFunc pollTimerFu
 		pollTimerFunc:    pollTimeFunc,
 		processTimerFunc: processTimerFunc,
 		logger:           hclog.Default().Named("timer-manager"),
+		cancelledKeys:    make(map[int64]struct{}),
 	}
 }
 
@@ -87,13 +92,46 @@ func (tm *timerManager) removeTimer(timer runtime.Timer) {
 
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
+	tm.deleteWaitingTimerLocked(timer.Key)
+}
+
+// deleteWaitingTimerLocked removes the waiting timer with the given key from the in-memory
+// waiting list and cancels its waiter goroutine. Callers must hold tm.mu for writing.
+func (tm *timerManager) deleteWaitingTimerLocked(key int64) {
 	tm.waitingTimers = slices.DeleteFunc(tm.waitingTimers, func(t waitingTimer) bool {
-		if t.timer.Key != timer.Key {
+		if t.timer.Key != key {
 			return false
 		}
 		t.cancel()
 		return true
 	})
+}
+
+// tombstoneCancelledTimer installs a cancellation tombstone for the timer key and purges the
+// waiting list, preventing a poll that started before the cancellation committed from
+// reinserting its stale Created copy. The single poll loop clears this tombstone only after it
+// has finished adding all results from a later poll.
+func (tm *timerManager) tombstoneCancelledTimer(timer runtime.Timer) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.cancelledKeys[timer.Key] = struct{}{}
+	tm.deleteWaitingTimerLocked(timer.Key)
+}
+
+func (tm *timerManager) pollTimers(end time.Time) error {
+	toFireTimers, err := tm.pollTimerFunc(tm.ctx, end)
+	if err != nil {
+		return err
+	}
+	for _, timer := range toFireTimers {
+		tm.addWaitingTimer(timer)
+	}
+	// Any successful poll (an empty result included) started after all tombstoned cancellations
+	// were committed, so it observed their Cancelled state and the tombstones are no longer needed.
+	tm.mu.Lock()
+	clear(tm.cancelledKeys)
+	tm.mu.Unlock()
+	return nil
 }
 
 func (tm *timerManager) run() {
@@ -128,13 +166,10 @@ func (tm *timerManager) runOnce(pollTicker *time.Ticker) (continueTimer bool) {
 		tm.processTimerFunc(context.WithoutCancel(tm.ctx), timer)
 	case t := <-pollTicker.C:
 		nextPoll := t.Add(tm.pollTimerDelay)
-		toFireTimers, err := tm.pollTimerFunc(tm.ctx, nextPoll)
+		err := tm.pollTimers(nextPoll)
 		if err != nil {
 			tm.logger.Error(fmt.Sprintf("Failed to poll timers for processing: %s", err))
 			return
-		}
-		for _, tft := range toFireTimers {
-			tm.addWaitingTimer(tft)
 		}
 		tm.mu.Lock()
 		tm.nextPoll = t.Add(tm.pollTimerDelay)
@@ -147,6 +182,9 @@ func (tm *timerManager) addWaitingTimer(tft runtime.Timer) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	if tm.shuttingDown {
+		return
+	}
+	if _, cancelled := tm.cancelledKeys[tft.Key]; cancelled {
 		return
 	}
 	for _, wt := range tm.waitingTimers {
@@ -182,11 +220,9 @@ func (tm *timerManager) start() {
 	tm.mu.Lock()
 	tm.nextPoll = time.Now().Add(tm.pollTimerDelay)
 	tm.mu.Unlock()
-	tm.runWg.Add(1)
-	go func() {
-		defer tm.runWg.Done()
+	tm.runWg.Go(func() {
 		tm.run()
-	}()
+	})
 }
 
 func (tm *timerManager) stop() {

--- a/test/e2e/timer_boundary_cancel_race_test.go
+++ b/test/e2e/timer_boundary_cancel_race_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -20,10 +21,13 @@ import (
 // cancelling the instance) then hung and the engine appeared frozen.
 //
 // The engine polls due timers into memory one poll cycle (POLL_TIMER_DELAY_SECONDS=1 in e2e)
-// ahead of their due date, while job completion cancels boundary timers in the DB only. The
-// test drives the job completion into that last poll window (shortly before DueAt) so the
-// already-loaded timer fires against the cancelled DB state. It then verifies the engine stays
-// fully operable: the follow-up job completes and the instance reaches Completed. Several
+// ahead of their due date. Job completion now cancels boundary timers through the engine's
+// single cancelTimer method, which also removes the already-loaded in-memory copy from the
+// timer manager. A short-lived post-flush cancellation tombstone rejects stale Created results
+// from an in-flight poll; persisted-state validation remains the final guard if a waiter already
+// reached the trigger channel. The test drives job completion into that last poll window
+// (shortly before DueAt) and verifies the engine stays fully operable: the follow-up job completes
+// and the instance reaches Completed. Several
 // instances are exercised to make hitting the race window overwhelmingly likely.
 func TestTimerBoundaryCancelledRightBeforeFiringKeepsEngineResponsive(t *testing.T) {
 	cleanProcessInstances(t)
@@ -38,6 +42,7 @@ func TestTimerBoundaryCancelledRightBeforeFiringKeepsEngineResponsive(t *testing
 	definition := deployAndGetUniqueProcessDefinition(t, bpmnFile)
 	require.NotZero(t, definition.Key, "Definition key should not be zero")
 
+	exercisedAttempts := 0
 	for i := range attempts {
 		instance, err := createProcessInstance(t, &definition.Key, nil)
 		require.NoError(t, err)
@@ -52,8 +57,8 @@ func TestTimerBoundaryCancelledRightBeforeFiringKeepsEngineResponsive(t *testing
 
 		// Complete the main job shortly before the boundary timer's due date, inside the last
 		// poll window, when the timer has most likely already been loaded into the timer
-		// manager's in-memory waiting list. The completion cancels the timer in the DB, but the
-		// in-memory copy still fires at DueAt and must handle the Cancelled state gracefully.
+		// manager's in-memory waiting list. The completion must cancel the timer in the DB and
+		// remove the in-memory copy without allowing an in-flight poll to reinsert it.
 		raceWindow := timer.DueAt.Add(-400 * time.Millisecond)
 		if !time.Now().Before(raceWindow) {
 			t.Logf("missed timer cancellation race window (attempt %d); cleaning up and retrying", i)
@@ -61,9 +66,10 @@ func TestTimerBoundaryCancelledRightBeforeFiringKeepsEngineResponsive(t *testing
 			continue
 		}
 		waitUntil(t, raceWindow)
+		exercisedAttempts++
 		require.NoError(t, completeJob(t, mainJob.Key, nil))
 
-		// Let the due date pass (plus a margin for the trigger to run) so the cancelled in-memory timer has fired by now.
+		// Let the due date pass (plus a margin) so a leftover in-memory timer would have fired by now.
 		waitUntil(t, timer.DueAt.Add(1500*time.Millisecond))
 
 		_, err = listProcessDefinitions(t)
@@ -87,6 +93,79 @@ func TestTimerBoundaryCancelledRightBeforeFiringKeepsEngineResponsive(t *testing
 		require.NoError(t, err)
 		require.Len(t, cancelled, 1, "the boundary timer should be Cancelled for instance %d", instance.Key)
 	}
+	require.Positive(t, exercisedAttempts, "at least one attempt must exercise the timer cancellation window")
+}
+
+// TestProcessInstanceCancelledRightBeforeBoundaryTimerFiresKeepsEngineResponsive covers the
+// process-instance cancellation path of the engine's single timer-cancel method (cancelTimer):
+// cancelling an instance whose non-interrupting boundary timer is already loaded into the timer
+// manager's in-memory waiting list must remove that in-memory copy as well, so the timer does
+// not fire against the cancelled DB state and the engine stays fully responsive afterwards.
+// The cancellation is driven into the last poll window (shortly before DueAt), when the timer
+// has already been polled into memory. Several instances are exercised to make hitting the window overwhelmingly likely.
+func TestProcessInstanceCancelledRightBeforeBoundaryTimerFiresKeepsEngineResponsive(t *testing.T) {
+	cleanProcessInstances(t)
+
+	const (
+		bpmnFile        = "testdata/timer/timer-boundary-noninterrupting-cancel-race.bpmn"
+		mainTaskElement = "main-task"
+		// A slow runner can miss the -400ms race window on some attempts; keep enough attempts
+		// that at least one is overwhelmingly likely to exercise the cancellation window.
+		attempts = 5
+	)
+
+	definition := deployAndGetUniqueProcessDefinition(t, bpmnFile)
+	require.NotZero(t, definition.Key, "Definition key should not be zero")
+
+	exercisedAttempts := 0
+	for i := range attempts {
+		instance, err := createProcessInstance(t, &definition.Key, nil)
+		require.NoError(t, err)
+		require.NotZero(t, instance.Key, "Process instance key should not be zero")
+
+		store, err := app.node.GetPartitionStore(t.Context(), zenflake.GetPartitionId(instance.Key))
+		require.NoError(t, err)
+
+		waitForProcessInstanceActiveJobByElementId(t, instance.Key, mainTaskElement)
+
+		timer := waitForCreatedProcessInstanceTimer(t, store, instance.Key)
+
+		// Cancel the process instance shortly before the boundary timer's due date, inside the
+		// last poll window, when the timer has most likely already been loaded into the timer
+		// manager's in-memory waiting list.
+		raceWindow := timer.DueAt.Add(-400 * time.Millisecond)
+		if !time.Now().Before(raceWindow) {
+			t.Logf("missed timer cancellation race window (attempt %d); cleaning up and retrying", i)
+			cleanupOwnedProcessInstance(t, instance.Key)
+			continue
+		}
+		waitUntil(t, raceWindow)
+		exercisedAttempts++
+
+		cancelResp, err := app.restClient.CancelProcessInstanceWithResponse(t.Context(), instance.Key)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, cancelResp.StatusCode(),
+			"process instance %d cancellation should succeed", instance.Key)
+
+		// Let the due date pass (plus a margin) so a leftover in-memory timer would have fired by now.
+		waitUntil(t, timer.DueAt.Add(1500*time.Millisecond))
+
+		_, err = listProcessDefinitions(t)
+		require.NoError(t, err, "engine must keep serving process definition list after the instance cancellation")
+
+		pi, err := getProcessInstance(t, instance.Key)
+		require.NoError(t, err)
+		require.Equal(t, zenclient.ProcessInstanceStateTerminated, pi.State,
+			"process instance %d should stay Terminated after the timer due date passed", instance.Key)
+
+		cancelled, err := store.FindProcessInstanceTimers(t.Context(), instance.Key, bpmnruntime.TimerStateCancelled)
+		require.NoError(t, err)
+		require.Len(t, cancelled, 1, "the boundary timer should be Cancelled for instance %d", instance.Key)
+		created, err := store.FindProcessInstanceTimers(t.Context(), instance.Key, bpmnruntime.TimerStateCreated)
+		require.NoError(t, err)
+		require.Empty(t, created, "no Created timer should remain for cancelled instance %d", instance.Key)
+	}
+	require.Positive(t, exercisedAttempts, "at least one attempt must exercise the timer cancellation window")
 }
 
 // waitForCreatedProcessInstanceTimer waits until the process instance has exactly one timer in Created state and returns it.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of process cancellation/completion by properly terminating active message subscriptions and cancelling all relevant timers.
  - Prevented cancelled timers (including boundary timers) from firing or being reinserted by in-flight polling.
  - Preserved engine responsiveness when a process is cancelled right before a boundary timer fires.
  - Enhanced recovery behavior when timer cancellation persists during intermittent flush failures.

- **Tests**
  - Added/expanded regression coverage for cancellation vs. polling races, lock-release behavior after boundary timer cancellation, and timer cancellation recovery across flush failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->