### PR TITLE
feat: notify discord on security findings

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -50,6 +50,13 @@ jobs:
         if: always()
         run: bash scripts/ci/release-security.sh summarize
 
+      - name: notify discord on findings
+        if: always()
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        run: bash scripts/ci/release-security.sh notify-discord-if-findings
+
       - name: upload trivy image sarif
         if: ${{ always() && hashFiles('trivy-reports/image.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v4

--- a/scripts/ci/release-security.sh
+++ b/scripts/ci/release-security.sh
@@ -275,7 +275,7 @@ notify_discord() {
     )
   }' "$summary_file")
 
-  curl -fsS \
+  curl --connect-timeout 10 --max-time 30 -fsS \
     -H 'Content-Type: application/json' \
     -d "$payload" \
     "$DISCORD_WEBHOOK_URL"

--- a/scripts/ci/release-security.sh
+++ b/scripts/ci/release-security.sh
@@ -19,6 +19,8 @@ Commands:
   resolve-digest     Resolve the published image digest and write outputs
   summarize          Build trivy-reports/summary.json and write outputs
   notify-discord     Send the release scan summary to Discord
+  notify-discord-if-findings
+                      Send the scan summary to Discord only when findings exist
 
 Common env:
   RELEASE_TAG         Release tag. Defaults to GITHUB_REF_NAME.
@@ -279,6 +281,31 @@ notify_discord() {
     "$DISCORD_WEBHOOK_URL"
 }
 
+notify_discord_if_findings() {
+  local summary_file="${TRIVY_REPORT_DIR}/summary.json"
+
+  if [ ! -s "$summary_file" ]; then
+    echo "${summary_file} does not exist; run summarize before notify-discord-if-findings" >&2
+    exit 1
+  fi
+
+  local finding_count
+  finding_count=$(jq '(
+    .image_vulnerabilities.HIGH +
+    .image_vulnerabilities.CRITICAL +
+    .filesystem_vulnerabilities.HIGH +
+    .filesystem_vulnerabilities.CRITICAL +
+    .secrets
+  )' "$summary_file")
+
+  if [ "$finding_count" -eq 0 ]; then
+    echo "No HIGH/CRITICAL vulnerabilities or secrets found; skipping Discord notification."
+    return 0
+  fi
+
+  notify_discord
+}
+
 command="${1:-}"
 case "$command" in
   install-trivy)
@@ -298,6 +325,9 @@ case "$command" in
     ;;
   notify-discord)
     notify_discord
+    ;;
+  notify-discord-if-findings)
+    notify_discord_if_findings
     ;;
   -h|--help|help)
     usage


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Discord notifications for security scan results when high/critical vulnerabilities or secret findings are detected.

* **Bug Fixes**
  * Discord notifications are now skipped when there are no relevant findings, reducing unnecessary alerts.
  * Security notification failures no longer block subsequent reporting steps.
  * Improved reliability of the webhook request with shorter connect and overall timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->