### PR TITLE
feat(#727): Add businessKey to CallActivity, expanded subprocess and …

### DIFF
--- a/internal/cluster/partition/partition_persistence.go
+++ b/internal/cluster/partition/partition_persistence.go
@@ -1226,7 +1226,7 @@ func SaveProcessInstanceWith(ctx context.Context, db Querier, processInstance bp
 	if processInstance.ProcessInstance().BusinessKey != nil {
 		businessKey = *processInstance.ProcessInstance().BusinessKey
 		bkFound = true
-	} else {
+	} else if processInstance.GetParentProcessInstanceKey() == nil {
 		businessKey, bkFound = appcontext.BusinessKeyFromContext(ctx)
 	}
 

--- a/internal/cluster/partition/partition_persistence.go
+++ b/internal/cluster/partition/partition_persistence.go
@@ -1221,10 +1221,13 @@ func SaveProcessInstanceWith(ctx context.Context, db Querier, processInstance bp
 		return fmt.Errorf("failed to marshal variables for instance %d: %w", processInstance.ProcessInstance().Key, err)
 	}
 
-	businessKey, bkFound := appcontext.BusinessKeyFromContext(ctx)
-	if !bkFound && processInstance.ProcessInstance().BusinessKey != nil {
+	var businessKey string
+	var bkFound bool
+	if processInstance.ProcessInstance().BusinessKey != nil {
 		businessKey = *processInstance.ProcessInstance().BusinessKey
 		bkFound = true
+	} else {
+		businessKey, bkFound = appcontext.BusinessKeyFromContext(ctx)
 	}
 
 	var parentProcessExecutionToken ssql.NullInt64

--- a/internal/cluster/partition/partition_persistence_test.go
+++ b/internal/cluster/partition/partition_persistence_test.go
@@ -725,6 +725,64 @@ func TestSaveProcessInstanceExplicitBusinessKeyOverridesContext(t *testing.T) {
 	assert.Equal(t, "", row.BusinessKey.String)
 }
 
+func TestSaveChildProcessInstanceDoesNotUseContextBusinessKey(t *testing.T) {
+	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t, false)
+	defer func() {
+		if err := partition.Stop(); err != nil {
+			t.Logf("failed to stop partition: %s", err)
+		}
+	}()
+
+	db := newTestDB(t, partition, conf, clientMgr, tStore, "test-child-business-key-context")
+	definition := runtime.ProcessDefinition{
+		BpmnProcessId: "child-business-key-context-process",
+		Version:       1,
+		Key:           db.GenerateId(),
+		BpmnData:      `<?xml version="1.0" encoding="UTF-8"?><bpmn:process id="child-business-key-context-process" isExecutable="true"></bpmn:process>`,
+		BpmnChecksum:  [16]byte{1},
+	}
+	require.NoError(t, db.SaveProcessDefinition(t.Context(), definition))
+
+	parent := runtime.DefaultProcessInstance{
+		ProcessInstanceData: runtime.ProcessInstanceData{
+			Definition:     &definition,
+			Key:            db.GenerateId(),
+			VariableHolder: runtime.VariableHolder{},
+			CreatedAt:      time.Now(),
+			State:          runtime.ActivityStateReady,
+		},
+	}
+	require.NoError(t, db.SaveProcessInstance(t.Context(), &parent))
+
+	parentToken := runtime.ExecutionToken{
+		Key:                db.GenerateId(),
+		ElementInstanceKey: db.GenerateId(),
+		ElementId:          "sub-process",
+		ProcessInstanceKey: parent.ProcessInstance().Key,
+		State:              runtime.TokenStateWaiting,
+	}
+	require.NoError(t, db.SaveToken(t.Context(), parentToken))
+
+	child := runtime.SubProcessInstance{
+		ParentProcessExecutionToken:           parentToken,
+		ParentProcessTargetElementInstanceKey: parentToken.ElementInstanceKey,
+		ParentProcessTargetElementId:          parentToken.ElementId,
+		ProcessInstanceData: runtime.ProcessInstanceData{
+			Definition:     &definition,
+			Key:            db.GenerateId(),
+			VariableHolder: runtime.VariableHolder{},
+			CreatedAt:      time.Now(),
+			State:          runtime.ActivityStateReady,
+		},
+	}
+	ctx := appcontext.WithBusinessKey(t.Context(), "context-business-key")
+	require.NoError(t, db.SaveProcessInstance(ctx, &child))
+
+	row, err := db.Queries.GetProcessInstance(t.Context(), child.ProcessInstance().Key)
+	require.NoError(t, err)
+	require.False(t, row.BusinessKey.Valid)
+}
+
 func queryCount(t *testing.T, db *DB, query string) int64 {
 	row := db.QueryRowContext(t.Context(), query)
 	var count int64

--- a/internal/cluster/partition/partition_persistence_test.go
+++ b/internal/cluster/partition/partition_persistence_test.go
@@ -687,6 +687,44 @@ func TestChildProcessInstanceInheritsParentHistoryTTL(t *testing.T) {
 	require.False(t, childWithoutTTLRow.HistoryTtlSec.Valid)
 }
 
+func TestSaveProcessInstanceExplicitBusinessKeyOverridesContext(t *testing.T) {
+	partition, conf, clientMgr, tStore, _ := prepareTestSetup(t, false)
+	defer func() {
+		if err := partition.Stop(); err != nil {
+			t.Logf("failed to stop partition: %s", err)
+		}
+	}()
+
+	db := newTestDB(t, partition, conf, clientMgr, tStore, "test-business-key-override")
+	definition := runtime.ProcessDefinition{
+		BpmnProcessId: "business-key-override-process",
+		Version:       1,
+		Key:           db.GenerateId(),
+		BpmnData:      `<?xml version="1.0" encoding="UTF-8"?><bpmn:process id="business-key-override-process" isExecutable="true"></bpmn:process>`,
+		BpmnChecksum:  [16]byte{1},
+	}
+	require.NoError(t, db.SaveProcessDefinition(t.Context(), definition))
+
+	emptyBusinessKey := ""
+	instance := runtime.DefaultProcessInstance{
+		ProcessInstanceData: runtime.ProcessInstanceData{
+			Definition:     &definition,
+			Key:            db.GenerateId(),
+			BusinessKey:    &emptyBusinessKey,
+			VariableHolder: runtime.VariableHolder{},
+			CreatedAt:      time.Now(),
+			State:          runtime.ActivityStateReady,
+		},
+	}
+	ctx := appcontext.WithBusinessKey(t.Context(), "context-business-key")
+	require.NoError(t, db.SaveProcessInstance(ctx, &instance))
+
+	row, err := db.Queries.GetProcessInstance(t.Context(), instance.ProcessInstance().Key)
+	require.NoError(t, err)
+	require.True(t, row.BusinessKey.Valid)
+	assert.Equal(t, "", row.BusinessKey.String)
+}
+
 func queryCount(t *testing.T, db *DB, query string) int64 {
 	row := db.QueryRowContext(t.Context(), query)
 	var count int64

--- a/pkg/bpmn/business_key_test.go
+++ b/pkg/bpmn/business_key_test.go
@@ -412,6 +412,7 @@ func TestChildBusinessKeyExpressionFailuresCreateIncident(t *testing.T) {
 
 				instance, err := bpmnEngine.CreateInstanceByKey(t.Context(), process.Key, failure.variables)
 				require.Error(t, err)
+				require.NotNil(t, instance)
 				assert.ErrorContains(t, err, failure.expectedError)
 				if failure.forbiddenError != "" {
 					assert.NotContains(t, err.Error(), failure.forbiddenError)

--- a/pkg/bpmn/business_key_test.go
+++ b/pkg/bpmn/business_key_test.go
@@ -1,0 +1,552 @@
+package bpmn
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/internal/appcontext"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallActivityBusinessKey(t *testing.T) {
+	tests := []struct {
+		name             string
+		businessKeyInput string
+		variables        map[string]interface{}
+		expected         string
+	}{
+		{
+			name:     "inherits parent business key when input is absent",
+			expected: "parent-key",
+		},
+		{
+			name:             "evaluates configured FEEL expression",
+			businessKeyInput: `<zenbpm:in businessKey="=processBusinessKey" />`,
+			variables:        map[string]interface{}{"processBusinessKey": "child-key"},
+			expected:         "child-key",
+		},
+		{
+			name:             "clears business key when configured expression is empty",
+			businessKeyInput: `<zenbpm:in businessKey="" />`,
+			expected:         "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			processID := fmt.Sprintf("business-key-child-%d", rand.Int63())
+			loadBusinessKeyChildProcess(t, processID)
+			parent := loadBusinessKeyCallActivityProcess(t, processID, test.businessKeyInput)
+			ctx := appcontext.WithBusinessKey(t.Context(), "parent-key")
+
+			instance, err := bpmnEngine.CreateInstanceByKey(ctx, parent.Key, test.variables)
+			require.NoError(t, err)
+			require.NotNil(t, instance.ProcessInstance().BusinessKey)
+			assert.Equal(t, "parent-key", *instance.ProcessInstance().BusinessKey)
+
+			waitForBusinessKeyProcessCompletion(t, instance.ProcessInstance().Key)
+			child := findChildCallActivityInstance(t, instance.ProcessInstance().Key)
+			require.NotNil(t, child.ProcessInstance().BusinessKey)
+			assert.Equal(t, test.expected, *child.ProcessInstance().BusinessKey)
+		})
+	}
+}
+
+func TestSubProcessBusinessKey(t *testing.T) {
+	tests := []struct {
+		name             string
+		businessKeyInput string
+		variables        map[string]interface{}
+		expected         string
+	}{
+		{
+			name:     "inherits parent business key when input is absent",
+			expected: "parent-key",
+		},
+		{
+			name:             "evaluates configured FEEL expression",
+			businessKeyInput: `<zenbpm:in businessKey="=processBusinessKey" />`,
+			variables:        map[string]interface{}{"processBusinessKey": "sub-process-key"},
+			expected:         "sub-process-key",
+		},
+		{
+			name:             "clears business key when configured expression is empty",
+			businessKeyInput: `<zenbpm:in businessKey="" />`,
+			expected:         "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			processID := fmt.Sprintf("business-key-sub-process-%d", rand.Int63())
+			process := loadBusinessKeySubProcess(t, processID, test.businessKeyInput)
+			ctx := appcontext.WithBusinessKey(t.Context(), "parent-key")
+
+			instance, err := bpmnEngine.CreateInstanceByKey(ctx, process.Key, test.variables)
+			require.NoError(t, err)
+
+			waitForBusinessKeyProcessCompletion(t, instance.ProcessInstance().Key)
+			child := findChildSubProcessInstance(t, instance.ProcessInstance().Key)
+			require.NotNil(t, child.ProcessInstance().BusinessKey)
+			assert.Equal(t, test.expected, *child.ProcessInstance().BusinessKey)
+		})
+	}
+}
+
+func TestEventSubProcessBusinessKey(t *testing.T) {
+	tests := []struct {
+		name             string
+		businessKeyInput string
+		expected         string
+	}{
+		{
+			name:     "inherits parent business key when input is absent",
+			expected: "parent-key",
+		},
+		{
+			name:             "evaluates configured FEEL expression against start event output",
+			businessKeyInput: `<zenbpm:in businessKey="=messageStartEventOutputVar" />`,
+			expected:         "messageStartEventOutputValue",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := inmemory.NewStorage()
+			engine := NewEngine(EngineWithStorage(store))
+			require.NoError(t, engine.Start(t.Context()))
+			defer engine.Stop()
+
+			handler := engine.NewTaskHandler().
+				Type("input-task-message-event-subprocess-interrupting").
+				Handler(func(ActivatedJob) {})
+			defer engine.RemoveHandler(handler)
+
+			process := loadBusinessKeyEventSubProcess(t, &engine, test.businessKeyInput)
+			ctx := appcontext.WithBusinessKey(t.Context(), "parent-key")
+			parent, err := engine.CreateInstanceByKey(ctx, process.Key, nil)
+			require.NoError(t, err)
+
+			correlationKey := "correlation-key-event-subprocess-1"
+			require.Eventually(t, func() bool {
+				_, err := store.FindMessageSubscriptionByName(t.Context(), "globalMessageRef", &correlationKey, runtime.ActivityStateActive)
+				return err == nil
+			}, 2*time.Second, 25*time.Millisecond)
+			require.NoError(t, engine.PublishMessageByName(t.Context(), "globalMessageRef", &correlationKey, nil))
+			require.Eventually(t, func() bool {
+				engine.runningInstances.lockInstance(parent.ProcessInstance().Key)
+				defer engine.runningInstances.unlockInstance(parent.ProcessInstance().Key)
+
+				instance, err := store.FindProcessInstanceByKey(t.Context(), parent.ProcessInstance().Key)
+				return err == nil && instance.ProcessInstance().State == runtime.ActivityStateCompleted
+			}, 2*time.Second, 25*time.Millisecond)
+
+			var eventSubProcess runtime.ProcessInstance
+			require.Eventually(t, func() bool {
+				for _, instance := range store.ProcessInstancesSnapshot() {
+					parentKey := instance.GetParentProcessInstanceKey()
+					if parentKey != nil && *parentKey == parent.ProcessInstance().Key {
+						eventSubProcess = instance
+						return true
+					}
+				}
+				return false
+			}, 2*time.Second, 25*time.Millisecond)
+			require.NotNil(t, eventSubProcess.ProcessInstance().BusinessKey)
+			assert.Equal(t, test.expected, *eventSubProcess.ProcessInstance().BusinessKey)
+		})
+	}
+}
+
+func TestEventSubProcessBusinessKeyFailureDoesNotInterruptParent(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+	require.NoError(t, engine.Start(t.Context()))
+	defer engine.Stop()
+
+	handler := engine.NewTaskHandler().
+		Type("input-task-message-event-subprocess-interrupting").
+		Handler(func(ActivatedJob) {})
+	defer engine.RemoveHandler(handler)
+
+	process := loadBusinessKeyEventSubProcess(t, &engine, `<zenbpm:in businessKey="=42" />`)
+	ctx := appcontext.WithBusinessKey(t.Context(), "parent-key")
+	parent, err := engine.CreateInstanceByKey(ctx, process.Key, nil)
+	require.NoError(t, err)
+
+	correlationKey := "correlation-key-event-subprocess-1"
+	require.Eventually(t, func() bool {
+		_, err := store.FindMessageSubscriptionByName(t.Context(), "globalMessageRef", &correlationKey, runtime.ActivityStateActive)
+		return err == nil
+	}, 2*time.Second, 25*time.Millisecond)
+
+	err = engine.PublishMessageByName(t.Context(), "globalMessageRef", &correlationKey, nil)
+	require.ErrorContains(t, err, "business key expression must evaluate to a string")
+
+	_, err = store.FindMessageSubscriptionByName(t.Context(), "globalMessageRef", &correlationKey, runtime.ActivityStateActive)
+	require.NoError(t, err, "failed override must leave the event subprocess trigger active")
+
+	engine.runningInstances.lockInstance(parent.ProcessInstance().Key)
+	persistedParent, err := store.FindProcessInstanceByKey(t.Context(), parent.ProcessInstance().Key)
+	engine.runningInstances.unlockInstance(parent.ProcessInstance().Key)
+	require.NoError(t, err)
+	assert.Equal(t, runtime.ActivityStateActive, persistedParent.ProcessInstance().State)
+
+	for _, instance := range store.ProcessInstancesSnapshot() {
+		parentKey := instance.GetParentProcessInstanceKey()
+		assert.False(t, parentKey != nil && *parentKey == parent.ProcessInstance().Key,
+			"failed override must not create an event subprocess instance")
+	}
+}
+
+func TestAncestorErrorEventSubProcessBusinessKeyFailureDoesNotTerminateIntermediateScope(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+	require.NoError(t, engine.Start(t.Context()))
+	defer engine.Stop()
+
+	activatedJobs := make(chan ActivatedJob, 1)
+	releaseJobs := make(chan struct{}, 1)
+	defer close(releaseJobs)
+	handler := engine.NewTaskHandler().
+		Type("business-key-ancestor-error").
+		Handler(func(job ActivatedJob) {
+			activatedJobs <- job
+			<-releaseJobs
+			job.Complete()
+		})
+	defer engine.RemoveHandler(handler)
+
+	processID := fmt.Sprintf("business-key-ancestor-error-%d", rand.Int63())
+	xml := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" targetNamespace="http://zenbpm.pbinitiative.org/test">
+  <bpmn:process id="%s" isExecutable="true">
+    <bpmn:startEvent id="root-start"><bpmn:outgoing>to-outer</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:sequenceFlow id="to-outer" sourceRef="root-start" targetRef="outer-sub" />
+    <bpmn:subProcess id="outer-sub">
+      <bpmn:outgoing>outer-to-end</bpmn:outgoing>
+      <bpmn:startEvent id="outer-start"><bpmn:outgoing>to-inner</bpmn:outgoing></bpmn:startEvent>
+      <bpmn:sequenceFlow id="to-inner" sourceRef="outer-start" targetRef="inner-sub" />
+      <bpmn:subProcess id="inner-sub">
+        <bpmn:outgoing>inner-to-end</bpmn:outgoing>
+        <bpmn:startEvent id="inner-start"><bpmn:outgoing>to-error-task</bpmn:outgoing></bpmn:startEvent>
+        <bpmn:sequenceFlow id="to-error-task" sourceRef="inner-start" targetRef="error-task" />
+        <bpmn:serviceTask id="error-task">
+          <bpmn:extensionElements><zenbpm:taskDefinition type="business-key-ancestor-error" /></bpmn:extensionElements>
+          <bpmn:incoming>to-error-task</bpmn:incoming><bpmn:outgoing>to-error-end</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:sequenceFlow id="to-error-end" sourceRef="error-task" targetRef="error-end" />
+        <bpmn:endEvent id="error-end"><bpmn:incoming>to-error-end</bpmn:incoming><bpmn:errorEventDefinition id="throw-error-def" errorRef="test-error" /></bpmn:endEvent>
+      </bpmn:subProcess>
+      <bpmn:sequenceFlow id="inner-to-end" sourceRef="inner-sub" targetRef="outer-end" />
+      <bpmn:endEvent id="outer-end" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="outer-to-end" sourceRef="outer-sub" targetRef="root-end" />
+    <bpmn:endEvent id="root-end" />
+    <bpmn:subProcess id="error-event-subprocess" triggeredByEvent="true">
+      <bpmn:extensionElements><zenbpm:in businessKey="=42" /></bpmn:extensionElements>
+      <bpmn:startEvent id="error-start"><bpmn:outgoing>error-to-end</bpmn:outgoing><bpmn:errorEventDefinition id="catch-error-def" errorRef="test-error" /></bpmn:startEvent>
+      <bpmn:sequenceFlow id="error-to-end" sourceRef="error-start" targetRef="handled-end" />
+      <bpmn:endEvent id="handled-end" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmn:error id="test-error" errorCode="42" />
+</bpmn:definitions>`, processID)
+	process, err := engine.LoadFromBytes(t.Context(), []byte(xml), rand.Int63())
+	require.NoError(t, err)
+	_, err = engine.CreateInstanceByKey(t.Context(), process.Key, nil)
+	require.NoError(t, err)
+
+	var job ActivatedJob
+	select {
+	case job = <-activatedJobs:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "inner subprocess job was not activated")
+	}
+	innerKey := job.ProcessInstanceKey()
+	activatedJobData, ok := job.(*activatedJob)
+	require.True(t, ok)
+	parentKey := activatedJobData.processInstanceInfo.GetParentProcessInstanceKey()
+	require.NotNil(t, parentKey)
+	outerKey := *parentKey
+
+	releaseJobs <- struct{}{}
+	require.Eventually(t, func() bool {
+		engine.runningInstances.lockInstance(innerKey)
+		defer engine.runningInstances.unlockInstance(innerKey)
+		instance, err := store.FindProcessInstanceByKey(t.Context(), innerKey)
+		return err == nil && instance.ProcessInstance().State == runtime.ActivityStateFailed
+	}, 2*time.Second, 25*time.Millisecond)
+
+	engine.runningInstances.lockInstance(outerKey)
+	persistedOuter, err := store.FindProcessInstanceByKey(t.Context(), outerKey)
+	engine.runningInstances.unlockInstance(outerKey)
+	require.NoError(t, err)
+	assert.Equal(t, runtime.ActivityStateActive, persistedOuter.ProcessInstance().State,
+		"invalid ancestor event-subprocess override must be validated before terminating intermediate scopes")
+}
+
+func loadBusinessKeyEventSubProcess(t *testing.T, engine *Engine, businessKeyInput string) *runtime.ProcessDefinition {
+	t.Helper()
+	xml, err := os.ReadFile("./test-cases/message_event_subprocess/message-event-subprocess-interrupting.bpmn")
+	require.NoError(t, err)
+	if businessKeyInput != "" {
+		const eventSubProcessExtension = `<bpmn:subProcess id="Activity_0adcic4" triggeredByEvent="true">
+      <bpmn:extensionElements>`
+		xml = []byte(strings.Replace(
+			string(xml),
+			eventSubProcessExtension,
+			eventSubProcessExtension+"\n        "+businessKeyInput,
+			1,
+		))
+		require.Contains(t, string(xml), businessKeyInput)
+	}
+
+	process, err := engine.LoadFromBytes(t.Context(), xml, rand.Int63())
+	require.NoError(t, err)
+	return process
+}
+
+func TestMultiInstanceCallActivityInheritsBusinessKey(t *testing.T) {
+	processID := fmt.Sprintf("business-key-multi-child-%d", rand.Int63())
+	loadBusinessKeyChildProcess(t, processID)
+	process := loadBusinessKeyMultiInstanceCallActivityProcess(t, processID)
+	ctx := appcontext.WithBusinessKey(t.Context(), "parent-key")
+
+	instance, err := bpmnEngine.CreateInstanceByKey(ctx, process.Key, map[string]interface{}{
+		"items": []interface{}{"item"},
+	})
+	require.NoError(t, err)
+
+	waitForBusinessKeyProcessCompletion(t, instance.ProcessInstance().Key)
+	multiInstance := findChildMultiInstanceInstance(t, instance.ProcessInstance().Key)
+	child := findChildCallActivityInstance(t, multiInstance.ProcessInstance().Key)
+	require.NotNil(t, child.ProcessInstance().BusinessKey)
+	assert.Equal(t, "parent-key", *child.ProcessInstance().BusinessKey)
+}
+
+// waitForBusinessKeyProcessCompletion reads the process state while holding the same
+// per-instance lock used by engine execution, so aliased in-memory instances are not
+// inspected while asynchronous child continuation is mutating them.
+func waitForBusinessKeyProcessCompletion(t *testing.T, instanceKey int64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		bpmnEngine.runningInstances.lockInstance(instanceKey)
+		defer bpmnEngine.runningInstances.unlockInstance(instanceKey)
+
+		instance, err := bpmnEngine.persistence.FindProcessInstanceByKey(t.Context(), instanceKey)
+		return err == nil && instance.ProcessInstance().State == runtime.ActivityStateCompleted
+	}, 2*time.Second, 50*time.Millisecond)
+}
+
+func TestChildBusinessKeyExpressionFailuresCreateIncident(t *testing.T) {
+	activityTypes := []struct {
+		name      string
+		elementID string
+		load      func(t *testing.T, processID, businessKeyInput string) *runtime.ProcessDefinition
+	}{
+		{
+			name:      "CallActivity",
+			elementID: "call",
+			load: func(t *testing.T, processID, businessKeyInput string) *runtime.ProcessDefinition {
+				loadBusinessKeyChildProcess(t, processID)
+				return loadBusinessKeyCallActivityProcess(t, processID, businessKeyInput)
+			},
+		},
+		{
+			name:      "SubProcess",
+			elementID: "sub-process",
+			load:      loadBusinessKeySubProcess,
+		},
+	}
+	failures := []struct {
+		name             string
+		businessKeyInput string
+		variables        map[string]interface{}
+		expectedError    string
+		forbiddenError   string
+	}{
+		{
+			name:             "missing leading equals",
+			businessKeyInput: `<zenbpm:in businessKey="literal-key" />`,
+			expectedError:    "business key expression must start with '='",
+		},
+		{
+			name:             "invalid FEEL syntax",
+			businessKeyInput: `<zenbpm:in businessKey="=1 +" />`,
+			expectedError:    "failed to evaluate business key expression",
+		},
+		{
+			name:             "undefined FEEL result",
+			businessKeyInput: `<zenbpm:in businessKey="=missingBusinessKey" />`,
+			expectedError:    "business key expression must evaluate to a string",
+		},
+		{
+			name:             "non-string FEEL result",
+			businessKeyInput: `<zenbpm:in businessKey="=42" />`,
+			expectedError:    "business key expression must evaluate to a string",
+		},
+		{
+			name:             "non-string result does not expose process variables",
+			businessKeyInput: `<zenbpm:in businessKey="=sensitiveBusinessKey" />`,
+			variables: map[string]interface{}{
+				"sensitiveBusinessKey": map[string]interface{}{"secret": "do-not-expose"},
+			},
+			expectedError:  "business key expression must evaluate to a string, got map[string]interface {}",
+			forbiddenError: "do-not-expose",
+		},
+	}
+
+	for _, activityType := range activityTypes {
+		for _, failure := range failures {
+			t.Run(activityType.name+"/"+failure.name, func(t *testing.T) {
+				processID := fmt.Sprintf("business-key-failure-%d", rand.Int63())
+				process := activityType.load(t, processID, failure.businessKeyInput)
+
+				instance, err := bpmnEngine.CreateInstanceByKey(t.Context(), process.Key, failure.variables)
+				require.Error(t, err)
+				assert.ErrorContains(t, err, failure.expectedError)
+				if failure.forbiddenError != "" {
+					assert.NotContains(t, err.Error(), failure.forbiddenError)
+				}
+
+				persisted, err := bpmnEngine.persistence.FindProcessInstanceByKey(t.Context(), instance.ProcessInstance().Key)
+				require.NoError(t, err)
+				assert.Equal(t, runtime.ActivityStateFailed, persisted.ProcessInstance().State)
+
+				incidents, err := bpmnEngine.persistence.FindIncidentsByProcessInstanceKey(t.Context(), instance.ProcessInstance().Key)
+				require.NoError(t, err)
+				require.Len(t, incidents, 1)
+				assert.Equal(t, activityType.elementID, incidents[0].ElementId)
+				assert.Equal(t, runtime.TokenStateFailed, incidents[0].Token.State)
+				assert.Contains(t, incidents[0].Message, failure.expectedError)
+				if failure.forbiddenError != "" {
+					assert.NotContains(t, incidents[0].Message, failure.forbiddenError)
+				}
+
+				assertNoChildBusinessKeyInstance(t, instance.ProcessInstance().Key)
+			})
+		}
+	}
+}
+
+func assertNoChildBusinessKeyInstance(t *testing.T, parentInstanceKey int64) {
+	t.Helper()
+	tokens, err := bpmnEngine.persistence.GetAllTokensForProcessInstance(t.Context(), parentInstanceKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, tokens)
+	for _, token := range tokens {
+		children, err := bpmnEngine.persistence.FindProcessInstancesByParentExecutionTokenKey(t.Context(), token.Key)
+		require.NoError(t, err)
+		assert.Empty(t, children, "failed business key expression must not create a child process instance")
+	}
+}
+
+func loadBusinessKeyChildProcess(t *testing.T, processID string) {
+	t.Helper()
+	xml := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="http://zenbpm.pbinitiative.org/test">
+  <bpmn:process id="%s" isExecutable="true">
+    <bpmn:startEvent id="child-start">
+      <bpmn:outgoing>child-flow</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="child-flow" sourceRef="child-start" targetRef="child-end" />
+    <bpmn:endEvent id="child-end" />
+  </bpmn:process>
+</bpmn:definitions>`, processID)
+	_, err := bpmnEngine.LoadFromBytes(t.Context(), []byte(xml), rand.Int63())
+	require.NoError(t, err)
+}
+
+func loadBusinessKeyCallActivityProcess(t *testing.T, calledProcessID, businessKeyInput string) *runtime.ProcessDefinition {
+	t.Helper()
+	processID := fmt.Sprintf("business-key-call-parent-%d", rand.Int63())
+	xml := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" targetNamespace="http://zenbpm.pbinitiative.org/test">
+  <bpmn:process id="%s" isExecutable="true">
+    <bpmn:startEvent id="parent-start">
+      <bpmn:outgoing>to-call</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="to-call" sourceRef="parent-start" targetRef="call" />
+    <bpmn:callActivity id="call">
+      <bpmn:outgoing>to-end</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <zenbpm:calledElement processId="%s" />
+        %s
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="to-end" sourceRef="call" targetRef="parent-end" />
+    <bpmn:endEvent id="parent-end" />
+  </bpmn:process>
+</bpmn:definitions>`, processID, calledProcessID, businessKeyInput)
+	process, err := bpmnEngine.LoadFromBytes(t.Context(), []byte(xml), rand.Int63())
+	require.NoError(t, err)
+	return process
+}
+
+func loadBusinessKeyMultiInstanceCallActivityProcess(t *testing.T, calledProcessID string) *runtime.ProcessDefinition {
+	t.Helper()
+	processID := fmt.Sprintf("business-key-multi-parent-%d", rand.Int63())
+	xml := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" targetNamespace="http://zenbpm.pbinitiative.org/test">
+  <bpmn:process id="%s" isExecutable="true">
+    <bpmn:startEvent id="parent-start">
+      <bpmn:outgoing>to-call</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="to-call" sourceRef="parent-start" targetRef="call" />
+    <bpmn:callActivity id="call">
+      <bpmn:incoming>to-call</bpmn:incoming>
+      <bpmn:outgoing>to-end</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <zenbpm:calledElement processId="%s" />
+      </bpmn:extensionElements>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zenbpm:loopCharacteristics inputCollection="=items" inputElement="item" outputCollection="results" outputElement="=item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="to-end" sourceRef="call" targetRef="parent-end" />
+    <bpmn:endEvent id="parent-end">
+      <bpmn:incoming>to-end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>`, processID, calledProcessID)
+	process, err := bpmnEngine.LoadFromBytes(t.Context(), []byte(xml), rand.Int63())
+	require.NoError(t, err)
+	return process
+}
+
+func loadBusinessKeySubProcess(t *testing.T, processID, businessKeyInput string) *runtime.ProcessDefinition {
+	t.Helper()
+	xml := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" targetNamespace="http://zenbpm.pbinitiative.org/test">
+  <bpmn:process id="%s" isExecutable="true">
+    <bpmn:startEvent id="parent-start">
+      <bpmn:outgoing>to-sub-process</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="to-sub-process" sourceRef="parent-start" targetRef="sub-process" />
+    <bpmn:subProcess id="sub-process">
+      <bpmn:outgoing>to-end</bpmn:outgoing>
+      <bpmn:extensionElements>%s</bpmn:extensionElements>
+      <bpmn:startEvent id="sub-process-start">
+        <bpmn:outgoing>sub-process-flow</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="sub-process-flow" sourceRef="sub-process-start" targetRef="sub-process-end" />
+      <bpmn:endEvent id="sub-process-end" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="to-end" sourceRef="sub-process" targetRef="parent-end" />
+    <bpmn:endEvent id="parent-end" />
+  </bpmn:process>
+</bpmn:definitions>`, processID, businessKeyInput)
+	process, err := bpmnEngine.LoadFromBytes(t.Context(), []byte(xml), rand.Int63())
+	require.NoError(t, err)
+	return process
+}

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -374,6 +374,26 @@ func resolveHistoryTTL(ctx context.Context, instance runtime.ProcessInstance) {
 	}
 }
 
+// resolveRootBusinessKey stores the request business key on the runtime object.
+// Child instances receive their resolved key explicitly at their creation site.
+func resolveRootBusinessKey(ctx context.Context, instance runtime.ProcessInstance) {
+	if instance.GetParentProcessInstanceKey() != nil || instance.ProcessInstance().BusinessKey != nil {
+		return
+	}
+	if businessKey, ok := appcontext.BusinessKeyFromContext(ctx); ok {
+		instance.ProcessInstance().BusinessKey = &businessKey
+	}
+}
+
+// newChildProcessInstanceData keeps inherited process-instance metadata consistent
+// across all child-scope creation paths.
+func newChildProcessInstanceData(parent runtime.ProcessInstance, businessKey *string) runtime.ProcessInstanceData {
+	return runtime.ProcessInstanceData{
+		BusinessKey:   businessKey,
+		HistoryTTLSec: parent.ProcessInstance().HistoryTTLSec,
+	}
+}
+
 // createInstance creates a process instance for a given process definition and returns it.
 // Also returns execution tokens for plain StartEvent
 func (engine *Engine) createInstance(
@@ -389,6 +409,7 @@ func (engine *Engine) createInstance(
 	instance.ProcessInstance().CreatedAt = time.Now()
 	instance.ProcessInstance().State = runtime.ActivityStateReady
 	resolveHistoryTTL(ctx, instance)
+	resolveRootBusinessKey(ctx, instance)
 
 	ctx, createSpan := engine.tracer.Start(ctx, fmt.Sprintf("create-instance:%s", instance.ProcessInstance().Definition.BpmnProcessId), trace.WithAttributes(
 		attribute.Int64(otelPkg.AttributeProcessInstanceKey, instance.ProcessInstance().Key),
@@ -472,6 +493,7 @@ func (engine *Engine) createInstanceWithStartingElements(
 	instance.ProcessInstance().CreatedAt = time.Now()
 	instance.ProcessInstance().State = runtime.ActivityStateReady
 	resolveHistoryTTL(ctx, instance)
+	resolveRootBusinessKey(ctx, instance)
 
 	startNodeIds := make([]string, 0, len(startingFlowNodes))
 	for _, startNode := range startingFlowNodes {

--- a/pkg/bpmn/engine_error_end_event.go
+++ b/pkg/bpmn/engine_error_end_event.go
@@ -146,6 +146,20 @@ func (engine *Engine) tryCatchEndErrorAtScope(
 		return false, tokens, nil
 	}
 
+	var propagatedVariables map[string]any
+	var businessKey *string
+	if subprocessMatch != nil {
+		propagatedVariables, businessKey, err = engine.resolveEventSubprocessActivationData(
+			subprocessMatch.instance,
+			subprocessMatch.subProcess,
+			subprocessMatch.startEvent,
+			nil,
+		)
+		if err != nil {
+			return false, nil, err
+		}
+	}
+
 	tokens, err = engine.terminateEndErrorChain(ctx, batch, propagatingScopes, tokens, prop)
 	if err != nil {
 		return false, nil, err
@@ -158,7 +172,7 @@ func (engine *Engine) tryCatchEndErrorAtScope(
 		return true, tokens, nil
 	}
 
-	if err := engine.activateErrorEventSubprocessInParentScope(ctx, batch, scope, subprocessMatch); err != nil {
+	if err := engine.activateErrorEventSubprocessInParentScope(ctx, batch, scope, subprocessMatch, propagatedVariables, businessKey); err != nil {
 		return false, nil, err
 	}
 	return true, tokens, nil

--- a/pkg/bpmn/engine_error_event_subprocess.go
+++ b/pkg/bpmn/engine_error_event_subprocess.go
@@ -204,7 +204,11 @@ func (engine *Engine) activateErrorEventSubprocess(
 		}
 	}
 
-	variableHolder, tokens, err := engine.prepareParentForEventSubprocess(ctx, batch, instance, match.startEvent, errorVariables, omitTokenKeys...)
+	propagatedVariables, businessKey, err := engine.resolveEventSubprocessActivationData(instance, match.subProcess, match.startEvent, errorVariables)
+	if err != nil {
+		return nil, nil, err
+	}
+	variableHolder, tokens, err := engine.prepareParentForEventSubprocess(ctx, batch, instance, match.startEvent, propagatedVariables, omitTokenKeys...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -212,7 +216,7 @@ func (engine *Engine) activateErrorEventSubprocess(
 		return nil, nil, nil
 	}
 
-	subProcessInstance, subTokens, err := engine.buildEventSubprocessInstance(ctx, batch, instance, match.subProcess, match.startEvent, variableHolder, tokens)
+	subProcessInstance, subTokens, err := engine.buildEventSubprocessInstance(ctx, batch, instance, match.subProcess, match.startEvent, variableHolder, businessKey, tokens)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -292,6 +296,8 @@ func (engine *Engine) activateErrorEventSubprocessInParentScope(
 	batch *EngineBatch,
 	parentScope *errorEventContext,
 	match *errorEventSubprocessMatch,
+	propagatedVariables map[string]any,
+	businessKey *string,
 ) error {
 	instance := match.instance
 
@@ -304,10 +310,7 @@ func (engine *Engine) activateErrorEventSubprocessInParentScope(
 	}
 
 	variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, nil)
-	propagatedVariables, err := variableHolder.PropagateMappedOutputsOrAll(match.startEvent.GetOutputMapping(), nil, engine.evaluateExpression)
-	if err != nil {
-		return fmt.Errorf("failed to propagate error variables to scope %d: %w", instance.ProcessInstance().Key, err)
-	}
+	instance.ProcessInstance().VariableHolder.SetLocalVariables(propagatedVariables)
 	for k, v := range propagatedVariables {
 		variableHolder.SetLocalVariable(k, v)
 	}
@@ -323,7 +326,7 @@ func (engine *Engine) activateErrorEventSubprocessInParentScope(
 		return nil
 	}
 
-	subProcessInstance, subTokens, err := engine.buildEventSubprocessInstance(ctx, batch, instance, match.subProcess, match.startEvent, variableHolder, tokens)
+	subProcessInstance, subTokens, err := engine.buildEventSubprocessInstance(ctx, batch, instance, match.subProcess, match.startEvent, variableHolder, businessKey, tokens)
 	if err != nil {
 		return err
 	}

--- a/pkg/bpmn/event_subprocess_subscription_handler.go
+++ b/pkg/bpmn/event_subprocess_subscription_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/pbinitiative/zenbpm/internal/safego"
@@ -81,7 +82,11 @@ func (engine *Engine) startEventSubprocess(ctx context.Context, t eventSubproces
 		return nil
 	}
 
-	variableHolder, tokens, err := engine.prepareParentForEventSubprocess(ctx, &batch, instance, startEventDef, t.inputVariables)
+	propagatedVariables, businessKey, err := engine.resolveEventSubprocessActivationData(instance, subProcessDef, startEventDef, t.inputVariables)
+	if err != nil {
+		return err
+	}
+	variableHolder, tokens, err := engine.prepareParentForEventSubprocess(ctx, &batch, instance, startEventDef, propagatedVariables)
 	if err != nil {
 		return err
 	}
@@ -90,7 +95,7 @@ func (engine *Engine) startEventSubprocess(ctx context.Context, t eventSubproces
 		return nil
 	}
 
-	subProcessInstance, subTokens, err := engine.buildEventSubprocessInstance(ctx, &batch, instance, subProcessDef, startEventDef, variableHolder, tokens)
+	subProcessInstance, subTokens, err := engine.buildEventSubprocessInstance(ctx, &batch, instance, subProcessDef, startEventDef, variableHolder, businessKey, tokens)
 	if err != nil {
 		return err
 	}
@@ -142,9 +147,41 @@ func resolveEventSubprocessDefs(instance runtime.ProcessInstance, elementId stri
 	return subProcessDef, startEventDef, nil
 }
 
+// resolveEventSubprocessActivationData evaluates start-event output mappings and the child business key without
+// mutating the parent scope. Validation therefore completes before an interrupting event subprocess cancels anything.
+func (engine *Engine) resolveEventSubprocessActivationData(
+	instance runtime.ProcessInstance,
+	subProcessDef *bpmn20.TSubProcess,
+	startEventDef *bpmn20.TStartEvent,
+	inputVariables map[string]any,
+) (map[string]any, *string, error) {
+	parentVariables := maps.Clone(instance.ProcessInstance().VariableHolder.LocalVariables())
+	detachedParent := runtime.NewVariableHolder(nil, parentVariables)
+	variableHolder := runtime.NewVariableHolder(&detachedParent, nil)
+	propagatedVariables, err := variableHolder.PropagateMappedOutputsOrAll(startEventDef.GetOutputMapping(), inputVariables, engine.evaluateExpression)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to propagate variables to process instance %d: %w", instance.ProcessInstance().Key, err)
+	}
+	for k, v := range propagatedVariables {
+		variableHolder.SetLocalVariable(k, v)
+	}
+
+	businessKeyVariables := instance.ProcessInstance().VariableHolder.ExecutionScopeSnapshot()
+	maps.Copy(businessKeyVariables, variableHolder.LocalVariables())
+	businessKey, err := engine.resolveChildBusinessKey(
+		instance.ProcessInstance().BusinessKey,
+		subProcessDef.GetBusinessKey(),
+		businessKeyVariables,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return propagatedVariables, businessKey, nil
+}
+
 // prepareParentForEventSubprocess handles all mutations to the parent process instance that must happen before the
-// event subprocess can be created: optionally interrupts the parent, propagates trigger variables and saves the
-// updated parent instance. It also fetches and returns the parent's currently active tokens.
+// event subprocess can be created: optionally interrupts the parent, applies validated trigger variables and saves
+// the updated parent instance. It also fetches and returns the parent's currently active tokens.
 //
 // omitTokenKeys are excluded from the interrupting cancellation. Callers that want a token to complete normally
 // (rather than be canceled) while still interrupting every other branch of the scope pass its key here — e.g. the
@@ -154,7 +191,7 @@ func (engine *Engine) prepareParentForEventSubprocess(
 	batch *EngineBatch,
 	instance runtime.ProcessInstance,
 	startEventDef *bpmn20.TStartEvent,
-	inputVariables map[string]any,
+	propagatedVariables map[string]any,
 	omitTokenKeys ...int64,
 ) (runtime.VariableHolder, []runtime.ExecutionToken, error) {
 	if startEventDef.IsInterrupting {
@@ -164,10 +201,7 @@ func (engine *Engine) prepareParentForEventSubprocess(
 	}
 
 	variableHolder := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, nil)
-	propagatedVariables, err := variableHolder.PropagateMappedOutputsOrAll(startEventDef.GetOutputMapping(), inputVariables, engine.evaluateExpression)
-	if err != nil {
-		return runtime.VariableHolder{}, nil, fmt.Errorf("failed to propagate variables to process instance %d: %w", instance.ProcessInstance().Key, err)
-	}
+	instance.ProcessInstance().VariableHolder.SetLocalVariables(propagatedVariables)
 	// Make sure the propagated variables are also visible inside the event subprocess itself.
 	for k, v := range propagatedVariables {
 		variableHolder.SetLocalVariable(k, v)
@@ -192,6 +226,7 @@ func (engine *Engine) buildEventSubprocessInstance(
 	subProcessDef *bpmn20.TSubProcess,
 	startEventDef *bpmn20.TStartEvent,
 	variableHolder runtime.VariableHolder,
+	businessKey *string,
 	tokens []runtime.ExecutionToken,
 ) (runtime.ProcessInstance, []runtime.ExecutionToken, error) {
 	startingFlowNodes := []bpmn20.FlowNode{startEventDef}
@@ -214,9 +249,7 @@ func (engine *Engine) buildEventSubprocessInstance(
 			ParentProcessExecutionToken:           tokens[0],
 			ParentProcessTargetElementInstanceKey: tokens[0].ElementInstanceKey,
 			ParentProcessTargetElementId:          subProcessDef.Id,
-			ProcessInstanceData: runtime.ProcessInstanceData{
-				HistoryTTLSec: instance.ProcessInstance().HistoryTTLSec,
-			},
+			ProcessInstanceData:                   newChildProcessInstanceData(instance, businessKey),
 		},
 	)
 	if err != nil {

--- a/pkg/bpmn/model/bpmn20/activities.go
+++ b/pkg/bpmn/model/bpmn20/activities.go
@@ -49,11 +49,18 @@ type TActivity struct {
 	// BPMN 2.0 Unorthodox elements. Part of the extensions elements see https://github.com/pbinitiative/zenbpm-bpmn-moddle
 	Input  []extensions.TIoMapping `xml:"extensionElements>ioMapping>input"`
 	Output []extensions.TIoMapping `xml:"extensionElements>ioMapping>output"`
+	In     *extensions.TIn         `xml:"extensionElements>in"`
 }
 
 func (task TActivity) GetInputMapping() []extensions.TIoMapping  { return task.Input }
 func (task TActivity) GetOutputMapping() []extensions.TIoMapping { return task.Output }
 func (task TActivity) GetMultiInstance() *TMultiInstance         { return task.MultiInstance }
+func (task TActivity) GetBusinessKey() *string {
+	if task.In == nil {
+		return nil
+	}
+	return task.In.BusinessKey
+}
 
 type TTask struct {
 	TActivity

--- a/pkg/bpmn/model/bpmn20/elements_test.go
+++ b/pkg/bpmn/model/bpmn20/elements_test.go
@@ -13,7 +13,19 @@ func TestActivityElementTypes(t *testing.T) {
 	assert.Equal(t, ElementType("SUB_PROCESS"), (&TSubProcess{}).GetType())
 }
 
+// activityWithoutBusinessKey models an activity implemented by a downstream package.
+// It intentionally does not expose GetBusinessKey, because that is not an activity-wide concern.
+type activityWithoutBusinessKey struct {
+	TFlowNode
+}
+
+func (activityWithoutBusinessKey) GetMultiInstance() *TMultiInstance {
+	return nil
+}
+
 func TestAllInterfacesImplemented(t *testing.T) {
+	var _ Activity = (*activityWithoutBusinessKey)(nil)
+
 	var _ InternalTask = &TServiceTask{}
 	var _ InternalTask = &TUserTask{}
 	var _ InternalTask = &TBusinessRuleTask{}

--- a/pkg/bpmn/model/bpmn20/extensions_namespace_test.go
+++ b/pkg/bpmn/model/bpmn20/extensions_namespace_test.go
@@ -92,6 +92,69 @@ func TestUnmarshalZenbpmExtensions_ZeebeBackwardsCompat(t *testing.T) {
 	assert.Equal(t, "oldOutVar", task.GetOutputMapping()[0].Target)
 }
 
+func TestUnmarshalZenbpmExtensions_BusinessKeyInput(t *testing.T) {
+	businessKeyXML := `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:custom="` + zenbpmNS + `">
+  <bpmn:process id="business-key" isExecutable="true">
+    <bpmn:callActivity id="configured-call">
+      <bpmn:extensionElements>
+        <custom:in businessKey="=processBusinessKey" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="inherited-call" />
+    <bpmn:subProcess id="cleared-sub-process">
+      <bpmn:extensionElements>
+        <custom:in businessKey="" />
+      </bpmn:extensionElements>
+    </bpmn:subProcess>
+  </bpmn:process>
+</bpmn:definitions>`
+
+	var def TDefinitions
+	err := xml.Unmarshal([]byte(businessKeyXML), &def)
+	assert.NoError(t, err)
+	assert.Equal(t, "=processBusinessKey", *def.Process.CallActivity[0].GetBusinessKey())
+	assert.Nil(t, def.Process.CallActivity[1].GetBusinessKey())
+	assert.Equal(t, "", *def.Process.SubProcess[0].GetBusinessKey())
+}
+
+func TestUnmarshalBusinessKeyInput_PreservesAttributePresenceAcrossNamespaces(t *testing.T) {
+	businessKeyXML := `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="` + zenbpmNS + `" xmlns:camunda="http://camunda.org/schema/1.0/bpmn">
+  <bpmn:process id="business-key-presence" isExecutable="true">
+    <bpmn:callActivity id="zenbpm-in-without-business-key">
+      <bpmn:extensionElements>
+        <zenbpm:in />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="camunda-variable-mapping">
+      <bpmn:extensionElements>
+        <camunda:in source="customerId" target="customerId" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="explicit-empty-business-key">
+      <bpmn:extensionElements>
+        <zenbpm:in businessKey="" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="feel-business-key">
+      <bpmn:extensionElements>
+        <zenbpm:in businessKey="=customerId" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+  </bpmn:process>
+</bpmn:definitions>`
+
+	var def TDefinitions
+	err := xml.Unmarshal([]byte(businessKeyXML), &def)
+	assert.NoError(t, err)
+	assert.Len(t, def.Process.CallActivity, 4)
+	assert.Nil(t, def.Process.CallActivity[0].GetBusinessKey())
+	assert.Nil(t, def.Process.CallActivity[1].GetBusinessKey())
+	assert.Equal(t, "", *def.Process.CallActivity[2].GetBusinessKey())
+	assert.Equal(t, "=customerId", *def.Process.CallActivity[3].GetBusinessKey())
+}
+
 func TestUnmarshalZenbpmExtensions_UserTaskWithAssignment(t *testing.T) {
 	zenbpmXML := `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="` + zenbpmNS + `">

--- a/pkg/bpmn/model/extensions/io_mapping.go
+++ b/pkg/bpmn/model/extensions/io_mapping.go
@@ -7,6 +7,10 @@ type TIoMapping struct {
 	Target string `xml:"target,attr"`
 }
 
+type TIn struct {
+	BusinessKey *string `xml:"businessKey,attr"`
+}
+
 type TCalledElement struct {
 	ProcessId   string  `xml:"processId,attr"`
 	BindingType *string `xml:"bindingType,attr,omitempty"`

--- a/pkg/bpmn/multi_instance.go
+++ b/pkg/bpmn/multi_instance.go
@@ -221,9 +221,7 @@ func (engine *Engine) startParallelMultiInstance(
 			ParentProcessExecutionToken:           currentToken,
 			ParentProcessTargetElementInstanceKey: currentToken.ElementInstanceKey,
 			ParentProcessTargetElementId:          element.GetId(),
-			ProcessInstanceData: runtime.ProcessInstanceData{
-				HistoryTTLSec: instance.ProcessInstance().HistoryTTLSec,
-			},
+			ProcessInstanceData:                   newChildProcessInstanceData(instance, instance.ProcessInstance().BusinessKey),
 		},
 	)
 	if err != nil {
@@ -294,9 +292,7 @@ func (engine *Engine) startSequentialMultiInstance(ctx context.Context, batch *E
 			ParentProcessExecutionToken:           currentToken,
 			ParentProcessTargetElementInstanceKey: currentToken.ElementInstanceKey,
 			ParentProcessTargetElementId:          element.GetId(),
-			ProcessInstanceData: runtime.ProcessInstanceData{
-				HistoryTTLSec: instance.ProcessInstance().HistoryTTLSec,
-			},
+			ProcessInstanceData:                   newChildProcessInstanceData(instance, instance.ProcessInstance().BusinessKey),
 		},
 	)
 	if err != nil {

--- a/pkg/bpmn/sub_process.go
+++ b/pkg/bpmn/sub_process.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pbinitiative/zenbpm/internal/log"
@@ -24,11 +25,12 @@ func (engine *Engine) resolveChildBusinessKey(parentBusinessKey, expression *str
 		inheritedBusinessKey := *parentBusinessKey
 		return &inheritedBusinessKey, nil
 	}
-	if *expression == "" {
+	trimmedExpression := strings.TrimSpace(*expression)
+	if trimmedExpression == "" {
 		emptyBusinessKey := ""
 		return &emptyBusinessKey, nil
 	}
-	if (*expression)[0] != '=' {
+	if (trimmedExpression)[0] != '=' {
 		return nil, fmt.Errorf("business key expression must start with '='")
 	}
 

--- a/pkg/bpmn/sub_process.go
+++ b/pkg/bpmn/sub_process.go
@@ -16,6 +16,33 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+func (engine *Engine) resolveChildBusinessKey(parentBusinessKey, expression *string, variables map[string]interface{}) (*string, error) {
+	if expression == nil {
+		if parentBusinessKey == nil {
+			return nil, nil
+		}
+		inheritedBusinessKey := *parentBusinessKey
+		return &inheritedBusinessKey, nil
+	}
+	if *expression == "" {
+		emptyBusinessKey := ""
+		return &emptyBusinessKey, nil
+	}
+	if (*expression)[0] != '=' {
+		return nil, fmt.Errorf("business key expression must start with '='")
+	}
+
+	result, err := engine.evaluateExpression(*expression, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate business key expression: %w", err)
+	}
+	businessKey, ok := result.(string)
+	if !ok {
+		return nil, fmt.Errorf("business key expression must evaluate to a string, got %T", result)
+	}
+	return &businessKey, nil
+}
+
 func (engine *Engine) createCallActivity(
 	ctx context.Context,
 	batch *EngineBatch,
@@ -28,6 +55,14 @@ func (engine *Engine) createCallActivity(
 	flowElementInput := callActivityVarHolder.ExecutionScopeSnapshot()
 	if err := callActivityVarHolder.EvaluateAndSetMappingsToLocalVariables(element.GetInputMapping(), engine.evaluateExpression); err != nil {
 		return runtime.ActivityStateFailed, fmt.Errorf("failed to evaluate local variables for call activity: %w", err)
+	}
+	businessKey, err := engine.resolveChildBusinessKey(
+		instance.ProcessInstance().BusinessKey,
+		element.GetBusinessKey(),
+		callActivityVarHolder.ExecutionScopeSnapshot(),
+	)
+	if err != nil {
+		return runtime.ActivityStateFailed, err
 	}
 	batch.SaveFlowElementInstance(ctx,
 		runtime.FlowElementInstance{
@@ -55,9 +90,7 @@ func (engine *Engine) createCallActivity(
 		&runtime.CallActivityInstance{
 			ParentProcessExecutionToken:           currentToken,
 			ParentProcessTargetElementInstanceKey: currentToken.ElementInstanceKey,
-			ProcessInstanceData: runtime.ProcessInstanceData{
-				HistoryTTLSec: instance.ProcessInstance().HistoryTTLSec,
-			},
+			ProcessInstanceData:                   newChildProcessInstanceData(instance, businessKey),
 		})
 	if err != nil {
 		return runtime.ActivityStateFailed, err
@@ -87,6 +120,14 @@ func (engine *Engine) createSubProcess(
 	if err := subProcessVariableHolder.EvaluateAndSetMappingsToLocalVariables(element.GetInputMapping(), engine.evaluateExpression); err != nil {
 		instance.ProcessInstance().State = runtime.ActivityStateFailed
 		return runtime.ActivityStateFailed, fmt.Errorf("failed to evaluate local variables for sub process: %w", err)
+	}
+	businessKey, err := engine.resolveChildBusinessKey(
+		instance.ProcessInstance().BusinessKey,
+		element.GetBusinessKey(),
+		subProcessVariableHolder.ExecutionScopeSnapshot(),
+	)
+	if err != nil {
+		return runtime.ActivityStateFailed, err
 	}
 
 	batch.SaveFlowElementInstance(ctx,
@@ -118,9 +159,7 @@ func (engine *Engine) createSubProcess(
 			ParentProcessExecutionToken:           currentToken,
 			ParentProcessTargetElementInstanceKey: currentToken.ElementInstanceKey,
 			ParentProcessTargetElementId:          element.Id,
-			ProcessInstanceData: runtime.ProcessInstanceData{
-				HistoryTTLSec: instance.ProcessInstance().HistoryTTLSec,
-			},
+			ProcessInstanceData:                   newChildProcessInstanceData(instance, businessKey),
 		},
 	)
 	if err != nil {

--- a/test/e2e/call_activity_business_key_test.go
+++ b/test/e2e/call_activity_business_key_test.go
@@ -1,0 +1,164 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+const callActivityBusinessKeyCalledProcessID = "business-key-called-process"
+
+func TestCallActivityBusinessKey(t *testing.T) {
+
+	t.Run("The called process should inherit the business key when the extension element is missing.", func(t *testing.T) {
+
+		businessKey := fmt.Sprintf("business-key-%d", time.Now().UnixNano())
+
+		definitionKey := deployCallActivityBusinessKeyProcessDefinitions(
+			t,
+			"testdata/call_activity/call_activity_with_business_key_no_override.bpmn",
+		)
+		processInstance := createProcessInstanceWithVariablesAndBusinessKey(t, definitionKey, &businessKey, map[string]any{
+			"businessKey": "business-key-value",
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		calledProcess := waitForDirectChildProcessInstance(t, processInstance.Key)
+		require.Equal(t, zenclient.ProcessInstanceProcessTypeCallActivity, calledProcess.ProcessType)
+		require.Equal(t, businessKey, requireCallActivityBusinessKey(t, calledProcess.BusinessKey))
+
+		completeJobForElementId(t, calledProcess.Key, "called-service-task", nil)
+		waitForProcessInstanceState(t, calledProcess.Key, zenclient.ProcessInstanceStateCompleted)
+
+		persistedCalledProcess, err := getProcessInstance(t, calledProcess.Key)
+		require.NoError(t, err)
+		require.Equal(t, businessKey, requireCallActivityBusinessKey(t, persistedCalledProcess.BusinessKey))
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateCompleted)
+	})
+
+	t.Run("The called process business key should be overridden when the extension element exists.", func(t *testing.T) {
+
+		businessKey := fmt.Sprintf("business-key-%d", time.Now().UnixNano())
+		businessKeyFromInputVariable := fmt.Sprintf("business-key-from-input-variable-%d", time.Now().UnixNano())
+
+		definitionKey := deployCallActivityBusinessKeyProcessDefinitions(
+			t,
+			"testdata/call_activity/call_activity_with_business_key_override.bpmn",
+		)
+		processInstance := createProcessInstanceWithVariablesAndBusinessKey(t, definitionKey, &businessKey, map[string]any{
+			"businessKeyFromInputVariable": businessKeyFromInputVariable,
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		calledProcess := waitForDirectChildProcessInstance(t, processInstance.Key)
+		require.Equal(t, zenclient.ProcessInstanceProcessTypeCallActivity, calledProcess.ProcessType)
+		require.Equal(t, businessKeyFromInputVariable, requireCallActivityBusinessKey(t, calledProcess.BusinessKey))
+		require.NotEqual(t, businessKey, requireCallActivityBusinessKey(t, calledProcess.BusinessKey))
+
+		completeJobForElementId(t, calledProcess.Key, "called-service-task", nil)
+		waitForProcessInstanceState(t, calledProcess.Key, zenclient.ProcessInstanceStateCompleted)
+
+		persistedCalledProcess, err := getProcessInstance(t, calledProcess.Key)
+		require.NoError(t, err)
+		require.Equal(t, businessKeyFromInputVariable, requireCallActivityBusinessKey(t, persistedCalledProcess.BusinessKey))
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateCompleted)
+	})
+
+	t.Run("The called process business key should be cleared when the override is empty.", func(t *testing.T) {
+
+		businessKey := fmt.Sprintf("business-key-%d", time.Now().UnixNano())
+
+		definitionKey := deployCallActivityBusinessKeyProcessDefinitions(
+			t,
+			"testdata/call_activity/call_activity_with_empty_business_key_override.bpmn",
+		)
+		processInstance := createProcessInstanceWithVariablesAndBusinessKey(t, definitionKey, &businessKey, map[string]any{})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		calledProcess := waitForDirectChildProcessInstance(t, processInstance.Key)
+		require.Equal(t, zenclient.ProcessInstanceProcessTypeCallActivity, calledProcess.ProcessType)
+		require.Empty(t, requireCallActivityBusinessKey(t, calledProcess.BusinessKey))
+
+		completeJobForElementId(t, calledProcess.Key, "called-service-task", nil)
+		waitForProcessInstanceState(t, calledProcess.Key, zenclient.ProcessInstanceStateCompleted)
+
+		persistedCalledProcess, err := getProcessInstance(t, calledProcess.Key)
+		require.NoError(t, err)
+		require.Empty(t, requireCallActivityBusinessKey(t, persistedCalledProcess.BusinessKey))
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateCompleted)
+	})
+
+	t.Run("A missing business key override value should create an incident.", func(t *testing.T) {
+
+		businessKey := fmt.Sprintf("business-key-%d", time.Now().UnixNano())
+
+		definitionKey := deployCallActivityBusinessKeyProcessDefinitions(
+			t,
+			"testdata/call_activity/call_activity_with_business_key_override.bpmn",
+		)
+		processInstance := createProcessInstanceWithVariablesAndBusinessKey(t, definitionKey, &businessKey, map[string]any{})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateFailed)
+		assertProcessInstanceIncidentsLength(t, processInstance.Key, 1)
+
+		incidents, err := getProcessInstanceIncidents(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Len(t, incidents, 1)
+		require.Equal(t, "service_task", incidents[0].ElementId)
+		require.Contains(t, incidents[0].Message, "business key expression must evaluate to a string")
+
+		childProcesses, err := getChildInstances(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Zero(t, childProcesses.TotalCount)
+	})
+}
+
+func deployCallActivityBusinessKeyProcessDefinitions(t testing.TB, parentFilename string) int64 {
+	t.Helper()
+
+	uniqueSuffix := time.Now().UnixNano()
+	calledProcessID := fmt.Sprintf("call-activity-business-key-called-process-%d", uniqueSuffix)
+	calledJobType := fmt.Sprintf("call-activity-business-key-called-task-%d", uniqueSuffix)
+
+	_, err := deployTestDataDefinitionWithJobType(
+		t,
+		"testdata/call_activity/call_activity_with_business_key_child_process.bpmn",
+		calledProcessID,
+		map[string]string{
+			"business-key-called-task": calledJobType,
+		},
+	)
+	require.NoError(t, err)
+
+	parentProcessID := fmt.Sprintf("call-activity-business-key-parent-%d", uniqueSuffix)
+	parentDefinition, err := deployTestDataDefinition(
+		t,
+		parentFilename,
+		parentProcessID,
+		nil,
+		map[string]string{
+			callActivityBusinessKeyCalledProcessID: calledProcessID,
+		},
+	)
+	require.NoError(t, err)
+	require.NotZero(t, parentDefinition.ProcessDefinitionKey)
+	return parentDefinition.ProcessDefinitionKey
+}
+
+func requireCallActivityBusinessKey(t testing.TB, businessKey *string) string {
+	t.Helper()
+	require.NotNil(t, businessKey)
+	return *businessKey
+}

--- a/test/e2e/process_instance_helpers_test.go
+++ b/test/e2e/process_instance_helpers_test.go
@@ -147,6 +147,23 @@ func createProcessInstanceWithVariables(t testing.TB, definitionKey int64, varia
 	return instance
 }
 
+func createProcessInstanceWithVariablesAndBusinessKey(t testing.TB, definitionKey int64, businessKey *string, variables map[string]any) zenclient.ProcessInstance {
+
+	t.Helper()
+	resp, err := app.restClient.CreateProcessInstanceWithResponse(t.Context(), zenclient.CreateProcessInstanceJSONRequestBody{
+		BpmnProcessId:        nil,
+		BusinessKey:          businessKey,
+		HistoryTimeToLive:    nil,
+		ProcessDefinitionKey: &definitionKey,
+		Variables:            &variables,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode())
+	require.NotNil(t, resp.JSON201)
+
+	return *resp.JSON201
+}
+
 func getProcessInstance(t testing.TB, key int64) (zenclient.ProcessInstance, error) {
 	t.Helper()
 

--- a/test/e2e/sub_process_business_key_test.go
+++ b/test/e2e/sub_process_business_key_test.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubProcessBusinessKey(t *testing.T) {
+
+	t.Run("The business key should not be overridden when the extension element is missing.", func(t *testing.T) {
+
+		businessKey := fmt.Sprintf("business-key-%d", time.Now().UnixNano())
+
+		definitionKey := deployTestDataProcessDefinitionKey(t, "testdata/sub_process/subprocess_with_business_key_no_override.bpmn")
+		processInstance := createProcessInstanceWithVariablesAndBusinessKey(t, definitionKey, &businessKey, map[string]any{
+			"businessKey": "business-key-value",
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+		innerProcess := waitForChildProcessInstance(t, processInstance.Key, 0)
+
+		require.NotNil(t, innerProcess.BusinessKey)
+
+		completeJobForElementId(t, innerProcess.Key, "service_task", nil)
+		waitForProcessInstanceState(t, innerProcess.Key, zenclient.ProcessInstanceStateCompleted)
+
+		persistedInnerProcessInstance, err := getProcessInstance(t, innerProcess.Key)
+
+		require.NoError(t, err)
+		require.Equal(t, requireBusinessKey(t, innerProcess.BusinessKey), requireBusinessKey(t, persistedInnerProcessInstance.BusinessKey))
+
+		persistedSubProcessInstance := waitForDirectChildProcessInstance(t, processInstance.Key)
+		require.Equal(t, zenclient.ProcessInstanceProcessTypeSubprocess, persistedSubProcessInstance.ProcessType)
+		require.Equal(t, businessKey, requireBusinessKey(t, persistedSubProcessInstance.BusinessKey))
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateCompleted)
+	})
+
+	t.Run("The business key should be overridden when the extension element exists.", func(t *testing.T) {
+
+		businessKey := fmt.Sprintf("business-key-%d", time.Now().UnixNano())
+		businessKeyFromInputVariable := fmt.Sprintf("business-key-from-input-variable-%d", time.Now().UnixNano())
+
+		definitionKey := deployTestDataProcessDefinitionKey(t, "testdata/sub_process/subprocess_with_business_key_override.bpmn")
+		processInstance := createProcessInstanceWithVariablesAndBusinessKey(t, definitionKey, &businessKey, map[string]any{
+			"businessKeyFromInputVariable": businessKeyFromInputVariable,
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+		innerProcess := waitForChildProcessInstance(t, processInstance.Key, 0)
+
+		require.NotNil(t, innerProcess.BusinessKey)
+
+		completeJobForElementId(t, innerProcess.Key, "service_task", nil)
+		waitForProcessInstanceState(t, innerProcess.Key, zenclient.ProcessInstanceStateCompleted)
+
+		persistedInnerProcessInstance, err := getProcessInstance(t, innerProcess.Key)
+
+		require.NoError(t, err)
+		require.Equal(t, requireBusinessKey(t, innerProcess.BusinessKey), requireBusinessKey(t, persistedInnerProcessInstance.BusinessKey))
+		require.NotEqual(t, businessKey, requireBusinessKey(t, persistedInnerProcessInstance.BusinessKey))
+
+		persistedSubProcessInstance := waitForDirectChildProcessInstance(t, processInstance.Key)
+		require.Equal(t, zenclient.ProcessInstanceProcessTypeSubprocess, persistedSubProcessInstance.ProcessType)
+		require.Equal(t, businessKeyFromInputVariable, requireBusinessKey(t, persistedSubProcessInstance.BusinessKey))
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateCompleted)
+	})
+}
+
+func requireBusinessKey(t testing.TB, businessKey *string) string {
+	t.Helper()
+	require.NotNil(t, businessKey)
+	return *businessKey
+}

--- a/test/e2e/testdata/call_activity/call_activity_with_business_key_child_process.bpmn
+++ b/test/e2e/testdata/call_activity/call_activity_with_business_key_child_process.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_business_key_called_process" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="call_activity_business_key_called_process" name="Call activity business key called process" isExecutable="true">
+    <bpmn:startEvent id="called-start">
+      <bpmn:outgoing>called-start-to-service-task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="called-start-to-service-task" sourceRef="called-start" targetRef="called-service-task" />
+    <bpmn:serviceTask id="called-service-task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="business-key-called-task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>called-start-to-service-task</bpmn:incoming>
+      <bpmn:outgoing>called-service-task-to-end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="called-service-task-to-end" sourceRef="called-service-task" targetRef="called-end" />
+    <bpmn:endEvent id="called-end">
+      <bpmn:incoming>called-service-task-to-end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_business_key_called_process">
+    <bpmndi:BPMNPlane id="BPMNPlane_business_key_called_process" bpmnElement="call_activity_business_key_called_process">
+      <bpmndi:BPMNShape id="called-start_di" bpmnElement="called-start">
+        <dc:Bounds x="170" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="called-service-task_di" bpmnElement="called-service-task">
+        <dc:Bounds x="270" y="100" width="130" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="called-end_di" bpmnElement="called-end">
+        <dc:Bounds x="470" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="called-start-to-service-task_di" bpmnElement="called-start-to-service-task">
+        <di:waypoint x="206" y="140" />
+        <di:waypoint x="270" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="called-service-task-to-end_di" bpmnElement="called-service-task-to-end">
+        <di:waypoint x="400" y="140" />
+        <di:waypoint x="470" y="140" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/call_activity/call_activity_with_business_key_no_override.bpmn
+++ b/test/e2e/testdata/call_activity/call_activity_with_business_key_no_override.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_business_key_child_scopes" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="call_activity_business_key_no_override" name="Call activity no override business key" isExecutable="true">
+    <bpmn:startEvent id="subprocess-start">
+      <bpmn:outgoing>Flow_1vp9qpm</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="subprocess-end">
+      <bpmn:incoming>Flow_196jomu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_196jomu" sourceRef="service_task" targetRef="subprocess-end" />
+    <bpmn:sequenceFlow id="Flow_1vp9qpm" sourceRef="subprocess-start" targetRef="service_task" />
+    <bpmn:callActivity id="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:calledElement processId="business-key-called-process" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1vp9qpm</bpmn:incoming>
+      <bpmn:outgoing>Flow_196jomu</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_business_key_child_scopes">
+    <bpmndi:BPMNPlane id="BPMNPlane_business_key_child_scopes" bpmnElement="call_activity_business_key_no_override">
+      <bpmndi:BPMNShape id="subprocess-start_di" bpmnElement="subprocess-start">
+        <dc:Bounds x="202" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess-end_di" bpmnElement="subprocess-end">
+        <dc:Bounds x="502" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xe1n9o_di" bpmnElement="service_task">
+        <dc:Bounds x="320" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_196jomu_di" bpmnElement="Flow_196jomu">
+        <di:waypoint x="420" y="450" />
+        <di:waypoint x="502" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vp9qpm_di" bpmnElement="Flow_1vp9qpm">
+        <di:waypoint x="238" y="450" />
+        <di:waypoint x="320" y="450" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/call_activity/call_activity_with_business_key_override.bpmn
+++ b/test/e2e/testdata/call_activity/call_activity_with_business_key_override.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_business_key_child_scopes" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="call_activity_business_key_override" name="Call activity override business key" isExecutable="true">
+    <bpmn:startEvent id="subprocess-start">
+      <bpmn:outgoing>Flow_1vp9qpm</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="subprocess-end">
+      <bpmn:incoming>Flow_196jomu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_196jomu" sourceRef="service_task" targetRef="subprocess-end" />
+    <bpmn:sequenceFlow id="Flow_1vp9qpm" sourceRef="subprocess-start" targetRef="service_task" />
+    <bpmn:callActivity id="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:calledElement processId="business-key-called-process" />
+        <zenbpm:in businessKey="=businessKeyFromInputVariable" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1vp9qpm</bpmn:incoming>
+      <bpmn:outgoing>Flow_196jomu</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_business_key_child_scopes">
+    <bpmndi:BPMNPlane id="BPMNPlane_business_key_child_scopes" bpmnElement="call_activity_business_key_override">
+      <bpmndi:BPMNShape id="subprocess-start_di" bpmnElement="subprocess-start">
+        <dc:Bounds x="202" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess-end_di" bpmnElement="subprocess-end">
+        <dc:Bounds x="502" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xe1n9o_di" bpmnElement="service_task">
+        <dc:Bounds x="320" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_196jomu_di" bpmnElement="Flow_196jomu">
+        <di:waypoint x="420" y="450" />
+        <di:waypoint x="502" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vp9qpm_di" bpmnElement="Flow_1vp9qpm">
+        <di:waypoint x="238" y="450" />
+        <di:waypoint x="320" y="450" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/call_activity/call_activity_with_empty_business_key_override.bpmn
+++ b/test/e2e/testdata/call_activity/call_activity_with_empty_business_key_override.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_business_key_child_scopes" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="call_activity_empty_business_key_override" name="Call activity empty business key override" isExecutable="true">
+    <bpmn:startEvent id="subprocess-start">
+      <bpmn:outgoing>Flow_1vp9qpm</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="subprocess-end">
+      <bpmn:incoming>Flow_196jomu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_196jomu" sourceRef="service_task" targetRef="subprocess-end" />
+    <bpmn:sequenceFlow id="Flow_1vp9qpm" sourceRef="subprocess-start" targetRef="service_task" />
+    <bpmn:callActivity id="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:calledElement processId="business-key-called-process" />
+        <zenbpm:in businessKey="" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1vp9qpm</bpmn:incoming>
+      <bpmn:outgoing>Flow_196jomu</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_business_key_child_scopes">
+    <bpmndi:BPMNPlane id="BPMNPlane_business_key_child_scopes" bpmnElement="call_activity_empty_business_key_override">
+      <bpmndi:BPMNShape id="subprocess-start_di" bpmnElement="subprocess-start">
+        <dc:Bounds x="202" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess-end_di" bpmnElement="subprocess-end">
+        <dc:Bounds x="502" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xe1n9o_di" bpmnElement="service_task">
+        <dc:Bounds x="320" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_196jomu_di" bpmnElement="Flow_196jomu">
+        <di:waypoint x="420" y="450" />
+        <di:waypoint x="502" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vp9qpm_di" bpmnElement="Flow_1vp9qpm">
+        <di:waypoint x="238" y="450" />
+        <di:waypoint x="320" y="450" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/sub_process/subprocess_with_business_key_no_override.bpmn
+++ b/test/e2e/testdata/sub_process/subprocess_with_business_key_no_override.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_business_key_child_scopes" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="sub_process_business_key_no_override" name="No override of business key" isExecutable="true">
+    <bpmn:startEvent id="root-start">
+      <bpmn:outgoing>root-to-subprocess</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="root-to-subprocess" sourceRef="root-start" targetRef="business-key-subprocess" />
+    <bpmn:subProcess id="business-key-subprocess" name="No override of subprocess business key">
+      <bpmn:incoming>root-to-subprocess</bpmn:incoming>
+      <bpmn:outgoing>subprocess-to-root-end</bpmn:outgoing>
+      <bpmn:startEvent id="subprocess-start">
+        <bpmn:outgoing>subprocess-to-service-task</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="subprocess-to-service-task" sourceRef="subprocess-start" targetRef="service_task" />
+      <bpmn:sequenceFlow id="to-subprocess-end" sourceRef="service_task" targetRef="subprocess-end" />
+      <bpmn:endEvent id="subprocess-end">
+        <bpmn:incoming>to-subprocess-end</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="service_task">
+        <bpmn:incoming>subprocess-to-service-task</bpmn:incoming>
+        <bpmn:outgoing>to-subprocess-end</bpmn:outgoing>
+      </bpmn:serviceTask>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="subprocess-to-root-end" sourceRef="business-key-subprocess" targetRef="root-end" />
+    <bpmn:endEvent id="root-end">
+      <bpmn:incoming>subprocess-to-root-end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_business_key_child_scopes">
+    <bpmndi:BPMNPlane id="BPMNPlane_business_key_child_scopes" bpmnElement="sub_process_business_key_no_override">
+      <bpmndi:BPMNShape id="root-start_di" bpmnElement="root-start">
+        <dc:Bounds x="160" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="business-key-subprocess_di" bpmnElement="business-key-subprocess" isExpanded="true">
+        <dc:Bounds x="250" y="160" width="410" height="150" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess-start_di" bpmnElement="subprocess-start">
+        <dc:Bounds x="290" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess-end_di" bpmnElement="subprocess-end">
+        <dc:Bounds x="570" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1711q8c_di" bpmnElement="service_task">
+        <dc:Bounds x="380" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="subprocess-to-call-activity_di" bpmnElement="subprocess-to-service-task">
+        <di:waypoint x="326" y="240" />
+        <di:waypoint x="380" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="call-activity-to-subprocess-end_di" bpmnElement="to-subprocess-end">
+        <di:waypoint x="480" y="240" />
+        <di:waypoint x="570" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="root-end_di" bpmnElement="root-end">
+        <dc:Bounds x="720" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="root-to-subprocess_di" bpmnElement="root-to-subprocess">
+        <di:waypoint x="196" y="240" />
+        <di:waypoint x="250" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="subprocess-to-root-end_di" bpmnElement="subprocess-to-root-end">
+        <di:waypoint x="660" y="240" />
+        <di:waypoint x="720" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/sub_process/subprocess_with_business_key_override.bpmn
+++ b/test/e2e/testdata/sub_process/subprocess_with_business_key_override.bpmn
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_business_key_child_scopes" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="sub_process_business_key_override" name="Override business key" isExecutable="true">
+    <bpmn:startEvent id="root-start">
+      <bpmn:outgoing>root-to-subprocess</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="root-to-subprocess" sourceRef="root-start" targetRef="business-key-subprocess" />
+    <bpmn:subProcess id="business-key-subprocess" name="Override of subprocess business key">
+      <bpmn:extensionElements>
+        <zenbpm:in businessKey="=businessKeyFromInputVariable" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>root-to-subprocess</bpmn:incoming>
+      <bpmn:outgoing>subprocess-to-root-end</bpmn:outgoing>
+      <bpmn:startEvent id="subprocess-start">
+        <bpmn:outgoing>subprocess-to-service-task</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="subprocess-to-service-task" sourceRef="subprocess-start" targetRef="service_task" />
+      <bpmn:sequenceFlow id="to-subprocess-end" sourceRef="service_task" targetRef="subprocess-end" />
+      <bpmn:endEvent id="subprocess-end">
+        <bpmn:incoming>to-subprocess-end</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="service_task">
+        <bpmn:incoming>subprocess-to-service-task</bpmn:incoming>
+        <bpmn:outgoing>to-subprocess-end</bpmn:outgoing>
+      </bpmn:serviceTask>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="subprocess-to-root-end" sourceRef="business-key-subprocess" targetRef="root-end" />
+    <bpmn:endEvent id="root-end">
+      <bpmn:incoming>subprocess-to-root-end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_business_key_child_scopes">
+    <bpmndi:BPMNPlane id="BPMNPlane_business_key_child_scopes" bpmnElement="sub_process_business_key_override">
+      <bpmndi:BPMNShape id="root-start_di" bpmnElement="root-start">
+        <dc:Bounds x="160" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="business-key-subprocess_di" bpmnElement="business-key-subprocess" isExpanded="true">
+        <dc:Bounds x="250" y="160" width="410" height="150" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess-start_di" bpmnElement="subprocess-start">
+        <dc:Bounds x="290" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess-end_di" bpmnElement="subprocess-end">
+        <dc:Bounds x="570" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1711q8c_di" bpmnElement="service_task">
+        <dc:Bounds x="380" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="subprocess-to-call-activity_di" bpmnElement="subprocess-to-service-task">
+        <di:waypoint x="326" y="240" />
+        <di:waypoint x="380" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="call-activity-to-subprocess-end_di" bpmnElement="to-subprocess-end">
+        <di:waypoint x="480" y="240" />
+        <di:waypoint x="570" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="root-end_di" bpmnElement="root-end">
+        <dc:Bounds x="720" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="root-to-subprocess_di" bpmnElement="root-to-subprocess">
+        <di:waypoint x="196" y="240" />
+        <di:waypoint x="250" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="subprocess-to-root-end_di" bpmnElement="subprocess-to-root-end">
+        <di:waypoint x="660" y="240" />
+        <di:waypoint x="720" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
closes #727 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Business Key handling and propagation across call activities, subprocesses, event subprocesses, multi-instances, and error event subprocesses, including correct root/child inheritance.
  * Expanded BPMN extension support for `zenbpm:in` / `custom:in` `businessKey`, preserving absent vs empty-string vs expression semantics during XML unmarshalling.
* **Bug Fixes**
  * Corrected Business Key precedence during process-instance persistence so explicit instance values override context and child instances don’t inherit context Business Keys.
  * Improved resolution and activation behavior when businessKey expressions are whitespace-only or invalid.
* **Tests**
  * Added/expanded coverage for persistence precedence, event/error subprocess behavior, FEEL error paths, and XML attribute presence semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->