### PR TITLE
fix: prevent dev releases tagging latest

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -80,7 +80,7 @@ dockers_v2:
     ids: 
      - zenbpm
     tags:
-      - '{{ if and (eq .Env.GORELEASER_DOCKER_LATEST "true") (eq .Prerelease "") }}latest{{ end }}'
+      - '{{ if and (eq .Env.GORELEASER_DOCKER_LATEST "true") (eq .Prerelease "") (hasPrefix "v" .Tag) }}latest{{ end }}'
       - "{{ .Tag }}"
     platforms:
     - linux/amd64


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted automatic `latest` Docker image tags to stable releases using version tags with the `v` prefix.
  * Prerelease versions and nonstandard tags no longer receive the `latest` tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->