### PR TITLE
fix(744): fix multi-instance activity creates a phantom active history entry after the final iteration

### DIFF
--- a/internal/cluster/partition/partition_persistence.go
+++ b/internal/cluster/partition/partition_persistence.go
@@ -2445,6 +2445,9 @@ func (rq *DB) GetFlowElementInstanceByKey(ctx context.Context, key int64) (bpmnr
 	var res bpmnruntime.FlowElementInstance
 	flowElementInstance, err := rq.Queries.GetFlowElementInstanceByKey(ctx, key)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return res, storage.ErrNotFound
+		}
 		return res, err
 	}
 

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -890,6 +890,19 @@ func (engine *Engine) processFlowNode(
 }
 
 func flowNodeOwnsHistory(element bpmn20.FlowNode) bool {
+	if activity, ok := element.(bpmn20.Activity); ok && activity.GetMultiInstance() != nil {
+		// Multi-instance history is written by startSequentialMultiInstance /
+		// startParallelMultiInstance in the parent process and by each iteration inside
+		// the multi-instance instance, so every create path of an activity that can carry
+		// loop characteristics must persist its own row.
+		//
+		// Returning false here would do more than add a stray row: the final control pass
+		// reuses the last iteration's ElementInstanceKey, and SaveFlowElementInstance is
+		// an upsert, so the generic save would overwrite that iteration's input variables
+		// with nil and break the output collection built from them.
+		return true
+	}
+
 	switch element.(type) {
 	case *bpmn20.TParallelGateway, *bpmn20.TInclusiveGateway:
 		// Synchronizing gateway cycles consume multiple tokens but produce one
@@ -1129,7 +1142,7 @@ func (engine *Engine) handleElementTransition(
 	case *runtime.DefaultProcessInstance, *runtime.SubProcessInstance, *runtime.CallActivityInstance:
 		return engine.handleDefaultElementTransition(ctx, batch, inst, element, currentToken)
 	case *runtime.MultiInstanceInstance:
-		return engine.handleMultiInstanceElementTransition(ctx, batch, inst, element, currentToken)
+		return engine.calculateMultiInstanceElementTransition(ctx, inst, element, currentToken)
 	default:
 		return nil, fmt.Errorf("unsupported instance type: %T", instance)
 	}

--- a/pkg/bpmn/multi_instance.go
+++ b/pkg/bpmn/multi_instance.go
@@ -52,6 +52,21 @@ func (engine *Engine) handleMultiInstanceActivity(ctx context.Context, batch *En
 			if err != nil {
 				return nil, fmt.Errorf("failed to process %s flow transition %d: %w", element.GetType(), activity.GetKey(), err)
 			}
+			// The start helpers only report Completed for an empty input collection. No
+			// multi-instance instance is created in that case, so the parent continuation
+			// that normally completes this history row never runs.
+			outputCollectionName := element.GetMultiInstance().LoopCharacteristics.OutputCollectionName
+			if err := batch.UpdateOutputFlowElementInstance(ctx, runtime.FlowElementInstance{
+				Key:                currentToken.ElementInstanceKey,
+				ProcessInstanceKey: instance.ProcessInstance().Key,
+				ElementId:          element.GetId(),
+				ElementType:        string(element.GetType()),
+				ExecutionTokenKey:  currentToken.Key,
+				OutputVariables:    map[string]any{outputCollectionName: []interface{}{}},
+				CompletedAt:        new(time.Now()),
+			}); err != nil {
+				return nil, fmt.Errorf("failed to complete %s history %d: %w", element.GetType(), activity.GetKey(), err)
+			}
 			return tokens, nil
 		default:
 			return []runtime.ExecutionToken{}, fmt.Errorf("unsupported activity state: %s", activityState)
@@ -79,7 +94,9 @@ func (engine *Engine) handleMultiInstanceActivity(ctx context.Context, batch *En
 		return []runtime.ExecutionToken{}, fmt.Errorf("multi instance input collection under key %q has unexpected type %T", inputElementName, inputCollectionVariable)
 	}
 
-	//TODO (n^2) — replaces with iteration index tracked on MultiInstanceInstance
+	// The history count is the iteration index. Each iteration is flushed before
+	// another token is processed, except for activities that complete synchronously;
+	// that path passes the known +1 count directly to the transition handler below.
 	multiInstancesAlreadyStarted, err := engine.persistence.GetFlowElementInstanceCountByProcessInstanceKey(ctx, instance.ProcessInstance().Key)
 	if err != nil {
 		return []runtime.ExecutionToken{}, err
@@ -121,7 +138,15 @@ func (engine *Engine) handleMultiInstanceActivity(ctx context.Context, batch *En
 		currentToken.State = runtime.TokenStateWaiting
 		return []runtime.ExecutionToken{currentToken}, nil
 	case runtime.ActivityStateCompleted:
-		tokens, err := engine.handleMultiInstanceElementTransition(ctx, batch, multiInstance, element, currentToken)
+		// The current history row is still queued in this batch, so account for it
+		// explicitly instead of trying to infer an unflushed row from persistence.
+		tokens, err := engine.calculateMultiInstanceElementTransitionWithStartedIterations(
+			ctx,
+			multiInstance,
+			element,
+			currentToken,
+			multiInstancesAlreadyStarted+1,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -240,7 +265,7 @@ func (engine *Engine) startSequentialMultiInstance(ctx context.Context, batch *E
 
 	flowElementInput := variableHolder.ExecutionScopeSnapshot()
 	flowElementInput[element.GetMultiInstance().LoopCharacteristics.InputElementName] = inputCollection
-	batch.SaveFlowElementInstance(ctx, runtime.FlowElementInstance{
+	err = batch.SaveFlowElementInstance(ctx, runtime.FlowElementInstance{
 		Key:                currentToken.ElementInstanceKey,
 		ProcessInstanceKey: instance.ProcessInstance().Key,
 		ElementId:          element.GetId(),
@@ -250,6 +275,9 @@ func (engine *Engine) startSequentialMultiInstance(ctx context.Context, batch *E
 		InputVariables:     flowElementInput,
 		OutputVariables:    nil,
 	})
+	if err != nil {
+		return runtime.ActivityStateFailed, err
+	}
 
 	if len(inputCollection) == 0 {
 		instance.ProcessInstance().VariableHolder.SetLocalVariable(element.GetMultiInstance().LoopCharacteristics.OutputCollectionName, []interface{}{})
@@ -354,7 +382,10 @@ func (engine *Engine) handleParentProcessContinuationForMultiInstance(ctx contex
 	}
 
 	for _, tok := range tokens {
-		batch.SaveToken(ctx, tok)
+		err := batch.SaveToken(ctx, tok)
+		if err != nil {
+			return err
+		}
 	}
 	err = batch.SaveProcessInstance(ctx, parentInstance)
 	if err != nil {
@@ -437,11 +468,33 @@ func (engine *Engine) buildActivityOutputEvaluationScope(elementInstance runtime
 	return scope, nil
 }
 
-func (engine *Engine) handleMultiInstanceElementTransition(ctx context.Context,
-	batch *EngineBatch,
+func (engine *Engine) calculateMultiInstanceElementTransition(ctx context.Context,
 	instance *runtime.MultiInstanceInstance,
 	element bpmn20.FlowNode,
 	currentToken runtime.ExecutionToken,
+) ([]runtime.ExecutionToken, error) {
+	startedIterations, err := engine.countStartedMultiInstanceIterations(ctx, instance, element)
+	if err != nil {
+		return nil, err
+	}
+	return engine.calculateMultiInstanceElementTransitionWithStartedIterations(
+		ctx,
+		instance,
+		element,
+		currentToken,
+		startedIterations,
+	)
+}
+
+// calculateMultiInstanceElementTransitionWithStartedIterations calculates the token
+// transition after one multi-instance iteration finished. startedIterations includes
+// the iteration that has just finished; synchronous callers pass the known count
+// because its current history row is still unflushed.
+func (engine *Engine) calculateMultiInstanceElementTransitionWithStartedIterations(ctx context.Context,
+	instance *runtime.MultiInstanceInstance,
+	element bpmn20.FlowNode,
+	currentToken runtime.ExecutionToken,
+	startedIterations int64,
 ) ([]runtime.ExecutionToken, error) {
 	multiInstanceElement, ok := element.(bpmn20.Activity)
 	if !ok || multiInstanceElement.GetMultiInstance() == nil {
@@ -466,8 +519,21 @@ func (engine *Engine) handleMultiInstanceElementTransition(ctx context.Context,
 	multiInstanceInputCollectionLength := len(multiInstanceCollection)
 
 	if multiInstanceElement.GetMultiInstance().IsSequential {
+		if startedIterations > int64(multiInstanceInputCollectionLength) {
+			currentToken.State = runtime.TokenStateFailed
+			return []runtime.ExecutionToken{currentToken}, fmt.Errorf(
+				"multi-instance process %d started %d iterations for an input collection of length %d",
+				instance.ProcessInstance().Key,
+				startedIterations,
+				multiInstanceInputCollectionLength,
+			)
+		}
 		currentToken.State = runtime.TokenStateRunning
-		currentToken.ElementInstanceKey = engine.generateKey()
+		// The last iteration keeps its element instance key so that the final control
+		// pass through handleMultiInstanceActivity does not open a new history entry.
+		if startedIterations < int64(multiInstanceInputCollectionLength) {
+			currentToken.ElementInstanceKey = engine.generateKey()
+		}
 		return []runtime.ExecutionToken{currentToken}, nil
 	}
 
@@ -480,12 +546,31 @@ func (engine *Engine) handleMultiInstanceElementTransition(ctx context.Context,
 	isLastIteration := len(completedTokens) == multiInstanceInputCollectionLength-1
 	if isLastIteration {
 		currentToken.State = runtime.TokenStateRunning
-		currentToken.ElementInstanceKey = engine.generateKey()
 		return []runtime.ExecutionToken{currentToken}, nil
 	}
 
 	currentToken.State = runtime.TokenStateCompleted
 	return []runtime.ExecutionToken{currentToken}, nil
+}
+
+// countStartedMultiInstanceIterations reads the iteration index from persisted history.
+// It is used only for sequential external completions, where the just-finished
+// iteration was created in an earlier, already flushed batch.
+func (engine *Engine) countStartedMultiInstanceIterations(
+	ctx context.Context,
+	instance *runtime.MultiInstanceInstance,
+	element bpmn20.FlowNode,
+) (int64, error) {
+	activity, ok := element.(bpmn20.Activity)
+	if !ok || activity.GetMultiInstance() == nil || !activity.GetMultiInstance().IsSequential {
+		return 0, nil
+	}
+	processInstanceKey := instance.ProcessInstance().Key
+	startedIterations, err := engine.persistence.GetFlowElementInstanceCountByProcessInstanceKey(ctx, processInstanceKey)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count started iterations of multi-instance process %d: %w", processInstanceKey, err)
+	}
+	return startedIterations, nil
 }
 
 func sortFlowElementInstancesSortByCreatedAtAndKey(elementInstances []runtime.FlowElementInstance, parentElementId string) []runtime.FlowElementInstance {

--- a/pkg/bpmn/sub_process_test.go
+++ b/pkg/bpmn/sub_process_test.go
@@ -542,6 +542,84 @@ func TestMultiInstanceParallelServiceTaskStartsAndCompletesWorkerJob(t *testing.
 	assertOutputCollectionMatches(t, instance, []string{"test1newVal", "test2newVal", "test3newVal"})
 	assertProcessCompletionWithSubProcess(t, instance)
 }
+
+func TestMultiInstanceCompletionDoesNotCreatePhantomHistory(t *testing.T) {
+	t.Run("sequential worker job", func(t *testing.T) {
+		assertMultiInstanceCompletionDoesNotCreatePhantomHistory(
+			t,
+			"./test-cases/multi_instance_service_task.bpmn",
+			false,
+		)
+	})
+
+	t.Run("parallel worker jobs", func(t *testing.T) {
+		assertMultiInstanceCompletionDoesNotCreatePhantomHistory(
+			t,
+			"./test-cases/multi_instance_parallel_service_task.bpmn",
+			false,
+		)
+	})
+
+	t.Run("sequential local task", func(t *testing.T) {
+		assertMultiInstanceCompletionDoesNotCreatePhantomHistory(
+			t,
+			"./test-cases/multi_instance_service_task.bpmn",
+			true,
+		)
+	})
+
+	t.Run("parallel local tasks", func(t *testing.T) {
+		assertMultiInstanceCompletionDoesNotCreatePhantomHistory(
+			t,
+			"./test-cases/multi_instance_parallel_service_task.bpmn",
+			true,
+		)
+	})
+}
+
+func assertMultiInstanceCompletionDoesNotCreatePhantomHistory(t *testing.T, processPath string, local bool) {
+	t.Helper()
+
+	process, err := bpmnEngine.LoadFromFile(t.Context(), processPath)
+	require.NoError(t, err)
+
+	if local {
+		taskHandler := bpmnEngine.NewTaskHandler().Id("Activity_0rae016").Handler(func(job ActivatedJob) {
+			job.SetOutputVariable("testJobOutput", "test1newVal")
+			job.Complete()
+		})
+		defer bpmnEngine.RemoveHandler(taskHandler)
+	}
+
+	instance, err := bpmnEngine.CreateInstanceByKey(t.Context(), process.Key, map[string]interface{}{
+		"testInputCollection": []string{"test1"},
+	})
+	require.NoError(t, err)
+	multiInstance := findChildMultiInstanceInstance(t, instance.ProcessInstance().Key)
+
+	if !local {
+		completeWorkerJobs(t, []string{"test1"}, "testJobOutput")
+	}
+	waitForProcessCompletion(t, instance.ProcessInstance().Key, 500*time.Millisecond, 100*time.Millisecond)
+
+	history, err := bpmnEngine.persistence.GetFlowElementInstancesByProcessInstanceKey(
+		t.Context(),
+		multiInstance.ProcessInstance().Key,
+		false,
+	)
+	require.NoError(t, err)
+	require.Len(t, history, 1, "one input item must create exactly one multi-instance history entry")
+	assert.NotNil(t, history[0].CompletedAt, "the only multi-instance history entry must be completed")
+
+	tokens, err := bpmnEngine.persistence.GetCompletedTokensForProcessInstance(
+		t.Context(),
+		multiInstance.ProcessInstance().Key,
+	)
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+	assert.Equal(t, history[0].Key, tokens[0].ElementInstanceKey, "the completed token must reference the real iteration")
+}
+
 func TestMultiInstanceParallelServiceTaskStartsAndCompletesLocalJob(t *testing.T) {
 	process, err := bpmnEngine.LoadFromFile(t.Context(), "./test-cases/multi_instance_parallel_service_task.bpmn")
 	assert.NoError(t, err)
@@ -1039,7 +1117,23 @@ func assertMultiInstanceReceiveTaskSkipsWithEmptyOutput(t *testing.T, instance r
 	subProcesses, err := bpmnEngine.persistence.FindProcessInstancesByParentExecutionTokenKey(t.Context(), tokens[0].Key)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(subProcesses))
+	assertNoActiveHistoryEntries(t, updatedInstance.ProcessInstance().Key)
 }
+
+// assertNoActiveHistoryEntries fails if a completed process instance left behind a
+// history entry that was never closed.
+func assertNoActiveHistoryEntries(t *testing.T, instanceKey int64) {
+	t.Helper()
+	history, err := bpmnEngine.persistence.GetFlowElementInstancesByProcessInstanceKey(t.Context(), instanceKey, false)
+	require.NoError(t, err)
+	require.NotEmpty(t, history)
+	for _, elementInstance := range history {
+		assert.NotNil(t, elementInstance.CompletedAt,
+			"history entry %s (%s) must not stay active after the process instance completed",
+			elementInstance.ElementId, elementInstance.ElementType)
+	}
+}
+
 func assertProcessCompletionWithSubProcess(t *testing.T, instance runtime.ProcessInstance) {
 	t.Helper()
 	assert.Equal(t, runtime.ActivityStateCompleted, instance.ProcessInstance().State)

--- a/pkg/storage/storagetest/storage.go
+++ b/pkg/storage/storagetest/storage.go
@@ -49,6 +49,7 @@ func (st *StorageTester) GetTests() map[string]StorageTestFunc {
 		st.TestDecisionStorageReaderGetSingle,
 		st.TestDecisionStorageReaderGetMultiple,
 		st.TestSaveFlowElementInstanceWriter,
+		st.TestFlowElementInstanceReaderNotFound,
 		st.TestFlowElementInstanceCompletedAt,
 		st.TestFlowElementInstanceSaveWithCompletedAt,
 		st.TestFlowElementInstanceUpdateOutputInsertPath,
@@ -740,6 +741,15 @@ func (st *StorageTester) TestSaveFlowElementInstanceWriter(s storage.Storage, _ 
 		}
 		err := s.SaveFlowElementInstance(t.Context(), historyItem)
 		assert.Nil(t, err)
+	}
+}
+
+// TestFlowElementInstanceReaderNotFound verifies that an exact lookup of a missing
+// flow element instance follows the storage contract and returns storage.ErrNotFound.
+func (st *StorageTester) TestFlowElementInstanceReaderNotFound(s storage.Storage, _ *testing.T) func(t *testing.T) {
+	return func(t *testing.T) {
+		_, err := s.GetFlowElementInstanceByKey(t.Context(), s.GenerateId())
+		assert.ErrorIs(t, err, storage.ErrNotFound)
 	}
 }
 

--- a/test/e2e/multi_instance_user_task_parallel_job_complete_flow_test.go
+++ b/test/e2e/multi_instance_user_task_parallel_job_complete_flow_test.go
@@ -1,0 +1,83 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParallelMultiInstanceUserTaskJobCompleteFlow(t *testing.T) {
+	t.Run("Completing every iteration completes the parent and child with exact history", func(t *testing.T) {
+		approvers := []string{"alice", "bob"}
+		processInstance := deployAndCreateUniqueProcessDefinition(t, multiInstanceUserTaskParallelMinimalBpmn, map[string]any{
+			"approvers": approvers,
+		})
+
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		multiInstanceProcess := waitForChildProcessInstance(t, processInstance.Key, 0)
+		jobs := waitForProcessInstanceActiveJobsByElementId(t, multiInstanceProcess.Key, "user_task", len(approvers))
+
+		waitForTwoProcessInstanceStates(
+			t,
+			processInstance.Key,
+			zenclient.ProcessInstanceStateActive,
+			multiInstanceProcess.Key,
+			zenclient.ProcessInstanceStateActive,
+		)
+		assertProcessInstanceTokenState(t, processInstance.Key, "user_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenStates(t, multiInstanceProcess.Key, "user_task", runtime.TokenStateWaiting, len(approvers))
+		assertExactProcessInstanceHistory(t, processInstance.Key, []string{
+			"start_event",
+			"Flow_to_user_task",
+			"user_task",
+		})
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{
+			"user_task",
+			"user_task",
+		})
+
+		for _, job := range jobs {
+			require.NoError(t, completeJob(t, job.Key, nil))
+		}
+
+		waitForTwoProcessInstanceStates(
+			t,
+			processInstance.Key,
+			zenclient.ProcessInstanceStateCompleted,
+			multiInstanceProcess.Key,
+			zenclient.ProcessInstanceStateCompleted,
+		)
+		assertProcessInstanceTokenState(t, processInstance.Key, "end_event", runtime.TokenStateCompleted)
+		assertProcessInstanceTokenStates(t, multiInstanceProcess.Key, "user_task", runtime.TokenStateCompleted, len(approvers))
+		assertExactProcessInstanceHistory(t, processInstance.Key, []string{
+			"start_event",
+			"Flow_to_user_task",
+			"user_task",
+			"Flow_to_end",
+			"end_event",
+		})
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{
+			"user_task",
+			"user_task",
+		})
+
+		iterationHistory := getFlowElementInstancesByElementId(t, multiInstanceProcess.Key, "user_task")
+		require.Len(t, iterationHistory, len(approvers))
+		for _, iteration := range iterationHistory {
+			require.NotNil(t, iteration.CompletedAt, "every multi-instance iteration must be completed")
+		}
+
+		completedJobs, err := getProcessInstanceJobs(t, multiInstanceProcess.Key)
+		require.NoError(t, err)
+		require.Len(t, completedJobs, len(approvers))
+		for _, job := range completedJobs {
+			require.Equal(t, public.JobStateCompleted, job.State)
+		}
+	})
+}

--- a/test/e2e/multi_instance_user_task_parallel_variables_test.go
+++ b/test/e2e/multi_instance_user_task_parallel_variables_test.go
@@ -24,6 +24,9 @@ func TestParallelMultiInstanceUserTaskVariables(t *testing.T) {
 		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
 			"results": []interface{}{},
 		})
+		history := getFlowElementInstancesByElementId(t, processInstance.Key, "user_task")
+		require.Len(t, history, 1)
+		require.NotNil(t, history[0].CompletedAt, "empty multi-instance activity history must be completed")
 	})
 
 	t.Run("empty input collection initializes empty output collection in parent scope", func(t *testing.T) {
@@ -40,6 +43,9 @@ func TestParallelMultiInstanceUserTaskVariables(t *testing.T) {
 			"approvers": []interface{}{},
 			"results":   []interface{}{},
 		})
+		history := getFlowElementInstancesByElementId(t, processInstance.Key, "user_task")
+		require.Len(t, history, 1)
+		require.NotNil(t, history[0].CompletedAt, "empty multi-instance activity history must be completed")
 	})
 
 	t.Run("input element propagates to each concurrent iteration job", func(t *testing.T) {
@@ -83,8 +89,10 @@ func TestParallelMultiInstanceUserTaskVariables(t *testing.T) {
 		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
 
 		flowElements := getFlowElementInstancesByElementId(t, firstChild.Key, "user_task")
+		require.Len(t, flowElements, 2, "history must contain exactly one entry per multi-instance iteration")
 		approversInFlowElements := make([]string, 0, 2)
 		for _, flowElement := range flowElements {
+			require.NotNil(t, flowElement.CompletedAt, "every multi-instance history entry must be completed")
 			approver, ok := flowElement.InputVariables["approver"].(string)
 			if !ok {
 				continue

--- a/test/e2e/multi_instance_user_task_sequential_job_complete_flow_test.go
+++ b/test/e2e/multi_instance_user_task_sequential_job_complete_flow_test.go
@@ -1,0 +1,108 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSequentialMultiInstanceUserTaskJobCompleteFlow(t *testing.T) {
+	t.Run("Completing each iteration in sequence completes the parent and child with exact history", func(t *testing.T) {
+		approvers := []string{"alice", "bob"}
+		processInstance := deployAndCreateUniqueProcessDefinition(t, multiInstanceUserTaskSequentialMinimalBpmn, map[string]any{
+			"approvers": approvers,
+		})
+
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		multiInstanceProcess := waitForChildProcessInstance(t, processInstance.Key, 0)
+		firstJob := waitForProcessInstanceActiveJobByElementId(t, multiInstanceProcess.Key, "user_task")
+
+		waitForTwoProcessInstanceStates(
+			t,
+			processInstance.Key,
+			zenclient.ProcessInstanceStateActive,
+			multiInstanceProcess.Key,
+			zenclient.ProcessInstanceStateActive,
+		)
+		assertProcessInstanceTokenState(t, processInstance.Key, "user_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, multiInstanceProcess.Key, "user_task", runtime.TokenStateWaiting)
+		assertExactProcessInstanceHistory(t, processInstance.Key, []string{
+			"start_event",
+			"Flow_to_user_task",
+			"user_task",
+		})
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{
+			"user_task",
+		})
+
+		require.NoError(t, completeJob(t, firstJob.Key, nil))
+		secondJob := waitForProcessInstanceActiveJobByElementId(t, multiInstanceProcess.Key, "user_task")
+		require.NotEqual(t, firstJob.Key, secondJob.Key)
+
+		waitForTwoProcessInstanceStates(
+			t,
+			processInstance.Key,
+			zenclient.ProcessInstanceStateActive,
+			multiInstanceProcess.Key,
+			zenclient.ProcessInstanceStateActive,
+		)
+		assertProcessInstanceTokenState(t, processInstance.Key, "user_task", runtime.TokenStateWaiting)
+		assertProcessInstanceTokenState(t, multiInstanceProcess.Key, "user_task", runtime.TokenStateWaiting)
+		assertExactProcessInstanceHistory(t, processInstance.Key, []string{
+			"start_event",
+			"Flow_to_user_task",
+			"user_task",
+		})
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{
+			"user_task",
+			"user_task",
+		})
+
+		iterationHistory := getFlowElementInstancesByElementId(t, multiInstanceProcess.Key, "user_task")
+		require.Len(t, iterationHistory, len(approvers))
+		require.NotNil(t, iterationHistory[0].CompletedAt, "the first iteration must be completed")
+		require.Nil(t, iterationHistory[1].CompletedAt, "the second iteration must remain active")
+
+		require.NoError(t, completeJob(t, secondJob.Key, nil))
+
+		waitForTwoProcessInstanceStates(
+			t,
+			processInstance.Key,
+			zenclient.ProcessInstanceStateCompleted,
+			multiInstanceProcess.Key,
+			zenclient.ProcessInstanceStateCompleted,
+		)
+		assertProcessInstanceTokenState(t, processInstance.Key, "end_event", runtime.TokenStateCompleted)
+		assertProcessInstanceTokenState(t, multiInstanceProcess.Key, "user_task", runtime.TokenStateCompleted)
+		assertExactProcessInstanceHistory(t, processInstance.Key, []string{
+			"start_event",
+			"Flow_to_user_task",
+			"user_task",
+			"Flow_to_end",
+			"end_event",
+		})
+		assertExactProcessInstanceHistory(t, multiInstanceProcess.Key, []string{
+			"user_task",
+			"user_task",
+		})
+
+		iterationHistory = getFlowElementInstancesByElementId(t, multiInstanceProcess.Key, "user_task")
+		require.Len(t, iterationHistory, len(approvers))
+		for _, iteration := range iterationHistory {
+			require.NotNil(t, iteration.CompletedAt, "every multi-instance iteration must be completed")
+		}
+
+		completedJobs, err := getProcessInstanceJobs(t, multiInstanceProcess.Key)
+		require.NoError(t, err)
+		require.Len(t, completedJobs, len(approvers))
+		for _, job := range completedJobs {
+			require.Equal(t, public.JobStateCompleted, job.State)
+		}
+	})
+}

--- a/test/e2e/multi_instance_user_task_sequential_variables_test.go
+++ b/test/e2e/multi_instance_user_task_sequential_variables_test.go
@@ -24,6 +24,9 @@ func TestSequentialMultiInstanceUserTaskVariables(t *testing.T) {
 		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
 			"results": []interface{}{},
 		})
+		history := getFlowElementInstancesByElementId(t, processInstance.Key, "user_task")
+		require.Len(t, history, 1)
+		require.NotNil(t, history[0].CompletedAt, "empty multi-instance activity history must be completed")
 	})
 
 	t.Run("empty input collection initializes empty output collection in parent scope", func(t *testing.T) {
@@ -40,6 +43,9 @@ func TestSequentialMultiInstanceUserTaskVariables(t *testing.T) {
 			"approvers": []interface{}{},
 			"results":   []interface{}{},
 		})
+		history := getFlowElementInstancesByElementId(t, processInstance.Key, "user_task")
+		require.Len(t, history, 1)
+		require.NotNil(t, history[0].CompletedAt, "empty multi-instance activity history must be completed")
 	})
 
 	t.Run("input element propagates to iteration job per iteration", func(t *testing.T) {
@@ -86,6 +92,12 @@ func TestSequentialMultiInstanceUserTaskVariables(t *testing.T) {
 		}
 
 		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+
+		flowElements := getFlowElementInstancesByElementId(t, firstChild.Key, "user_task")
+		require.Len(t, flowElements, 2, "history must contain exactly one entry per multi-instance iteration")
+		for _, flowElement := range flowElements {
+			require.NotNil(t, flowElement.CompletedAt, "every multi-instance history entry must be completed")
+		}
 
 		assertFlowElementInputVariablesAt(t, firstChild.Key, "user_task", 0, map[string]any{
 			"approver":  "alice",


### PR DESCRIPTION
closes #744 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed sequential and parallel multi-instance execution to prevent duplicate/phantom history entries, ensuring completed tokens reference the correct iteration keys.
  - Improved handling for empty or nil input collections so parent/output collections and iteration completion outputs are persisted correctly.
  - Made missing flow element instance reads return a consistent “not found” error.
- **Reliability**
  - Strengthened multi-instance history and token/state verification across job-based and local-task completions.
- **Tests**
  - Added new storage, unit, and end-to-end coverage for multi-instance completion, variables, and history cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->