### PR TITLE
fix: use supported goreleaser latest tag condition

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -80,7 +80,7 @@ dockers_v2:
     ids: 
      - zenbpm
     tags:
-      - '{{ if and (eq .Env.GORELEASER_DOCKER_LATEST "true") (eq .Prerelease "") (hasPrefix "v" .Tag) }}latest{{ end }}'
+      - '{{ if and (eq .Env.GORELEASER_DOCKER_LATEST "true") (not .IsSnapshot) (eq .Prerelease "") }}latest{{ end }}'
       - "{{ .Tag }}"
     platforms:
     - linux/amd64


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Docker image publishing so the `latest` tag is applied to stable releases without requiring a specific version-prefix format.
  * Snapshot and prerelease builds continue to be excluded from receiving the `latest` tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->