### PR TITLE
refactor(codebase): replace `ptr.To` with native `new()`

### DIFF
--- a/internal/cluster/controller/controller.go
+++ b/internal/cluster/controller/controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/safego"
 	"github.com/pbinitiative/zenbpm/internal/sql"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	rstore "github.com/rqlite/rqlite/v10/store"
 	"github.com/rqlite/rqlite/v10/tcp"
 )
@@ -153,8 +152,8 @@ func (c *Controller) assignPartition(ctx context.Context, partitionId uint32, no
 	}
 	c.logger.Info(fmt.Sprintf("Assigning partition %d to %s", partitionId, nodeId))
 	err := c.store.WritePartitionChange(&proto.NodePartitionChange{
-		NodeId:      ptr.To(nodeId),
-		PartitionId: ptr.To(partitionId),
+		NodeId:      new(nodeId),
+		PartitionId: new(partitionId),
 		State:       proto.NodePartitionState_NODE_PARTITION_STATE_JOINING.Enum(),
 		Role:        proto.Role_ROLE_TYPE_UNKNOWN.Enum(),
 	})
@@ -267,8 +266,8 @@ func (c *Controller) handlePartitionStateJoining(ctx context.Context, partitionI
 		Type: proto.Command_TYPE_NODE_PARTITION_CHANGE.Enum(),
 		Request: &proto.Command_NodePartitionChange{
 			NodePartitionChange: &proto.NodePartitionChange{
-				NodeId:      ptr.To(c.store.ID()),
-				PartitionId: ptr.To(partitionId),
+				NodeId:      new(c.store.ID()),
+				PartitionId: new(partitionId),
 				State:       proto.NodePartitionState_NODE_PARTITION_STATE_INITIALIZING.Enum(),
 				Role:        c.store.Role().Enum(),
 			},
@@ -378,8 +377,8 @@ func (c *Controller) handlePartitionStateInitializing(ctx context.Context, parti
 	}
 	partitionChangeCmd := &proto.Command_NodePartitionChange{
 		NodePartitionChange: &proto.NodePartitionChange{
-			NodeId:      ptr.To(c.store.ID()),
-			PartitionId: ptr.To(partitionId),
+			NodeId:      new(c.store.ID()),
+			PartitionId: new(partitionId),
 			State:       proto.NodePartitionState_NODE_PARTITION_STATE_INITIALIZED.Enum(),
 			Role:        partitionNode.Role().Enum(),
 		},

--- a/internal/cluster/jobmanager/client.go
+++ b/internal/cluster/jobmanager/client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
 	"github.com/pbinitiative/zenbpm/internal/cluster/state"
 	"github.com/pbinitiative/zenbpm/internal/safego"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenflake"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -256,7 +255,7 @@ func (c *jobClient) removeClient(ctx context.Context, clientID ClientID) {
 	if subFound {
 		err := c.broadcastToNodes(&proto.SubscribeJobRequest{
 			Type:     proto.SubscribeJobRequest_TYPE_UNSUBSCRIBE_ALL.Enum(),
-			ClientId: ptr.To(string(clientID)),
+			ClientId: new(string(clientID)),
 		})
 		if err != nil {
 			c.logger.Error("failed to remove client from nodes", "clientID", clientID, "err", err)
@@ -268,9 +267,9 @@ func (c *jobClient) removeClient(ctx context.Context, clientID ClientID) {
 
 func (c *jobClient) addJobSub(ctx context.Context, clientID ClientID, jobType JobType) error {
 	err := c.broadcastToNodes(&proto.SubscribeJobRequest{
-		JobType:  ptr.To(string(jobType)),
+		JobType:  new(string(jobType)),
 		Type:     proto.SubscribeJobRequest_TYPE_SUBSCRIBE.Enum(),
-		ClientId: ptr.To(string(clientID)),
+		ClientId: new(string(clientID)),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to subscribe client %s to jobType %s: %w", clientID, jobType, err)
@@ -289,9 +288,9 @@ func (c *jobClient) completeJob(ctx context.Context, clientID ClientID, jobKey i
 		return fmt.Errorf("failed to marshal variables for job completion: %w", err)
 	}
 	_, err = lClient.CompleteJob(ctx, &proto.CompleteJobRequest{
-		Key:       ptr.To(jobKey),
+		Key:       new(jobKey),
 		Variables: vars,
-		ClientId:  ptr.To(string(clientID)),
+		ClientId:  new(string(clientID)),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to complete job %d from client: %w", jobKey, err)
@@ -323,9 +322,9 @@ func (c *jobClient) failJob(ctx context.Context, clientID ClientID, jobKey int64
 
 func (c *jobClient) removeJobSub(ctx context.Context, clientID ClientID, jobType JobType) error {
 	err := c.broadcastToNodes(&proto.SubscribeJobRequest{
-		JobType:  ptr.To(string(jobType)),
+		JobType:  new(string(jobType)),
 		Type:     proto.SubscribeJobRequest_TYPE_UNSUBSCRIBE.Enum(),
-		ClientId: ptr.To(string(clientID)),
+		ClientId: new(string(clientID)),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to unsubscribe client %s from jobType %s: %w", clientID, jobType, err)

--- a/internal/cluster/jobmanager/manager_test.go
+++ b/internal/cluster/jobmanager/manager_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/cluster/state"
 	"github.com/pbinitiative/zenbpm/internal/sql"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -391,7 +390,7 @@ func (s *grpcSrv) CompleteJob(ctx context.Context, req *proto.CompleteJobRequest
 			return &proto.CompleteJobResponse{
 				Error: &proto.ErrorResult{
 					Code:    nil,
-					Message: ptr.To(errMsg.Error()),
+					Message: new(errMsg.Error()),
 				},
 			}, errMsg
 		}
@@ -402,7 +401,7 @@ func (s *grpcSrv) CompleteJob(ctx context.Context, req *proto.CompleteJobRequest
 		return &proto.CompleteJobResponse{
 			Error: &proto.ErrorResult{
 				Code:    nil,
-				Message: ptr.To(errMsg.Error()),
+				Message: new(errMsg.Error()),
 			},
 		}, errMsg
 	}

--- a/internal/cluster/jobmanager/server.go
+++ b/internal/cluster/jobmanager/server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
 	"github.com/pbinitiative/zenbpm/internal/safego"
 	"github.com/pbinitiative/zenbpm/internal/sql"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc"
@@ -222,7 +221,7 @@ func (s *jobServer) distributeJobs() {
 			// non blocked stream or use a pool of GRPC connections to handle jobs
 			err := nodeStream.stream.Send(&proto.SubscribeJobResponse{
 				JobType:  &job.Type,
-				ClientId: ptr.To(string(clientID)),
+				ClientId: new(string(clientID)),
 				Job: &proto.InternalJob{
 					Key:            &job.Key,
 					InstanceKey:    &job.ProcessInstanceKey,

--- a/internal/cluster/join.go
+++ b/internal/cluster/join.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/pbinitiative/zenbpm/internal/cluster/client"
 	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	rqproto "github.com/rqlite/rqlite/v10/command/proto"
 )
 
@@ -87,7 +86,7 @@ func (j *Joiner) join(targetAddr, id, addr string, suf rqproto.Suffrage) (string
 	req := &proto.JoinRequest{
 		Id:      &id,
 		Address: &addr,
-		Voter:   ptr.To(suf == rqproto.Suffrage_VOTER),
+		Voter:   new(suf == rqproto.Suffrage_VOTER),
 	}
 
 	// Attempt to join.

--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -281,7 +281,7 @@ func (node *ZenNode) GetDmnResourceDefinitions(ctx context.Context, request *pro
 		}
 		items = append(items, &proto.DmnResourceDefinition{
 			Key:                     &def.Key,
-			Version:                 ptr.To(int32(def.Version)),
+			Version:                 new(int32(def.Version)), // #nosec G115 -- definition versions are bounded well below MaxInt32
 			DmnResourceDefinitionId: &def.DmnResourceDefinitionID,
 			Definition:              []byte(def.DmnData),
 			DmnDefinitionName:       &def.DmnDefinitionName,
@@ -289,7 +289,7 @@ func (node *ZenNode) GetDmnResourceDefinitions(ctx context.Context, request *pro
 	}
 	return proto.DmnResourceDefinitionsPage{
 		Items:      items,
-		TotalCount: ptr.To(int32(totalCount)),
+		TotalCount: new(int32(totalCount)),
 	}, nil
 }
 
@@ -308,7 +308,7 @@ func (node *ZenNode) GetDmnResourceDefinition(ctx context.Context, key int64) (p
 	}
 	return proto.DmnResourceDefinition{
 		Key:                     &def.Key,
-		Version:                 ptr.To(int32(def.Version)),
+		Version:                 new(int32(def.Version)), // #nosec G115 -- definition versions are bounded well below MaxInt32
 		DmnResourceDefinitionId: &def.DmnResourceDefinitionID,
 		Definition:              []byte(def.DmnData),
 		DmnDefinitionName:       &def.DmnDefinitionName,
@@ -361,7 +361,7 @@ func (node *ZenNode) deployDmnResourceDefinitionToPartition(
 	}
 
 	resp, err := zenNodeClient.DeployDmnResourceDefinition(ctx, &proto.DeployDmnResourceDefinitionRequest{
-		Key:  ptr.To(definitionKey),
+		Key:  new(definitionKey),
 		Data: data,
 	})
 
@@ -536,7 +536,7 @@ func (node *ZenNode) deployProcessDefinitionToPartition(
 	}
 
 	resp, err := zenNodeClient.DeployProcessDefinition(ctx, &proto.DeployProcessDefinitionRequest{
-		Key:                                    ptr.To(definitionKey),
+		Key:                                    new(definitionKey),
 		Data:                                   data,
 		ResourceName:                           &resourceName,
 		RegisterProcessDefinitionSubscriptions: &registerProcessDefinitionSubscriptions,
@@ -769,14 +769,14 @@ func (node *ZenNode) GetProcessDefinitions(ctx context.Context, bpmnProcessId *s
 		}
 		resp = append(resp, &proto.ProcessDefinition{
 			Key:         &def.Key,
-			Version:     ptr.To(int32(def.Version)),
+			Version:     new(int32(def.Version)), // #nosec G115 -- definition versions are bounded well below MaxInt32
 			ProcessId:   &def.BpmnProcessID,
 			ProcessName: &def.BpmnProcessName,
 		})
 	}
 	return proto.ProcessDefinitionsPage{
 		Items:      resp,
-		TotalCount: ptr.To(int32(totalCount)),
+		TotalCount: new(int32(totalCount)),
 	}, nil
 }
 
@@ -795,7 +795,7 @@ func (node *ZenNode) GetLatestProcessDefinition(ctx context.Context, processId s
 	}
 	return proto.ProcessDefinition{
 		Key:        &def.Key,
-		Version:    ptr.To(int32(def.Version)),
+		Version:    new(int32(def.Version)), // #nosec G115 -- definition versions are bounded well below MaxInt32
 		ProcessId:  &def.BpmnProcessID,
 		Definition: []byte(def.BpmnData),
 	}, nil
@@ -816,7 +816,7 @@ func (node *ZenNode) GetProcessDefinition(ctx context.Context, key int64) (proto
 	}
 	return proto.ProcessDefinition{
 		Key:        &def.Key,
-		Version:    ptr.To(int32(def.Version)),
+		Version:    new(int32(def.Version)), // #nosec G115 -- definition versions are bounded well below MaxInt32
 		ProcessId:  &def.BpmnProcessID,
 		Definition: []byte(def.BpmnData),
 	}, nil
@@ -1305,7 +1305,7 @@ func (node *ZenNode) getJobsForPartition(
 	}
 	var reqState *int64
 	if jobState != nil {
-		reqState = ptr.To(int64(*jobState))
+		reqState = new(int64(*jobState))
 	}
 
 	var sortString string

--- a/internal/cluster/partition/partition_persistence_test.go
+++ b/internal/cluster/partition/partition_persistence_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/sql"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
 	dmnruntime "github.com/pbinitiative/zenbpm/pkg/dmn/runtime"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/storage"
 	"github.com/pbinitiative/zenbpm/pkg/storage/storagetest"
 	"github.com/stretchr/testify/assert"
@@ -92,7 +91,7 @@ func prepareTestSetup(t *testing.T, runMigrationWithRollback bool) (*ZenPartitio
 		return &zenproto.FindActiveMessageResponse{
 			Error: &zenproto.ErrorResult{
 				Code:    nil,
-				Message: ptr.To(err.Error()),
+				Message: new(err.Error()),
 			},
 		}, status.Error(codes.NotFound, err.Error())
 	}
@@ -444,9 +443,9 @@ func TestDataCleanup(t *testing.T) {
 		timer := runtime.Timer{
 			ElementId:            "timer-elem",
 			Key:                  r2 + 80,
-			ElementInstanceKey:   ptr.To(r2 + 81),
+			ElementInstanceKey:   new(r2 + 81),
 			ProcessDefinitionKey: pd.Key,
-			ProcessInstanceKey:   ptr.To(inst2.ProcessInstance().Key),
+			ProcessInstanceKey:   new(inst2.ProcessInstance().Key),
 			TimerState:           runtime.TimerStateCreated,
 			CreatedAt:            time.Now(),
 			DueAt:                time.Now().Add(1 * time.Hour),
@@ -814,8 +813,8 @@ func testMessageCorrelation(t *testing.T, db *DB, ts *servertest.TestServer) {
 			return &zenproto.FindActiveMessageResponse{
 				Key:                  &pointer.MessageSubscriptionKey,
 				ElementId:            nil,
-				ProcessDefinitionKey: ptr.To(int64(1)),
-				ProcessInstanceKey:   ptr.To(int64(1)),
+				ProcessDefinitionKey: new(int64(1)),
+				ProcessInstanceKey:   new(int64(1)),
 				Name:                 &pointer.Name,
 				State:                &pointer.State,
 				CorrelationKey:       &pointer.CorrelationKey,

--- a/internal/cluster/server/server_test.go
+++ b/internal/cluster/server/server_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
 	"github.com/pbinitiative/zenbpm/internal/cluster/state"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -46,8 +45,8 @@ func TestServer(t *testing.T) {
 	zsc := proto.NewZenServiceClient(grpcClient)
 
 	_, err = zsc.Notify(ctx, &proto.NotifyRequest{
-		Id:      ptr.To("123"),
-		Address: ptr.To("local-1.cluster"),
+		Id:      new("123"),
+		Address: new("local-1.cluster"),
 	})
 	if err != nil {
 		t.Fatalf("failed to notify server: %s", err)
@@ -57,9 +56,9 @@ func TestServer(t *testing.T) {
 	}
 
 	_, err = zsc.Join(ctx, &proto.JoinRequest{
-		Id:      ptr.To("123"),
-		Address: ptr.To("local-1.cluster"),
-		Voter:   ptr.To(true),
+		Id:      new("123"),
+		Address: new("local-1.cluster"),
+		Voter:   new(true),
 	})
 	if err != nil {
 		t.Fatalf("failed to notify server: %s", err)

--- a/internal/cluster/server_test.go
+++ b/internal/cluster/server_test.go
@@ -16,7 +16,6 @@ import (
 	zenproto "github.com/pbinitiative/zenbpm/internal/cluster/proto"
 	"github.com/pbinitiative/zenbpm/internal/cluster/server"
 	"github.com/pbinitiative/zenbpm/internal/cluster/state"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
@@ -70,8 +69,8 @@ func TestFkdUpClient(t *testing.T) {
 			Type: proto.Command_TYPE_NODE_PARTITION_CHANGE.Enum(),
 			Request: &proto.Command_NodePartitionChange{
 				NodePartitionChange: &proto.NodePartitionChange{
-					NodeId:      ptr.To("123"),
-					PartitionId: ptr.To(uint32(1)),
+					NodeId:      new("123"),
+					PartitionId: new(uint32(1)),
 					State:       proto.NodePartitionState_NODE_PARTITION_STATE_ERROR.Enum(),
 					Role:        proto.Role_ROLE_TYPE_FOLLOWER.Enum(),
 				},

--- a/internal/cluster/store/store.go
+++ b/internal/cluster/store/store.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/rqlitecompat/random"
 	"github.com/pbinitiative/zenbpm/internal/rqlitecompat/rsync"
 	"github.com/pbinitiative/zenbpm/internal/safego"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/rqlite/rqlite/v10/tcp"
 	pb "google.golang.org/protobuf/proto"
 )
@@ -318,8 +317,8 @@ func (s *Store) addNewNode(node raft.Server) error {
 		return nil
 	}
 	nodeChange := &proto.NodeChange{
-		NodeId: ptr.To(string(node.ID)),
-		Addr:   ptr.To(string(node.Address)),
+		NodeId: new(string(node.ID)),
+		Addr:   new(string(node.Address)),
 		State:  proto.NodeState_NODE_STATE_STARTED.Enum(),
 		Role:   proto.Role_ROLE_TYPE_FOLLOWER.Enum(),
 	}
@@ -342,7 +341,7 @@ func (s *Store) shutdownNode(nodeId raft.ServerID) error {
 		return nil
 	}
 	nodeChange := &proto.NodeChange{
-		NodeId: ptr.To(string(nodeId)),
+		NodeId: new(string(nodeId)),
 		State:  proto.NodeState_NODE_STATE_SHUTDOWN.Enum(),
 		Role:   proto.Role_ROLE_TYPE_FOLLOWER.Enum(),
 	}
@@ -360,7 +359,7 @@ func (s *Store) resumeNode(nodeId raft.ServerID) error {
 		return nil
 	}
 	nodeChange := &proto.NodeChange{
-		NodeId: ptr.To(string(nodeId)),
+		NodeId: new(string(nodeId)),
 		State:  proto.NodeState_NODE_STATE_STARTED.Enum(),
 		Role:   proto.Role_ROLE_TYPE_FOLLOWER.Enum(),
 	}
@@ -397,8 +396,8 @@ func (s *Store) selfLeaderChange(leader bool) error {
 
 	s.logger.Info("this node is now leader")
 	err := s.WriteNodeChange(&proto.NodeChange{
-		NodeId:   ptr.To(s.raftID),
-		Addr:     ptr.To(s.Addr()),
+		NodeId:   new(s.raftID),
+		Addr:     new(s.Addr()),
 		State:    proto.NodeState_NODE_STATE_STARTED.Enum(),
 		Role:     proto.Role_ROLE_TYPE_LEADER.Enum(),
 		Suffrage: proto.RaftSuffrage_RAFT_SUFFRAGE_VOTER.Enum(),

--- a/internal/cluster/store/store_multi_test.go
+++ b/internal/cluster/store/store_multi_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/cluster/state"
 	"github.com/pbinitiative/zenbpm/internal/config"
 	"github.com/pbinitiative/zenbpm/internal/rqlitecompat/random"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 )
 
 func TestMultiNodeVerifyLeader(t *testing.T) {
@@ -57,9 +56,9 @@ func TestMultiNodeVerifyLeader(t *testing.T) {
 	}
 
 	if err := s1.Join(&zproto.JoinRequest{
-		Id:      ptr.To(s2.ID()),
-		Address: ptr.To(s2.Addr()),
-		Voter:   ptr.To(true),
+		Id:      new(s2.ID()),
+		Address: new(s2.Addr()),
+		Voter:   new(true),
 	}); err != nil {
 		t.Fatalf("failed to join single-node store s2: %s", err.Error())
 	}
@@ -129,9 +128,9 @@ func TestMultiNodeSimple(t *testing.T) {
 	}
 
 	if err := s1.Join(&zproto.JoinRequest{
-		Id:      ptr.To(s2.ID()),
-		Address: ptr.To(s2.Addr()),
-		Voter:   ptr.To(true),
+		Id:      new(s2.ID()),
+		Address: new(s2.Addr()),
+		Voter:   new(true),
 	}); err != nil {
 		t.Fatalf("failed to join single-node store: %s", err.Error())
 	}
@@ -141,8 +140,8 @@ func TestMultiNodeSimple(t *testing.T) {
 
 	// Write some data.
 	err := s1.WritePartitionChange(&proto.NodePartitionChange{
-		NodeId:      ptr.To(s2.ID()),
-		PartitionId: ptr.To(testPartitionId),
+		NodeId:      new(s2.ID()),
+		PartitionId: new(testPartitionId),
 		State:       proto.NodePartitionState_NODE_PARTITION_STATE_INITIALIZED.Enum(),
 		Role:        proto.Role_ROLE_TYPE_LEADER.Enum(),
 	})
@@ -172,8 +171,8 @@ func TestMultiNodeSimple(t *testing.T) {
 
 	// Write some more changes to state.
 	err = s1.WritePartitionChange(&proto.NodePartitionChange{
-		NodeId:      ptr.To(s2.ID()),
-		PartitionId: ptr.To(testPartitionId),
+		NodeId:      new(s2.ID()),
+		PartitionId: new(testPartitionId),
 		State:       proto.NodePartitionState_NODE_PARTITION_STATE_LEAVING.Enum(),
 		Role:        proto.Role_ROLE_TYPE_LEADER.Enum(),
 	})
@@ -182,8 +181,8 @@ func TestMultiNodeSimple(t *testing.T) {
 	}
 
 	err = s1.WritePartitionChange(&proto.NodePartitionChange{
-		NodeId:      ptr.To(s1.ID()),
-		PartitionId: ptr.To(testPartitionId),
+		NodeId:      new(s1.ID()),
+		PartitionId: new(testPartitionId),
 		State:       proto.NodePartitionState_NODE_PARTITION_STATE_INITIALIZED.Enum(),
 		Role:        proto.Role_ROLE_TYPE_LEADER.Enum(),
 	})
@@ -253,9 +252,9 @@ func TestMultiNodePeerObservations(t *testing.T) {
 	}
 
 	if err := s1.Join(&zproto.JoinRequest{
-		Id:      ptr.To(s2.ID()),
-		Address: ptr.To(s2.Addr()),
-		Voter:   ptr.To(true),
+		Id:      new(s2.ID()),
+		Address: new(s2.Addr()),
+		Voter:   new(true),
 	}); err != nil {
 		t.Fatalf("failed to join single-node store: %s", err.Error())
 	}
@@ -310,9 +309,9 @@ func TestMultiNodePeerObservations(t *testing.T) {
 	}
 
 	if err := s1.Join(&zproto.JoinRequest{
-		Id:      ptr.To(s3.ID()),
-		Address: ptr.To(s3.Addr()),
-		Voter:   ptr.To(true),
+		Id:      new(s3.ID()),
+		Address: new(s3.Addr()),
+		Voter:   new(true),
 	}); err != nil {
 		t.Fatalf("failed to join single-node store: %s", err.Error())
 	}

--- a/internal/cluster/zenerr/errors.go
+++ b/internal/cluster/zenerr/errors.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
 	"github.com/pbinitiative/zenbpm/internal/rest/public"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 )
 
 var (
@@ -92,8 +91,8 @@ func Join(new error, original *ZenError) *ZenError {
 
 func (zenError *ZenError) ToProtoError() *proto.ErrorResult {
 	return &proto.ErrorResult{
-		Code:    (*uint32)(ptr.To(zenError.Code)),
-		Message: ptr.To(zenError.err.Error()),
+		Code:    (*uint32)(new(zenError.Code)),
+		Message: new(zenError.err.Error()),
 	}
 }
 

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/cluster/jobmanager"
 	"github.com/pbinitiative/zenbpm/internal/grpc/interceptor/recovery"
 	"github.com/pbinitiative/zenbpm/internal/safego"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient/proto"
 	"go.opentelemetry.io/otel"
 
@@ -124,7 +123,7 @@ func (s *Server) recvClientRequests(stream grpc.BidiStreamingServer[proto.JobStr
 				_ = sendJobStreamResponse(stream, sendMu, &proto.JobStreamResponse{
 					Error: &proto.ErrorResult{
 						Code:    nil,
-						Message: ptr.To(fmt.Sprintf("Failed to unmarshal variables: %s", err)),
+						Message: new(fmt.Sprintf("Failed to unmarshal variables: %s", err)),
 					},
 					Job: &proto.WaitingJob{
 						Key: req.Complete.Key,
@@ -137,7 +136,7 @@ func (s *Server) recvClientRequests(stream grpc.BidiStreamingServer[proto.JobStr
 				_ = sendJobStreamResponse(stream, sendMu, &proto.JobStreamResponse{
 					Error: &proto.ErrorResult{
 						Code:    nil,
-						Message: ptr.To(fmt.Sprintf("Failed to complete job: %s", err)),
+						Message: new(fmt.Sprintf("Failed to complete job: %s", err)),
 					},
 					Job: &proto.WaitingJob{
 						Key: req.Complete.Key,
@@ -151,7 +150,7 @@ func (s *Server) recvClientRequests(stream grpc.BidiStreamingServer[proto.JobStr
 				_ = sendJobStreamResponse(stream, sendMu, &proto.JobStreamResponse{
 					Error: &proto.ErrorResult{
 						Code:    nil,
-						Message: ptr.To(fmt.Sprintf("Failed to unmarshal variables: %s", err)),
+						Message: new(fmt.Sprintf("Failed to unmarshal variables: %s", err)),
 					},
 					Job: &proto.WaitingJob{
 						Key: req.Fail.Key,
@@ -164,7 +163,7 @@ func (s *Server) recvClientRequests(stream grpc.BidiStreamingServer[proto.JobStr
 				_ = sendJobStreamResponse(stream, sendMu, &proto.JobStreamResponse{
 					Error: &proto.ErrorResult{
 						Code:    nil,
-						Message: ptr.To(fmt.Sprintf("Failed to fail job: %s", err)),
+						Message: new(fmt.Sprintf("Failed to fail job: %s", err)),
 					},
 					Job: &proto.WaitingJob{
 						Key: req.Fail.Key,
@@ -206,7 +205,7 @@ func (s *Server) sendClientJobs(stream grpc.BidiStreamingServer[proto.JobStreamR
 					Key:            &job.Key,
 					InstanceKey:    &job.InstanceKey,
 					InputVariables: job.InputVariables,
-					Type:           ptr.To(string(job.Type)),
+					Type:           new(string(job.Type)),
 					ElementId:      &job.ElementID,
 					CreatedAt:      &job.CreatedAt,
 				},

--- a/internal/rest/server.go
+++ b/internal/rest/server.go
@@ -184,7 +184,7 @@ func (s *Server) GetDmnResourceDefinitions(ctx context.Context, request public.G
 			), nil
 		}
 	} else {
-		request.Params.SortOrder = ptr.To(public.GetDmnResourceDefinitionsParamsSortOrderDesc)
+		request.Params.SortOrder = new(public.GetDmnResourceDefinitionsParamsSortOrderDesc)
 	}
 	sortByOrder := sql.SortString(request.Params.SortOrder, sortByDbColumn)
 
@@ -254,7 +254,7 @@ func (s *Server) GetDmnResourceDefinition(ctx context.Context, request public.Ge
 			Key:                     definition.GetKey(),
 			Version:                 int(definition.GetVersion()),
 		},
-		DmnData: ptr.To(string(definition.GetDefinition())),
+		DmnData: new(string(definition.GetDefinition())),
 	}, nil
 }
 
@@ -403,10 +403,10 @@ func (s *Server) GetDecisionInstances(ctx context.Context, request public.GetDec
 
 	var evaluatedFrom, evaluatedTo *int64
 	if request.Params.EvaluatedFrom != nil {
-		evaluatedFrom = ptr.To(request.Params.EvaluatedFrom.UnixMilli())
+		evaluatedFrom = new(request.Params.EvaluatedFrom.UnixMilli())
 	}
 	if request.Params.EvaluatedTo != nil {
-		evaluatedTo = ptr.To(request.Params.EvaluatedTo.UnixMilli())
+		evaluatedTo = new(request.Params.EvaluatedTo.UnixMilli())
 	}
 	var sortByColumn *string
 	if request.Params.SortBy != nil {
@@ -429,7 +429,7 @@ func (s *Server) GetDecisionInstances(ctx context.Context, request public.GetDec
 			), nil
 		}
 	} else {
-		request.Params.SortOrder = ptr.To(public.GetDecisionInstancesParamsSortOrderDesc)
+		request.Params.SortOrder = new(public.GetDecisionInstancesParamsSortOrderDesc)
 	}
 	sortByOrder := sql.SortString(request.Params.SortOrder, sortByColumn)
 
@@ -473,7 +473,7 @@ func (s *Server) GetDecisionInstances(ctx context.Context, request public.GetDec
 		decisionInstancesPage.Partitions[i] = public.PartitionDecisionInstances{
 			Items:     make([]public.DecisionInstanceSummary, len(partitionInstances.GetDecisionInstances())),
 			Partition: int(partitionInstances.GetPartitionId()),
-			Count:     ptr.To(len(partitionInstances.GetDecisionInstances())),
+			Count:     new(len(partitionInstances.GetDecisionInstances())),
 		}
 		count += len(partitionInstances.GetDecisionInstances())
 		totalCount += int(partitionInstances.GetTotalCount())
@@ -694,7 +694,7 @@ func (s *Server) GetProcessDefinitions(ctx context.Context, request public.GetPr
 			Key:             p.GetKey(),
 			Version:         int(p.GetVersion()),
 			BpmnProcessId:   p.GetProcessId(),
-			BpmnProcessName: ptr.To(p.GetProcessName()),
+			BpmnProcessName: new(p.GetProcessName()),
 		}
 		items[i] = processDefinitionSimple
 	}
@@ -734,7 +734,7 @@ func (s *Server) GetProcessDefinition(ctx context.Context, request public.GetPro
 			Key:           definition.GetKey(),
 			Version:       int(definition.GetVersion()),
 		},
-		BpmnData: ptr.To(string(definition.GetDefinition())),
+		BpmnData: new(string(definition.GetDefinition())),
 	}, nil
 }
 
@@ -914,7 +914,7 @@ func (s *Server) GetProcessDefinitionStatistics(ctx context.Context, request pub
 				Key:           stat.GetKey(),
 				Version:       int(stat.GetVersion()),
 				BpmnProcessId: stat.GetBpmnProcessId(),
-				Name:          ptr.To(stat.GetBpmnProcessName()),
+				Name:          new(stat.GetBpmnProcessName()),
 				InstanceCounts: public.InstanceCounts{
 					Total:        int(stat.InstanceCounts.GetTotal()),
 					Active:       int(stat.InstanceCounts.GetActive()),
@@ -1064,13 +1064,13 @@ func (s *Server) GetProcessInstances(ctx context.Context, request public.GetProc
 		// output values we return (ActivityStateActive, ActivityStateCompleted, ...). Unify the input/output values.
 		switch *request.Params.State {
 		case public.GetProcessInstancesParamsStateActive:
-			state = ptr.To(int64(runtime.ActivityStateActive))
+			state = new(int64(runtime.ActivityStateActive))
 		case public.GetProcessInstancesParamsStateCompleted:
-			state = ptr.To(int64(runtime.ActivityStateCompleted))
+			state = new(int64(runtime.ActivityStateCompleted))
 		case public.GetProcessInstancesParamsStateTerminated:
-			state = ptr.To(int64(runtime.ActivityStateTerminated))
+			state = new(int64(runtime.ActivityStateTerminated))
 		case public.GetProcessInstancesParamsStateFailed:
-			state = ptr.To(int64(runtime.ActivityStateFailed))
+			state = new(int64(runtime.ActivityStateFailed))
 		default:
 			supportedStates := [...]public.GetProcessInstancesParamsState{public.GetProcessInstancesParamsStateActive, public.GetProcessInstancesParamsStateCompleted, public.GetProcessInstancesParamsStateTerminated, public.GetProcessInstancesParamsStateFailed}
 			return public.GetProcessInstances400JSONResponse(
@@ -1079,10 +1079,10 @@ func (s *Server) GetProcessInstances(ctx context.Context, request public.GetProc
 		}
 	}
 	if request.Params.CreatedFrom != nil {
-		createdFrom = ptr.To(request.Params.CreatedFrom.UnixMilli())
+		createdFrom = new(request.Params.CreatedFrom.UnixMilli())
 	}
 	if request.Params.CreatedTo != nil {
-		createdTo = ptr.To(request.Params.CreatedTo.UnixMilli())
+		createdTo = new(request.Params.CreatedTo.UnixMilli())
 	}
 	var sortByDbColumn *string
 	if request.Params.SortBy != nil {
@@ -1105,7 +1105,7 @@ func (s *Server) GetProcessInstances(ctx context.Context, request public.GetProc
 			), nil
 		}
 	} else {
-		request.Params.SortOrder = ptr.To(public.GetProcessInstancesParamsSortOrderDesc)
+		request.Params.SortOrder = new(public.GetProcessInstancesParamsSortOrderDesc)
 	}
 	sortByOrder := sql.SortString(request.Params.SortOrder, sortByDbColumn)
 
@@ -1185,7 +1185,7 @@ func (s *Server) GetProcessInstances(ctx context.Context, request public.GetProc
 				IncidentCount:        new(int(instance.GetIncidentCount())),
 			}
 			if instance.GetParentInstanceKey() != 0 {
-				processInstancesPage.Partitions[i].Items[k].ParentProcessInstanceKey = ptr.To(instance.GetParentInstanceKey())
+				processInstancesPage.Partitions[i].Items[k].ParentProcessInstanceKey = new(instance.GetParentInstanceKey())
 			}
 		}
 	}
@@ -1228,7 +1228,7 @@ func (s *Server) GetProcessInstance(ctx context.Context, request public.GetProce
 
 	var parentProcessInstanceKey *int64
 	if pKey := instance.GetParentInstanceKey(); pKey != 0 {
-		parentProcessInstanceKey = ptr.To(pKey)
+		parentProcessInstanceKey = new(pKey)
 	}
 
 	processInstanceState, errInstanceState := getRestProcessInstanceState(runtime.ActivityState(instance.GetState()))
@@ -1270,13 +1270,13 @@ func (s *Server) GetChildProcessInstances(ctx context.Context, request public.Ge
 		// output values we return (ActivityStateActive, ActivityStateCompleted, ...). Unify the input/output values.
 		switch *request.Params.State {
 		case public.GetChildProcessInstancesParamsStateActive:
-			state = ptr.To(int64(runtime.ActivityStateActive))
+			state = new(int64(runtime.ActivityStateActive))
 		case public.GetChildProcessInstancesParamsStateCompleted:
-			state = ptr.To(int64(runtime.ActivityStateCompleted))
+			state = new(int64(runtime.ActivityStateCompleted))
 		case public.GetChildProcessInstancesParamsStateTerminated:
-			state = ptr.To(int64(runtime.ActivityStateTerminated))
+			state = new(int64(runtime.ActivityStateTerminated))
 		case public.GetChildProcessInstancesParamsStateFailed:
-			state = ptr.To(int64(runtime.ActivityStateFailed))
+			state = new(int64(runtime.ActivityStateFailed))
 		default:
 			return public.GetChildProcessInstances400JSONResponse{
 				Code:    "TODO",
@@ -1307,7 +1307,7 @@ func (s *Server) GetChildProcessInstances(ctx context.Context, request public.Ge
 			}, nil
 		}
 	} else {
-		request.Params.SortOrder = ptr.To(public.GetChildProcessInstancesParamsSortOrderDesc)
+		request.Params.SortOrder = new(public.GetChildProcessInstancesParamsSortOrderDesc)
 	}
 	sortByOrder := sql.SortString(request.Params.SortOrder, sortByDbColumn)
 
@@ -1380,7 +1380,7 @@ func (s *Server) GetChildProcessInstances(ctx context.Context, request public.Ge
 				IncidentCount:        new(int(instance.GetIncidentCount())),
 			}
 			if instance.GetParentInstanceKey() != 0 {
-				processInstancesPage.Partitions[i].Items[k].ParentProcessInstanceKey = ptr.To(instance.GetParentInstanceKey())
+				processInstancesPage.Partitions[i].Items[k].ParentProcessInstanceKey = new(instance.GetParentInstanceKey())
 			}
 		}
 	}
@@ -1809,11 +1809,11 @@ func (s *Server) GetJobs(ctx context.Context, request public.GetJobsRequestObjec
 	if request.Params.State != nil {
 		switch *request.Params.State {
 		case public.JobStateActive:
-			reqState = ptr.To(runtime.ActivityStateActive)
+			reqState = new(runtime.ActivityStateActive)
 		case public.JobStateCompleted:
-			reqState = ptr.To(runtime.ActivityStateCompleted)
+			reqState = new(runtime.ActivityStateCompleted)
 		case public.JobStateTerminated:
-			reqState = ptr.To(runtime.ActivityStateActive)
+			reqState = new(runtime.ActivityStateActive)
 		default:
 			supportedStates := [...]public.JobState{public.JobStateActive, public.JobStateCompleted, public.JobStateTerminated}
 			return public.GetJobs400JSONResponse(
@@ -2126,7 +2126,7 @@ func (s *Server) GetIncidents(ctx context.Context, request public.GetIncidentsRe
 			CreatedAt:          time.UnixMilli(incident.GetCreatedAt()),
 			ResolvedAt: func() *time.Time {
 				if incident.ResolvedAt != nil {
-					return ptr.To(time.UnixMilli(incident.GetResolvedAt()))
+					return new(time.UnixMilli(incident.GetResolvedAt()))
 				}
 				return nil
 			}(),
@@ -2314,7 +2314,7 @@ func getEvaluatedDecisionsResponse(evaluatedDecisions []dmn.EvaluatedDecisionRes
 		responseEvaluatedDecisions = append(responseEvaluatedDecisions, public.EvaluatedDecision{
 			DecisionId:   &evaluatedDecision.DecisionId,
 			DecisionName: &evaluatedDecision.DecisionName,
-			DecisionType: ptr.To(public.EvaluatedDecisionDecisionType(evaluatedDecision.DecisionType)),
+			DecisionType: new(public.EvaluatedDecisionDecisionType(evaluatedDecision.DecisionType)),
 			Inputs:       &responseEvaluatedInputs,
 			MatchedRules: &responseMatchedRules,
 			Outputs:      nil, // TODO What should be here? Total matchedRules outputs?

--- a/internal/sql/helpers.go
+++ b/internal/sql/helpers.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 
 	"github.com/pbinitiative/zenbpm/internal/rest/public"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 )
 
 func ToNullString[S ~string](p *S) sql.NullString {
@@ -57,5 +56,5 @@ func SortString[O ~string, B ~string](sortOrder *O, sortBy *B) *Sort {
 		return nil
 	}
 
-	return ptr.To(Sort(string(*sortBy) + "_" + order))
+	return new(Sort(string(*sortBy) + "_" + order))
 }

--- a/internal/sql/helpers_test.go
+++ b/internal/sql/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,12 +14,12 @@ func TestToNullString(t *testing.T) {
 		assert.Equal(t, "", got.String)
 	})
 	t.Run("non-nil pointer yields valid", func(t *testing.T) {
-		got := ToNullString(ptr.To("hello"))
+		got := ToNullString(new("hello"))
 		assert.True(t, got.Valid)
 		assert.Equal(t, "hello", got.String)
 	})
 	t.Run("empty string is still valid", func(t *testing.T) {
-		got := ToNullString(ptr.To(""))
+		got := ToNullString(new(""))
 		assert.True(t, got.Valid)
 		assert.Equal(t, "", got.String)
 	})
@@ -33,12 +32,12 @@ func TestToNullInt64(t *testing.T) {
 		assert.Equal(t, int64(0), got.Int64)
 	})
 	t.Run("non-nil pointer yields valid", func(t *testing.T) {
-		got := ToNullInt64(ptr.To(int64(42)))
+		got := ToNullInt64(new(int64(42)))
 		assert.True(t, got.Valid)
 		assert.Equal(t, int64(42), got.Int64)
 	})
 	t.Run("zero value is still valid when pointer is non-nil", func(t *testing.T) {
-		got := ToNullInt64(ptr.To(int64(0)))
+		got := ToNullInt64(new(int64(0)))
 		assert.True(t, got.Valid)
 		assert.Equal(t, int64(0), got.Int64)
 	})

--- a/pkg/bpmn/incident_api.go
+++ b/pkg/bpmn/incident_api.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/model/bpmn20"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
 	otelPkg "github.com/pbinitiative/zenbpm/pkg/otel"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 )
@@ -128,7 +127,7 @@ func (engine *Engine) ResolveIncident(ctx context.Context, key int64) (retErr er
 		if err := engine.retryEventSubprocessSubscriptionIncident(ctx, &batch, instance, incident); err != nil {
 			return fmt.Errorf("failed to recreate event subprocess subscription for incident %d: %w", key, err)
 		}
-		incident.ResolvedAt = ptr.To(time.Now())
+		incident.ResolvedAt = new(time.Now())
 		if err := batch.SaveIncident(ctx, incident); err != nil {
 			return fmt.Errorf("failed to save resolved incident %d: %w", incident.Key, err)
 		}
@@ -150,7 +149,7 @@ func (engine *Engine) ResolveIncident(ctx context.Context, key int64) (retErr er
 		return newEngineErrorf("failed to find jobs for token key: %d", incident.Token.Key)
 	}
 
-	incident.ResolvedAt = ptr.To(time.Now())
+	incident.ResolvedAt = new(time.Now())
 	err = batch.SaveIncident(ctx, incident)
 	if err != nil {
 		return err
@@ -214,7 +213,7 @@ func (engine *Engine) resolveIncidentsForToken(ctx context.Context, batch *Engin
 			continue
 		}
 
-		incident.ResolvedAt = ptr.To(time.Now())
+		incident.ResolvedAt = new(time.Now())
 		err = batch.SaveIncident(ctx, incident)
 		if err != nil {
 			return fmt.Errorf("failed to save changes to incident %d: %w", incident.Key, err)

--- a/pkg/bpmn/jobs.go
+++ b/pkg/bpmn/jobs.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -51,7 +50,7 @@ func (engine *Engine) createInternalTask(
 		if !ok {
 			assigneeStr = fmt.Sprintf("%v", assigneeResult)
 		}
-		job.Assignee = ptr.To(assigneeStr)
+		job.Assignee = new(assigneeStr)
 	}
 
 	err := batch.SaveJob(ctx, job)

--- a/pkg/ptr/ptr.go
+++ b/pkg/ptr/ptr.go
@@ -1,11 +1,5 @@
 package ptr
 
-// Deprecated: Use method new() instead, its new function added in go 1.26
-// To returns a pointer to the given value.
-func To[T any](v T) *T {
-	return &v
-}
-
 // Deref dereferences ptr and returns the value it points to if no nil, or else
 // returns def.
 func Deref[T any](ptr *T, def T) T {

--- a/test/acceptance_tests/helpers_test.go
+++ b/test/acceptance_tests/helpers_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -325,8 +324,8 @@ func completeJob(t testing.TB, jobKey int64, variables map[string]any) {
 func historyElementIds(t testing.TB, processInstanceKey int64) []string {
 	t.Helper()
 	resp, err := app.restClient.GetHistoryWithResponse(t.Context(), processInstanceKey, &zenclient.GetHistoryParams{
-		Page: ptr.To(int32(1)),
-		Size: ptr.To(int32(-1)),
+		Page: new(int32(1)),
+		Size: new(int32(-1)),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.JSON200)

--- a/test/e2e/decision_evaluation_test.go
+++ b/test/e2e/decision_evaluation_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,7 +14,7 @@ func TestRestApiEvaluateDecision(t *testing.T) {
 	_, err := deployDmnResourceDefinition(t, "bulk-evaluation-test/can-autoliquidate-rule.dmn")
 	assert.NoError(t, err)
 	definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
-		DmnResourceDefinitionId: ptr.To("example_canAutoLiquidate"),
+		DmnResourceDefinitionId: new("example_canAutoLiquidate"),
 	})
 	assert.NoError(t, err)
 	if len(definitions) > 0 {

--- a/test/e2e/decision_instance_test.go
+++ b/test/e2e/decision_instance_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/pbinitiative/zenbpm/pkg/zenflake"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +15,7 @@ func TestDecisionInstance(t *testing.T) {
 	_, err := deployDmnResourceDefinition(t, "bulk-evaluation-test/can-autoliquidate-rule.dmn")
 	assert.NoError(t, err)
 	definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
-		DmnResourceDefinitionId: ptr.To("example_canAutoLiquidate"),
+		DmnResourceDefinitionId: new("example_canAutoLiquidate"),
 	})
 	assert.NoError(t, err)
 	if len(definitions) > 0 {
@@ -79,11 +78,11 @@ func TestDecisionInstances(t *testing.T) {
 	t.Run("deploy dmn resource definition", func(t *testing.T) {
 		_, err := deployDmnResourceDefinition(t, "bulk-evaluation-test/can-autoliquidate-rule.dmn")
 		assert.NoError(t, err)
-		resDefId1Key, err = deployDmnResourceDefinitionWithNewNameAndId(t, "bulk-evaluation-test/can-autoliquidate-rule.dmn", ptr.To("resDefName1"), ptr.To("resDefId1"))
+		resDefId1Key, err = deployDmnResourceDefinitionWithNewNameAndId(t, "bulk-evaluation-test/can-autoliquidate-rule.dmn", new("resDefName1"), new("resDefId1"))
 		assert.NoError(t, err)
-		redDefId2Key, err = deployDmnResourceDefinitionWithNewNameAndId(t, "bulk-evaluation-test/can-autoliquidate-rule.dmn", ptr.To("resDefName2"), ptr.To("resDefId2"))
+		redDefId2Key, err = deployDmnResourceDefinitionWithNewNameAndId(t, "bulk-evaluation-test/can-autoliquidate-rule.dmn", new("resDefName2"), new("resDefId2"))
 		assert.NoError(t, err)
-		_, err = deployDmnResourceDefinitionWithNewNameAndId(t, "bulk-evaluation-test/can-autoliquidate-rule.dmn", ptr.To("resDefName3"), ptr.To("resDefId3"))
+		_, err = deployDmnResourceDefinitionWithNewNameAndId(t, "bulk-evaluation-test/can-autoliquidate-rule.dmn", new("resDefName3"), new("resDefId3"))
 		assert.NoError(t, err)
 	})
 
@@ -91,7 +90,7 @@ func TestDecisionInstances(t *testing.T) {
 		result, err := evaluateDecision(
 			t,
 			zenclient.EvaluateDecisionJSONBodyBindingTypeLatest,
-			ptr.To("resDefId1"),
+			new("resDefId1"),
 			"resDefId1Rule",
 			nil,
 			map[string]any{
@@ -105,7 +104,7 @@ func TestDecisionInstances(t *testing.T) {
 
 		var decisionInstanceRes *zenclient.GetDecisionInstancesResponse
 		decisionInstanceRes, err = app.restClient.GetDecisionInstancesWithResponse(t.Context(), &zenclient.GetDecisionInstancesParams{
-			DmnResourceDefinitionKey: ptr.To(resDefId1Key),
+			DmnResourceDefinitionKey: new(resDefId1Key),
 		})
 		assert.NoError(t, err)
 		decisionInstancePartitionPage := decisionInstanceRes.JSON200
@@ -121,7 +120,7 @@ func TestDecisionInstances(t *testing.T) {
 		result, err := evaluateDecision(
 			t,
 			zenclient.EvaluateDecisionJSONBodyBindingTypeLatest,
-			ptr.To("resDefId2"),
+			new("resDefId2"),
 			"resDefId2Rule",
 			nil,
 			map[string]any{
@@ -132,7 +131,7 @@ func TestDecisionInstances(t *testing.T) {
 		result, err = evaluateDecision(
 			t,
 			zenclient.EvaluateDecisionJSONBodyBindingTypeLatest,
-			ptr.To("resDefId2"),
+			new("resDefId2"),
 			"resDefId2Rule",
 			nil,
 			map[string]any{
@@ -148,11 +147,11 @@ func TestDecisionInstances(t *testing.T) {
 		future := time.Now().AddDate(0, 0, 1)
 		var decisionInstanceRes *zenclient.GetDecisionInstancesResponse
 		decisionInstanceRes, err = app.restClient.GetDecisionInstancesWithResponse(t.Context(), &zenclient.GetDecisionInstancesParams{
-			DmnResourceDefinitionId: ptr.To("resDefId2"),
-			EvaluatedFrom:           ptr.To(past),
-			EvaluatedTo:             ptr.To(future),
-			SortBy:                  ptr.To(zenclient.GetDecisionInstancesParamsSortByEvaluatedAt),
-			SortOrder:               ptr.To(zenclient.GetDecisionInstancesParamsSortOrderDesc),
+			DmnResourceDefinitionId: new("resDefId2"),
+			EvaluatedFrom:           new(past),
+			EvaluatedTo:             new(future),
+			SortBy:                  new(zenclient.GetDecisionInstancesParamsSortByEvaluatedAt),
+			SortOrder:               new(zenclient.GetDecisionInstancesParamsSortOrderDesc),
 		})
 		assert.NoError(t, err)
 		decisionInstancePartitionPage := decisionInstanceRes.JSON200
@@ -204,7 +203,7 @@ func TestDecisionInstanceLinkedToProcessInstance(t *testing.T) {
 func TestGetDecisionInstancesErrorResponses(t *testing.T) {
 	t.Run("invalid sortBy returns 400 BAD_REQUEST", func(t *testing.T) {
 		resp, err := app.restClient.GetDecisionInstancesWithResponse(t.Context(), &zenclient.GetDecisionInstancesParams{
-			SortBy: (*zenclient.GetDecisionInstancesParamsSortBy)(ptr.To("invalid-sort-by")),
+			SortBy: (*zenclient.GetDecisionInstancesParamsSortBy)(new("invalid-sort-by")),
 		})
 		assert.NoError(t, err)
 		assert.Nil(t, resp.JSON200)
@@ -215,7 +214,7 @@ func TestGetDecisionInstancesErrorResponses(t *testing.T) {
 
 	t.Run("invalid sortOrder returns 400 BAD_REQUEST", func(t *testing.T) {
 		resp, err := app.restClient.GetDecisionInstancesWithResponse(t.Context(), &zenclient.GetDecisionInstancesParams{
-			SortOrder: (*zenclient.GetDecisionInstancesParamsSortOrder)(ptr.To("invalid-sort-order")),
+			SortOrder: (*zenclient.GetDecisionInstancesParamsSortOrder)(new("invalid-sort-order")),
 		})
 		assert.NoError(t, err)
 		assert.Nil(t, resp.JSON200)

--- a/test/e2e/event_subscriptions_test.go
+++ b/test/e2e/event_subscriptions_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,7 +21,7 @@ func TestGetProcessInstanceMessageSubscriptions(t *testing.T) {
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		resp, err := app.restClient.GetProcessInstanceMessageSubscriptionsWithResponse(t.Context(), instance.Key, &zenclient.GetProcessInstanceMessageSubscriptionsParams{
-			Size: ptr.To(int32(100)),
+			Size: new(int32(100)),
 		})
 		assert.NoError(collect, err)
 		assert.NotNil(collect, resp.JSON200)
@@ -80,7 +79,7 @@ func TestMessageSubscriptionsPagination(t *testing.T) {
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				resp, err := app.restClient.GetProcessInstanceMessageSubscriptionsWithResponse(
 					t.Context(), instanceKey,
-					&zenclient.GetProcessInstanceMessageSubscriptionsParams{Size: ptr.To(int32(100))})
+					&zenclient.GetProcessInstanceMessageSubscriptionsParams{Size: new(int32(100))})
 				assert.NoError(collect, err)
 				assert.NotNil(collect, resp.JSON200)
 				assert.Equal(collect, 3, resp.JSON200.TotalCount)
@@ -92,8 +91,8 @@ func TestMessageSubscriptionsPagination(t *testing.T) {
 			resp, err := app.restClient.GetProcessInstanceMessageSubscriptionsWithResponse(
 				t.Context(), instanceKey,
 				&zenclient.GetProcessInstanceMessageSubscriptionsParams{
-					Page: ptr.To(int32(page)),
-					Size: ptr.To(int32(size)),
+					Page: new(int32(page)),
+					Size: new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.NotNil(t, resp.JSON200)
@@ -126,7 +125,7 @@ func TestMessageSubscriptionsStateFilter(t *testing.T) {
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		resp, err := app.restClient.GetProcessInstanceMessageSubscriptionsWithResponse(
 			t.Context(), instance.Key,
-			&zenclient.GetProcessInstanceMessageSubscriptionsParams{Size: ptr.To(int32(100))})
+			&zenclient.GetProcessInstanceMessageSubscriptionsParams{Size: new(int32(100))})
 		assert.NoError(collect, err)
 		assert.NotNil(collect, resp.JSON200)
 		assert.Equal(collect, 3, resp.JSON200.TotalCount)
@@ -136,8 +135,8 @@ func TestMessageSubscriptionsStateFilter(t *testing.T) {
 		resp, err := app.restClient.GetProcessInstanceMessageSubscriptionsWithResponse(
 			t.Context(), instance.Key,
 			&zenclient.GetProcessInstanceMessageSubscriptionsParams{
-				State: ptr.To(zenclient.EventSubscriptionStateActive),
-				Size:  ptr.To(int32(100)),
+				State: new(zenclient.EventSubscriptionStateActive),
+				Size:  new(int32(100)),
 			})
 		require.NoError(t, err)
 		require.NotNil(t, resp.JSON200)
@@ -148,7 +147,7 @@ func TestMessageSubscriptionsStateFilter(t *testing.T) {
 		resp, err := app.restClient.GetProcessInstanceMessageSubscriptionsWithResponse(
 			t.Context(), instance.Key,
 			&zenclient.GetProcessInstanceMessageSubscriptionsParams{
-				State: ptr.To(zenclient.EventSubscriptionStateCompleted),
+				State: new(zenclient.EventSubscriptionStateCompleted),
 			})
 		require.NoError(t, err)
 		require.NotNil(t, resp.JSON200)
@@ -162,7 +161,7 @@ func TestMessageSubscriptionsInvalidState(t *testing.T) {
 	resp, err := app.restClient.GetProcessInstanceMessageSubscriptionsWithResponse(
 		t.Context(), 1,
 		&zenclient.GetProcessInstanceMessageSubscriptionsParams{
-			State: ptr.To(zenclient.EventSubscriptionStateCompensated),
+			State: new(zenclient.EventSubscriptionStateCompensated),
 		})
 	require.NoError(t, err)
 	assert.Equal(t, 400, resp.StatusCode())
@@ -178,7 +177,7 @@ func TestGetProcessInstanceTimerSubscriptions(t *testing.T) {
 	t.Cleanup(func() { cleanupOwnedProcessInstance(t, instance.Key) })
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(t.Context(), instance.Key, &zenclient.GetProcessInstanceTimerSubscriptionsParams{Size: ptr.To(int32(100))})
+		resp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(t.Context(), instance.Key, &zenclient.GetProcessInstanceTimerSubscriptionsParams{Size: new(int32(100))})
 		assert.NoError(collect, err)
 		assert.NotNil(collect, resp.JSON200)
 		assert.Equal(collect, 1, resp.JSON200.TotalCount)
@@ -215,7 +214,7 @@ func TestTimerSubscriptionsPagination(t *testing.T) {
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				resp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(
 					t.Context(), instanceKey,
-					&zenclient.GetProcessInstanceTimerSubscriptionsParams{Size: ptr.To(int32(100))})
+					&zenclient.GetProcessInstanceTimerSubscriptionsParams{Size: new(int32(100))})
 				assert.NoError(collect, err)
 				assert.NotNil(collect, resp.JSON200)
 				assert.Equal(collect, 3, resp.JSON200.TotalCount)
@@ -227,8 +226,8 @@ func TestTimerSubscriptionsPagination(t *testing.T) {
 			resp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(
 				t.Context(), instanceKey,
 				&zenclient.GetProcessInstanceTimerSubscriptionsParams{
-					Page: ptr.To(int32(page)),
-					Size: ptr.To(int32(size)),
+					Page: new(int32(page)),
+					Size: new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.NotNil(t, resp.JSON200)
@@ -254,7 +253,7 @@ func TestTimerSubscriptionsInvalidState(t *testing.T) {
 	resp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(
 		t.Context(), 1,
 		&zenclient.GetProcessInstanceTimerSubscriptionsParams{
-			State: ptr.To(zenclient.EventSubscriptionStateCompensated),
+			State: new(zenclient.EventSubscriptionStateCompensated),
 		})
 	require.NoError(t, err)
 	assert.Equal(t, 400, resp.StatusCode())
@@ -270,7 +269,7 @@ func TestGetProcessInstanceErrorSubscriptions(t *testing.T) {
 	t.Cleanup(func() { cleanupOwnedProcessInstance(t, instance.Key) })
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp, err := app.restClient.GetProcessInstanceErrorSubscriptionsWithResponse(t.Context(), instance.Key, &zenclient.GetProcessInstanceErrorSubscriptionsParams{Size: ptr.To(int32(100))})
+		resp, err := app.restClient.GetProcessInstanceErrorSubscriptionsWithResponse(t.Context(), instance.Key, &zenclient.GetProcessInstanceErrorSubscriptionsParams{Size: new(int32(100))})
 		assert.NoError(collect, err)
 		assert.NotNil(collect, resp.JSON200)
 		assert.Equal(collect, 1, resp.JSON200.TotalCount)
@@ -294,7 +293,7 @@ func TestErrorSubscriptionsInvalidState(t *testing.T) {
 	resp, err := app.restClient.GetProcessInstanceErrorSubscriptionsWithResponse(
 		t.Context(), 1,
 		&zenclient.GetProcessInstanceErrorSubscriptionsParams{
-			State: ptr.To(zenclient.EventSubscriptionStateCompleted),
+			State: new(zenclient.EventSubscriptionStateCompleted),
 		})
 	require.NoError(t, err)
 	assert.Equal(t, 400, resp.StatusCode())
@@ -314,7 +313,7 @@ func TestTimerSubscriptionsStateFilter(t *testing.T) {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			resp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(
 				t.Context(), instance.Key,
-				&zenclient.GetProcessInstanceTimerSubscriptionsParams{Size: ptr.To(int32(100))})
+				&zenclient.GetProcessInstanceTimerSubscriptionsParams{Size: new(int32(100))})
 			assert.NoError(collect, err)
 			assert.NotNil(collect, resp.JSON200)
 			assert.Equal(collect, 1, resp.JSON200.TotalCount)
@@ -328,7 +327,7 @@ func TestTimerSubscriptionsStateFilter(t *testing.T) {
 		activeResp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(
 			t.Context(), instance.Key,
 			&zenclient.GetProcessInstanceTimerSubscriptionsParams{
-				State: ptr.To(zenclient.EventSubscriptionStateActive),
+				State: new(zenclient.EventSubscriptionStateActive),
 			})
 		require.NoError(t, err)
 		require.NotNil(t, activeResp.JSON200)
@@ -339,8 +338,8 @@ func TestTimerSubscriptionsStateFilter(t *testing.T) {
 			resp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(
 				t.Context(), instance.Key,
 				&zenclient.GetProcessInstanceTimerSubscriptionsParams{
-					State: ptr.To(zenclient.EventSubscriptionStateWithdrawn),
-					Size:  ptr.To(int32(100)),
+					State: new(zenclient.EventSubscriptionStateWithdrawn),
+					Size:  new(int32(100)),
 				})
 			assert.NoError(collect, err)
 			if !assert.NotNil(collect, resp.JSON200) {
@@ -366,7 +365,7 @@ func TestTimerSubscriptionsStateFilter(t *testing.T) {
 		activeResp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(
 			t.Context(), instance.Key,
 			&zenclient.GetProcessInstanceTimerSubscriptionsParams{
-				State: ptr.To(zenclient.EventSubscriptionStateActive),
+				State: new(zenclient.EventSubscriptionStateActive),
 			})
 		require.NoError(t, err)
 		require.NotNil(t, activeResp.JSON200)
@@ -376,8 +375,8 @@ func TestTimerSubscriptionsStateFilter(t *testing.T) {
 			resp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(
 				t.Context(), instance.Key,
 				&zenclient.GetProcessInstanceTimerSubscriptionsParams{
-					State: ptr.To(zenclient.EventSubscriptionStateCompleted),
-					Size:  ptr.To(int32(100)),
+					State: new(zenclient.EventSubscriptionStateCompleted),
+					Size:  new(int32(100)),
 				})
 			assert.NoError(collect, err)
 			if !assert.NotNil(collect, resp.JSON200) {
@@ -402,7 +401,7 @@ func TestErrorSubscriptionsStateFilter(t *testing.T) {
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		resp, err := app.restClient.GetProcessInstanceErrorSubscriptionsWithResponse(
 			t.Context(), instance.Key,
-			&zenclient.GetProcessInstanceErrorSubscriptionsParams{Size: ptr.To(int32(100))})
+			&zenclient.GetProcessInstanceErrorSubscriptionsParams{Size: new(int32(100))})
 		assert.NoError(collect, err)
 		assert.NotNil(collect, resp.JSON200)
 		assert.Equal(collect, 1, resp.JSON200.TotalCount)
@@ -411,8 +410,8 @@ func TestErrorSubscriptionsStateFilter(t *testing.T) {
 	activeResp, err := app.restClient.GetProcessInstanceErrorSubscriptionsWithResponse(
 		t.Context(), instance.Key,
 		&zenclient.GetProcessInstanceErrorSubscriptionsParams{
-			State: ptr.To(zenclient.EventSubscriptionStateActive),
-			Size:  ptr.To(int32(100)),
+			State: new(zenclient.EventSubscriptionStateActive),
+			Size:  new(int32(100)),
 		})
 	require.NoError(t, err)
 	require.NotNil(t, activeResp.JSON200)
@@ -429,7 +428,7 @@ func TestErrorSubscriptionsStateFilter(t *testing.T) {
 	postCancelResp, err := app.restClient.GetProcessInstanceErrorSubscriptionsWithResponse(
 		t.Context(), instance.Key,
 		&zenclient.GetProcessInstanceErrorSubscriptionsParams{
-			State: ptr.To(zenclient.EventSubscriptionStateActive),
+			State: new(zenclient.EventSubscriptionStateActive),
 		})
 	require.NoError(t, err)
 	require.NotNil(t, postCancelResp.JSON200)
@@ -440,8 +439,8 @@ func TestErrorSubscriptionsStateFilter(t *testing.T) {
 		resp, err := app.restClient.GetProcessInstanceErrorSubscriptionsWithResponse(
 			t.Context(), instance.Key,
 			&zenclient.GetProcessInstanceErrorSubscriptionsParams{
-				State: ptr.To(zenclient.EventSubscriptionStateWithdrawn),
-				Size:  ptr.To(int32(100)),
+				State: new(zenclient.EventSubscriptionStateWithdrawn),
+				Size:  new(int32(100)),
 			})
 		assert.NoError(collect, err)
 		if !assert.NotNil(collect, resp.JSON200) {
@@ -466,7 +465,7 @@ func TestEventSubscriptionsEmptyResults(t *testing.T) {
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		resp, err := app.restClient.GetProcessInstanceTimerSubscriptionsWithResponse(
 			t.Context(), instance.Key,
-			&zenclient.GetProcessInstanceTimerSubscriptionsParams{Size: ptr.To(int32(100))})
+			&zenclient.GetProcessInstanceTimerSubscriptionsParams{Size: new(int32(100))})
 		assert.NoError(collect, err)
 		assert.NotNil(collect, resp.JSON200)
 		assert.Equal(collect, 1, resp.JSON200.TotalCount)

--- a/test/e2e/incidents_test.go
+++ b/test/e2e/incidents_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,7 +141,7 @@ func TestIncidentStateFilter(t *testing.T) {
 func getProcessInstanceIncidentsByState(t testing.TB, processInstanceKey int64, state string) ([]zenclient.Incident, error) {
 
 	r, err := app.restClient.GetIncidentsWithResponse(t.Context(), processInstanceKey, &zenclient.GetIncidentsParams{
-		State: ptr.To(zenclient.GetIncidentsParamsState(state)),
+		State: new(zenclient.GetIncidentsParamsState(state)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal incident page: %w", err)

--- a/test/e2e/job_assign_test.go
+++ b/test/e2e/job_assign_test.go
@@ -30,7 +30,7 @@ func TestJobAssignPersistsAfterCompletion(t *testing.T) {
 
 	jobs, err := getJobs(t, zenclient.GetJobsParams{
 		ProcessInstanceKey: &instance.Key,
-		State:              ptr.To(zenclient.JobStateActive),
+		State:              new(zenclient.JobStateActive),
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, jobs.Partitions[0].Items, "expected at least one active job")

--- a/test/e2e/job_helpers_test.go
+++ b/test/e2e/job_helpers_test.go
@@ -118,7 +118,7 @@ func assertProcessInstanceHasNoActiveJobByElementId(t testing.TB, processInstanc
 }
 
 func readWaitingJobs(t testing.TB, jobType string) (zenclient.JobPartitionPage, error) {
-	return getJobs(t, zenclient.GetJobsParams{JobType: &jobType, State: ptr.To(zenclient.JobStateActive)})
+	return getJobs(t, zenclient.GetJobsParams{JobType: &jobType, State: new(zenclient.JobStateActive)})
 }
 
 func getJobs(t testing.TB, params zenclient.GetJobsParams) (zenclient.JobPartitionPage, error) {

--- a/test/e2e/job_test.go
+++ b/test/e2e/job_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"testing"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/assert"
 )
@@ -62,15 +61,15 @@ func TestRestApiJob(t *testing.T) {
 	assert.NotEmpty(t, instance2.Key)
 
 	t.Run("test filter by state", func(t *testing.T) {
-		jobs, err := app.restClient.GetJobsWithResponse(t.Context(), &zenclient.GetJobsParams{JobType: ptr.To("input-task-1")})
+		jobs, err := app.restClient.GetJobsWithResponse(t.Context(), &zenclient.GetJobsParams{JobType: new("input-task-1")})
 		assert.NoError(t, err)
 
 		items := jobs.JSON200.Partitions[0].Items
 		assert.Len(t, items, 2)
 
 		jobs, err = app.restClient.GetJobsWithResponse(t.Context(), &zenclient.GetJobsParams{
-			JobType: ptr.To("input-task-1"),
-			State:   ptr.To(zenclient.JobStateActive),
+			JobType: new("input-task-1"),
+			State:   new(zenclient.JobStateActive),
 		})
 		assert.NoError(t, err)
 
@@ -82,16 +81,16 @@ func TestRestApiJob(t *testing.T) {
 
 	t.Run("test sorting by key", func(t *testing.T) {
 		jobs, err := app.restClient.GetJobsWithResponse(t.Context(), &zenclient.GetJobsParams{
-			SortBy:    ptr.To(zenclient.GetJobsParamsSortByKey),
-			SortOrder: ptr.To(zenclient.GetJobsParamsSortOrderAsc),
+			SortBy:    new(zenclient.GetJobsParamsSortByKey),
+			SortOrder: new(zenclient.GetJobsParamsSortOrderAsc),
 		})
 		assert.NoError(t, err)
 		items := jobs.JSON200.Partitions[0].Items
 		assert.True(t, items[0].Key < items[1].Key)
 
 		jobs, err = app.restClient.GetJobsWithResponse(t.Context(), &zenclient.GetJobsParams{
-			SortBy:    ptr.To(zenclient.GetJobsParamsSortByKey),
-			SortOrder: ptr.To(zenclient.GetJobsParamsSortOrderDesc),
+			SortBy:    new(zenclient.GetJobsParamsSortByKey),
+			SortOrder: new(zenclient.GetJobsParamsSortOrderDesc),
 		})
 		assert.NoError(t, err)
 		items = jobs.JSON200.Partitions[0].Items
@@ -99,7 +98,7 @@ func TestRestApiJob(t *testing.T) {
 	})
 
 	t.Run("test getting job by key - ok", func(t *testing.T) {
-		jobs, err := app.restClient.GetJobsWithResponse(t.Context(), &zenclient.GetJobsParams{JobType: ptr.To("input-task-1")})
+		jobs, err := app.restClient.GetJobsWithResponse(t.Context(), &zenclient.GetJobsParams{JobType: new("input-task-1")})
 		assert.NoError(t, err)
 		assert.Equal(t, 200, jobs.StatusCode())
 		assert.NotEmpty(t, jobs.JSON200)
@@ -119,7 +118,7 @@ func TestRestApiJob(t *testing.T) {
 func TestRestApiJobBadRequestResponse(t *testing.T) {
 	t.Run("test BadRequest response", func(t *testing.T) {
 		response, _ := app.restClient.GetJobsWithResponse(t.Context(), &zenclient.GetJobsParams{
-			State: (*zenclient.JobState)(ptr.To("non-existing-state")),
+			State: (*zenclient.JobState)(new("non-existing-state")),
 		})
 		assert.Nil(t, response.JSON200)
 		assert.NotNil(t, response.JSON400)

--- a/test/e2e/message_end_event_test.go
+++ b/test/e2e/message_end_event_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"testing"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/assert"
 )
@@ -46,7 +45,7 @@ func TestMessageEndEvent(t *testing.T) {
 	})
 
 	t.Run("the state of corresponding job should be COMPLETED", func(t *testing.T) {
-		jobsPartitionPage, err := getJobs(t, zenclient.GetJobsParams{JobType: ptr.To("message-end-event-task-1")})
+		jobsPartitionPage, err := getJobs(t, zenclient.GetJobsParams{JobType: new("message-end-event-task-1")})
 		assert.NoError(t, err)
 		assert.NotEmpty(t, jobsPartitionPage)
 		assert.NotEmpty(t, jobsPartitionPage.Partitions[0].Items)

--- a/test/e2e/message_event_subprocess_test.go
+++ b/test/e2e/message_event_subprocess_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	bpmnruntime "github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/pbinitiative/zenbpm/pkg/zenflake"
 	"github.com/stretchr/testify/assert"
@@ -50,8 +49,8 @@ func TestMessageEventSubProcess(t *testing.T) {
 
 		// Read and complete the active job for the service task
 		jobs, err := getJobs(t, zenclient.GetJobsParams{
-			JobType:            ptr.To("input-task-message-event-subprocess-interrupting"),
-			ProcessInstanceKey: ptr.To(instance.Key),
+			JobType:            new("input-task-message-event-subprocess-interrupting"),
+			ProcessInstanceKey: new(instance.Key),
 		})
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(jobs.Partitions), "Should have exactly one partition with jobs")

--- a/test/e2e/message_start_event_test.go
+++ b/test/e2e/message_start_event_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	bpmnruntime "github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/pbinitiative/zenbpm/pkg/zenflake"
 	"github.com/stretchr/testify/assert"
@@ -407,7 +406,7 @@ func TestMessageStartEvent_SameMessageForInstanceAndSubprocess(t *testing.T) {
 	// event-subprocess message start event resolves to "myKey" once the new instance is created.
 	publishResp, err := app.restClient.PublishMessageWithResponse(t.Context(), zenclient.PublishMessageJSONRequestBody{
 		// instance should be started even on not-null correlation-key because the definition-level subscription should ignore the correlation key for routing
-		CorrelationKey: ptr.To("some-non-existing-correlation-key"),
+		CorrelationKey: new("some-non-existing-correlation-key"),
 		MessageName:    uniqueMessageName,
 		Variables: &map[string]any{
 			"key": "myKey",

--- a/test/e2e/message_test.go
+++ b/test/e2e/message_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/assert"
 )
@@ -203,8 +202,8 @@ func TestRestApiMessage(t *testing.T) {
 		assert.NoError(t, err)
 
 		jobs, err := getJobs(t, zenclient.GetJobsParams{
-			State:              ptr.To(zenclient.JobStateActive),
-			ProcessInstanceKey: ptr.To(instance.Key),
+			State:              new(zenclient.JobStateActive),
+			ProcessInstanceKey: new(instance.Key),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(jobs.Partitions))
@@ -217,8 +216,8 @@ func TestRestApiMessage(t *testing.T) {
 		assert.Equal(t, 201, response.StatusCode())
 
 		jobs, err = getJobs(t, zenclient.GetJobsParams{
-			State:              ptr.To(zenclient.JobStateActive),
-			ProcessInstanceKey: ptr.To(instance.Key),
+			State:              new(zenclient.JobStateActive),
+			ProcessInstanceKey: new(instance.Key),
 		})
 		assert.NoError(t, err)
 
@@ -228,8 +227,8 @@ func TestRestApiMessage(t *testing.T) {
 		assert.NoError(t, err)
 
 		jobs, err = getJobs(t, zenclient.GetJobsParams{
-			State:              ptr.To(zenclient.JobStateActive),
-			ProcessInstanceKey: ptr.To(instance.Key),
+			State:              new(zenclient.JobStateActive),
+			ProcessInstanceKey: new(instance.Key),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(jobs.Partitions))

--- a/test/e2e/pagination_child_processes_test.go
+++ b/test/e2e/pagination_child_processes_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/require"
 )
@@ -32,8 +31,8 @@ func TestChildProcessesPagination(t *testing.T) {
 			resp, err := app.restClient.GetChildProcessInstancesWithResponse(t.Context(),
 				subInstanceKey,
 				&zenclient.GetChildProcessInstancesParams{
-					Page: ptr.To(int32(page)),
-					Size: ptr.To(int32(size)),
+					Page: new(int32(page)),
+					Size: new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode())
@@ -133,7 +132,7 @@ func waitForAllChildInstances(t *testing.T, parentKey int64, childCount int, sub
 		if *subInstanceKey == 0 {
 			resp, err := app.restClient.GetChildProcessInstancesWithResponse(t.Context(),
 				parentKey, &zenclient.GetChildProcessInstancesParams{
-					Size: ptr.To(int32(10)),
+					Size: new(int32(10)),
 				})
 			if err != nil || resp.JSON200 == nil {
 				return false
@@ -152,7 +151,7 @@ func waitForAllChildInstances(t *testing.T, parentKey int64, childCount int, sub
 		}
 		resp2, err := app.restClient.GetChildProcessInstancesWithResponse(t.Context(),
 			*subInstanceKey, &zenclient.GetChildProcessInstancesParams{
-				Size: ptr.To(int32(100)),
+				Size: new(int32(100)),
 			})
 		if err != nil || resp2.JSON200 == nil {
 			return false

--- a/test/e2e/pagination_dmn_test.go
+++ b/test/e2e/pagination_dmn_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/require"
 )
@@ -22,8 +21,8 @@ func TestDmnResourceDefinitionsPagination(t *testing.T) {
 		FetchPage: func(t *testing.T, page, size int) (int, int, int, int) {
 			resp, err := app.restClient.GetDmnResourceDefinitionsWithResponse(t.Context(),
 				&zenclient.GetDmnResourceDefinitionsParams{
-					Page: ptr.To(int32(page)),
-					Size: ptr.To(int32(size)),
+					Page: new(int32(page)),
+					Size: new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode())
@@ -68,8 +67,8 @@ func TestDecisionInstancesPagination(t *testing.T) {
 				&zenclient.GetDecisionInstancesParams{
 					DmnResourceDefinitionKey: &dmnKey,
 					EvaluatedFrom:            &st,
-					Page:                     ptr.To(int32(page)),
-					Size:                     ptr.To(int32(size)),
+					Page:                     new(int32(page)),
+					Size:                     new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode())
@@ -103,8 +102,8 @@ func createManyDmnResourceDefinitions(t *testing.T, count int) {
 		uniqueId := fmt.Sprintf("pagination-dmn-%d-%d", time.Now().UnixNano(), i)
 		_, err := deployDmnResourceDefinitionWithNewNameAndId(t,
 			"bulk-evaluation-test/can-autoliquidate-rule.dmn",
-			ptr.To(fmt.Sprintf("pagination-dmn-name-%d", i)),
-			ptr.To(uniqueId),
+			new(fmt.Sprintf("pagination-dmn-name-%d", i)),
+			new(uniqueId),
 		)
 		require.NoError(t, err)
 	}
@@ -116,8 +115,8 @@ func deployDmnAndSeed(t *testing.T) (int64, string, time.Time) {
 	uniqueId := fmt.Sprintf("pagination-decision-%d", time.Now().UnixNano())
 	key, err := deployDmnResourceDefinitionWithNewNameAndId(t,
 		"bulk-evaluation-test/can-autoliquidate-rule.dmn",
-		ptr.To(fmt.Sprintf("pagination-decision-name-%d", time.Now().UnixNano())),
-		ptr.To(uniqueId),
+		new(fmt.Sprintf("pagination-decision-name-%d", time.Now().UnixNano())),
+		new(uniqueId),
 	)
 	require.NoError(t, err)
 
@@ -132,7 +131,7 @@ func createDecisionInstances(t *testing.T, uniqueId, decisionId string, count in
 		_, err := evaluateDecision(
 			t,
 			zenclient.EvaluateDecisionJSONBodyBindingTypeLatest,
-			ptr.To(uniqueId),
+			new(uniqueId),
 			decisionId,
 			nil,
 			map[string]any{
@@ -153,7 +152,7 @@ func waitForDecisionInstances(t *testing.T, dmnKey int64, seedTime time.Time, re
 			&zenclient.GetDecisionInstancesParams{
 				DmnResourceDefinitionKey: &dmnKey,
 				EvaluatedFrom:            &st,
-				Size:                     ptr.To(int32(100)),
+				Size:                     new(int32(100)),
 			})
 		if err != nil || resp.JSON200 == nil {
 			return false

--- a/test/e2e/pagination_history_test.go
+++ b/test/e2e/pagination_history_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/require"
 )
@@ -31,8 +30,8 @@ func TestFlowElementHistoryPagination(t *testing.T) {
 		FetchPage: func(t *testing.T, page, size int) (int, int, int, int) {
 			resp, err := app.restClient.GetHistoryWithResponse(t.Context(), instanceKey,
 				&zenclient.GetHistoryParams{
-					Page: ptr.To(int32(page)),
-					Size: ptr.To(int32(size)),
+					Page: new(int32(page)),
+					Size: new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode())

--- a/test/e2e/pagination_incidents_test.go
+++ b/test/e2e/pagination_incidents_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/require"
 )
@@ -31,8 +30,8 @@ func TestIncidentsPagination(t *testing.T) {
 		FetchPage: func(t *testing.T, page, size int) (int, int, int, int) {
 			resp, err := app.restClient.GetIncidentsWithResponse(t.Context(), instanceKey,
 				&zenclient.GetIncidentsParams{
-					Page: ptr.To(int32(page)),
-					Size: ptr.To(int32(size)),
+					Page: new(int32(page)),
+					Size: new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode())
@@ -74,7 +73,7 @@ func waitForActiveJobs(t *testing.T, instanceKey int64, jobType string, totalInc
 			&zenclient.GetJobsParams{
 				ProcessInstanceKey: &instanceKey,
 				JobType:            &jobType,
-				Size:               ptr.To(int32(100)),
+				Size:               new(int32(100)),
 			})
 		if err != nil || resp.JSON200 == nil {
 			return false
@@ -98,7 +97,7 @@ func failActiveJobs(t *testing.T, instanceKey int64, jobType string) {
 		&zenclient.GetJobsParams{
 			ProcessInstanceKey: &instanceKey,
 			JobType:            &jobType,
-			Size:               ptr.To(int32(100)),
+			Size:               new(int32(100)),
 		})
 	require.NoError(t, err)
 	require.NotNil(t, resp.JSON200)

--- a/test/e2e/pagination_jobs_test.go
+++ b/test/e2e/pagination_jobs_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/require"
 )
@@ -33,8 +32,8 @@ func TestGlobalJobsPagination(t *testing.T) {
 			resp, err := app.restClient.GetJobsWithResponse(t.Context(),
 				&zenclient.GetJobsParams{
 					JobType: &jobType,
-					Page:    ptr.To(int32(page)),
-					Size:    ptr.To(int32(size)),
+					Page:    new(int32(page)),
+					Size:    new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode())
@@ -100,8 +99,8 @@ func TestProcessInstanceJobsPagination(t *testing.T) {
 			resp, err := app.restClient.GetProcessInstanceJobsWithResponse(t.Context(),
 				subInstanceKey,
 				&zenclient.GetProcessInstanceJobsParams{
-					Page: ptr.To(int32(page)),
-					Size: ptr.To(int32(size)),
+					Page: new(int32(page)),
+					Size: new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode())
@@ -151,7 +150,7 @@ func waitForGlobalJobsCount(t *testing.T, jobType string, required int) {
 		resp, err := app.restClient.GetJobsWithResponse(t.Context(),
 			&zenclient.GetJobsParams{
 				JobType: &jobType,
-				Size:    ptr.To(int32(100)),
+				Size:    new(int32(100)),
 			})
 		if err != nil || resp.JSON200 == nil {
 			return false
@@ -185,7 +184,7 @@ func waitForSubInstanceJobs(t *testing.T, jobType string, jobCount int, subInsta
 		resp, err := app.restClient.GetJobsWithResponse(t.Context(),
 			&zenclient.GetJobsParams{
 				JobType: &jobType,
-				Size:    ptr.To(int32(100)),
+				Size:    new(int32(100)),
 			})
 		if err != nil || resp.JSON200 == nil {
 			return false

--- a/test/e2e/pagination_process_definition_statistics_test.go
+++ b/test/e2e/pagination_process_definition_statistics_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,8 +22,8 @@ func TestProcessDefinitionStatisticsPagination(t *testing.T) {
 			resp, err := app.restClient.GetProcessDefinitionStatisticsWithResponse(t.Context(),
 				&zenclient.GetProcessDefinitionStatisticsParams{
 					BpmnProcessDefinitionKeyIn: &keys,
-					Page:                       ptr.To(int32(page)),
-					Size:                       ptr.To(int32(size)),
+					Page:                       new(int32(page)),
+					Size:                       new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode())
@@ -67,8 +66,8 @@ func TestProcessDefinitionStatisticsEmptyKeyFilter(t *testing.T) {
 	resp, err := app.restClient.GetProcessDefinitionStatisticsWithResponse(t.Context(),
 		&zenclient.GetProcessDefinitionStatisticsParams{
 			BpmnProcessDefinitionKeyIn: &[]int64{}, // empty array — must not filter out everything
-			Page:                       ptr.To(int32(1)),
-			Size:                       ptr.To(int32(1)),
+			Page:                       new(int32(1)),
+			Size:                       new(int32(1)),
 		})
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode())

--- a/test/e2e/pagination_process_definition_test.go
+++ b/test/e2e/pagination_process_definition_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/require"
 )
@@ -20,8 +19,8 @@ func TestProcessDefinitionPagination(t *testing.T) {
 		FetchPage: func(t *testing.T, page, size int) (int, int, int, int) {
 			resp, err := app.restClient.GetProcessDefinitionsWithResponse(t.Context(),
 				&zenclient.GetProcessDefinitionsParams{
-					Page: ptr.To(int32(page)),
-					Size: ptr.To(int32(size)),
+					Page: new(int32(page)),
+					Size: new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode())

--- a/test/e2e/pagination_process_instance_test.go
+++ b/test/e2e/pagination_process_instance_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/require"
 )
@@ -28,8 +27,8 @@ func TestProcessInstancePagination(t *testing.T) {
 			resp, err := app.restClient.GetProcessInstancesWithResponse(t.Context(),
 				&zenclient.GetProcessInstancesParams{
 					BpmnProcessId: &bpmnProcessId,
-					Page:          ptr.To(int32(page)),
-					Size:          ptr.To(int32(size)),
+					Page:          new(int32(page)),
+					Size:          new(int32(size)),
 				})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode())

--- a/test/e2e/process_definition_statistics_test.go
+++ b/test/e2e/process_definition_statistics_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -255,7 +254,7 @@ func TestProcessDefinitionStatistics(t *testing.T) {
 	t.Run("search filter", func(t *testing.T) {
 		resp, err := app.restClient.GetProcessDefinitionStatisticsWithResponse(t.Context(),
 			&zenclient.GetProcessDefinitionStatisticsParams{
-				Search: ptr.To("service-task"),
+				Search: new("service-task"),
 			})
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode())
@@ -271,13 +270,13 @@ func TestProcessDefinitionStatistics(t *testing.T) {
 
 		allVersions, err := app.restClient.GetProcessDefinitionStatisticsWithResponse(t.Context(),
 			&zenclient.GetProcessDefinitionStatisticsParams{
-				OnlyLatest: ptr.To(false),
+				OnlyLatest: new(false),
 			})
 		assert.NoError(t, err)
 
 		latestOnly, err := app.restClient.GetProcessDefinitionStatisticsWithResponse(t.Context(),
 			&zenclient.GetProcessDefinitionStatisticsParams{
-				OnlyLatest: ptr.To(true),
+				OnlyLatest: new(true),
 			})
 		assert.NoError(t, err)
 		assert.LessOrEqual(t, latestOnly.JSON200.TotalCount, allVersions.JSON200.TotalCount)
@@ -286,8 +285,8 @@ func TestProcessDefinitionStatistics(t *testing.T) {
 	t.Run("sort by version desc", func(t *testing.T) {
 		resp, err := app.restClient.GetProcessDefinitionStatisticsWithResponse(t.Context(),
 			&zenclient.GetProcessDefinitionStatisticsParams{
-				SortBy:    ptr.To(zenclient.GetProcessDefinitionStatisticsParamsSortByVersion),
-				SortOrder: ptr.To(zenclient.GetProcessDefinitionStatisticsParamsSortOrderDesc),
+				SortBy:    new(zenclient.GetProcessDefinitionStatisticsParamsSortByVersion),
+				SortOrder: new(zenclient.GetProcessDefinitionStatisticsParamsSortOrderDesc),
 			})
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode())
@@ -300,8 +299,8 @@ func TestProcessDefinitionStatistics(t *testing.T) {
 	t.Run("sort by instanceCount desc", func(t *testing.T) {
 		resp, err := app.restClient.GetProcessDefinitionStatisticsWithResponse(t.Context(),
 			&zenclient.GetProcessDefinitionStatisticsParams{
-				SortBy:    ptr.To(zenclient.GetProcessDefinitionStatisticsParamsSortByInstanceCount),
-				SortOrder: ptr.To(zenclient.GetProcessDefinitionStatisticsParamsSortOrderDesc),
+				SortBy:    new(zenclient.GetProcessDefinitionStatisticsParamsSortByInstanceCount),
+				SortOrder: new(zenclient.GetProcessDefinitionStatisticsParamsSortOrderDesc),
 			})
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode())
@@ -314,8 +313,8 @@ func TestProcessDefinitionStatistics(t *testing.T) {
 	t.Run("bad request for page=0", func(t *testing.T) {
 		resp, err := app.restClient.GetProcessDefinitionStatisticsWithResponse(t.Context(),
 			&zenclient.GetProcessDefinitionStatisticsParams{
-				Page: ptr.To(int32(0)),
-				Size: ptr.To(int32(10)),
+				Page: new(int32(0)),
+				Size: new(int32(10)),
 			})
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -326,8 +325,8 @@ func TestProcessDefinitionStatistics(t *testing.T) {
 	t.Run("bad request for size>100", func(t *testing.T) {
 		resp, err := app.restClient.GetProcessDefinitionStatisticsWithResponse(t.Context(),
 			&zenclient.GetProcessDefinitionStatisticsParams{
-				Page: ptr.To(int32(1)),
-				Size: ptr.To(int32(101)),
+				Page: new(int32(1)),
+				Size: new(int32(101)),
 			})
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode())

--- a/test/e2e/process_instance_statistics_test.go
+++ b/test/e2e/process_instance_statistics_test.go
@@ -17,7 +17,7 @@ func TestGetProcessInstanceElementStatistics(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("active token exists while blocked at service task at element `service-task-1`", func(t *testing.T) {
-		instance, err := createProcessInstance(t, ptr.To(definition.Key), map[string]any{"testVar": 1})
+		instance, err := createProcessInstance(t, new(definition.Key), map[string]any{"testVar": 1})
 		require.NoError(t, err)
 		defer app.restClient.CancelProcessInstanceWithResponse(t.Context(), instance.Key)
 
@@ -40,7 +40,7 @@ func TestGetProcessInstanceElementStatistics(t *testing.T) {
 		def, err := deployGetUniqueDefinition(t, "business_rule/simple-business-rule-task-local.bpmn")
 		require.NoError(t, err)
 
-		instance, err := createProcessInstance(t, ptr.To(def.Key), map[string]any{})
+		instance, err := createProcessInstance(t, new(def.Key), map[string]any{})
 		require.NoError(t, err)
 
 		resp, err := app.restClient.GetProcessInstanceElementStatisticsWithResponse(t.Context(), instance.Key)
@@ -54,11 +54,11 @@ func TestGetProcessInstanceElementStatistics(t *testing.T) {
 	})
 
 	t.Run("statistics are scoped to the given process instance", func(t *testing.T) {
-		instance1, err := createProcessInstance(t, ptr.To(definition.Key), map[string]any{"testVar": 1})
+		instance1, err := createProcessInstance(t, new(definition.Key), map[string]any{"testVar": 1})
 		require.NoError(t, err)
 		defer app.restClient.CancelProcessInstanceWithResponse(t.Context(), instance1.Key)
 
-		instance2, err := createProcessInstance(t, ptr.To(definition.Key), map[string]any{"testVar": 2})
+		instance2, err := createProcessInstance(t, new(definition.Key), map[string]any{"testVar": 2})
 		require.NoError(t, err)
 		defer app.restClient.CancelProcessInstanceWithResponse(t.Context(), instance2.Key)
 
@@ -71,7 +71,7 @@ func TestGetProcessInstanceElementStatistics(t *testing.T) {
 	})
 
 	t.Run("active count is zero after instance is cancelled", func(t *testing.T) {
-		instance, err := createProcessInstance(t, ptr.To(definition.Key), map[string]any{"testVar": 1})
+		instance, err := createProcessInstance(t, new(definition.Key), map[string]any{"testVar": 1})
 		require.NoError(t, err)
 
 		resp, err := app.restClient.GetProcessInstanceElementStatisticsWithResponse(t.Context(), instance.Key)
@@ -96,7 +96,7 @@ func TestGetProcessInstanceElementStatistics(t *testing.T) {
 		incidentDef, err := deployGetUniqueDefinition(t, "exclusive-gateway-with-condition.bpmn")
 		require.NoError(t, err)
 
-		instance, err := createProcessInstance(t, ptr.To(incidentDef.Key), map[string]any{"price": 0})
+		instance, err := createProcessInstance(t, new(incidentDef.Key), map[string]any{"price": 0})
 		require.NoError(t, err)
 
 		resp, err := app.restClient.GetProcessInstanceElementStatisticsWithResponse(t.Context(), instance.Key)
@@ -114,7 +114,7 @@ func TestGetProcessInstanceElementStatisticsCompletedAndTerminated(t *testing.T)
 		require.NoError(t, err)
 
 		testInputCollection := []string{"a", "b", "c"}
-		instance, err := createProcessInstance(t, ptr.To(definition.Key), map[string]any{
+		instance, err := createProcessInstance(t, new(definition.Key), map[string]any{
 			"testInputCollection": testInputCollection,
 		})
 		require.NoError(t, err)
@@ -157,7 +157,7 @@ func TestGetProcessInstanceElementStatisticsCompletedAndTerminated(t *testing.T)
 		definition, err := deployGetUniqueDefinition(t, "service-task-input-output.bpmn")
 		require.NoError(t, err)
 
-		instance, err := createProcessInstance(t, ptr.To(definition.Key), map[string]any{"testVar": 1})
+		instance, err := createProcessInstance(t, new(definition.Key), map[string]any{"testVar": 1})
 		require.NoError(t, err)
 
 		resp, err := app.restClient.GetProcessInstanceElementStatisticsWithResponse(t.Context(), instance.Key)
@@ -181,7 +181,7 @@ func TestGetProcessInstanceElementStatisticsCompletedAndTerminated(t *testing.T)
 		termDef, err := deployGetDefinition(t, "parallel_flow_with_terminate_end_task.bpmn", "parallel_flow_with_terminate_end_task")
 		require.NoError(t, err)
 
-		instance, err := createProcessInstance(t, ptr.To(termDef.Key), map[string]any{})
+		instance, err := createProcessInstance(t, new(termDef.Key), map[string]any{})
 		require.NoError(t, err)
 
 		resp, err := app.restClient.GetProcessInstanceElementStatisticsWithResponse(t.Context(), instance.Key)
@@ -201,7 +201,7 @@ func TestGetProcessInstanceElementStatisticsMultiInstance(t *testing.T) {
 	t.Run("parallel multi-instance shows body tokens not scope token", func(t *testing.T) {
 		testInputCollection := []string{"a", "b", "c"}
 		testInputCollectionLen := len(testInputCollection)
-		instance, err := createProcessInstance(t, ptr.To(definition.Key), map[string]any{
+		instance, err := createProcessInstance(t, new(definition.Key), map[string]any{
 			"testInputCollection": testInputCollection,
 		})
 		require.NoError(t, err)
@@ -237,7 +237,7 @@ func TestGetProcessInstanceElementStatisticsMultiInstance(t *testing.T) {
 		seqDef, err := deployGetUniqueDefinition(t, "multi_instance_service_task.bpmn")
 		require.NoError(t, err)
 
-		instance, err := createProcessInstance(t, ptr.To(seqDef.Key), map[string]any{
+		instance, err := createProcessInstance(t, new(seqDef.Key), map[string]any{
 			"testInputCollection": []string{"a", "b", "c"},
 		})
 		require.NoError(t, err)

--- a/test/e2e/process_instance_test.go
+++ b/test/e2e/process_instance_test.go
@@ -203,7 +203,7 @@ func TestBusinessKey(t *testing.T) {
 	t.Run("complete service task", func(t *testing.T) {
 		jobs, err := getJobs(t, zenclient.GetJobsParams{
 			ProcessInstanceKey: &instance.Key,
-			State:              ptr.To(zenclient.JobStateActive),
+			State:              new(zenclient.JobStateActive),
 		})
 		assert.NoError(t, err)
 		assert.NotEmpty(t, jobs.Partitions)
@@ -217,7 +217,7 @@ func TestBusinessKey(t *testing.T) {
 	t.Run("complete user task", func(t *testing.T) {
 		jobs, err := getJobs(t, zenclient.GetJobsParams{
 			ProcessInstanceKey: &instance.Key,
-			State:              ptr.To(zenclient.JobStateActive),
+			State:              new(zenclient.JobStateActive),
 		})
 		assert.NoError(t, err)
 		assert.NotEmpty(t, jobs.Partitions)
@@ -296,9 +296,9 @@ func TestCreatedAt(t *testing.T) {
 	t.Run("find process instances by createdAt in past sorted desc", func(t *testing.T) {
 		processInstances, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
 			BpmnProcessId: &definition.BpmnProcessId,
-			CreatedFrom:   ptr.To(past),
-			SortBy:        ptr.To(zenclient.GetProcessInstancesParamsSortByCreatedAt),
-			SortOrder:     ptr.To(zenclient.GetProcessInstancesParamsSortOrderDesc),
+			CreatedFrom:   new(past),
+			SortBy:        new(zenclient.GetProcessInstancesParamsSortByCreatedAt),
+			SortOrder:     new(zenclient.GetProcessInstancesParamsSortOrderDesc),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 2, processInstances.JSON200.TotalCount)
@@ -311,9 +311,9 @@ func TestCreatedAt(t *testing.T) {
 	t.Run("find process instances by createdAt in past sorted asc", func(t *testing.T) {
 		processInstances, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
 			BpmnProcessId: &definition.BpmnProcessId,
-			CreatedFrom:   ptr.To(past),
-			SortBy:        ptr.To(zenclient.GetProcessInstancesParamsSortByCreatedAt),
-			SortOrder:     ptr.To(zenclient.GetProcessInstancesParamsSortOrderAsc),
+			CreatedFrom:   new(past),
+			SortBy:        new(zenclient.GetProcessInstancesParamsSortByCreatedAt),
+			SortOrder:     new(zenclient.GetProcessInstancesParamsSortOrderAsc),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 2, processInstances.JSON200.TotalCount)
@@ -326,8 +326,8 @@ func TestCreatedAt(t *testing.T) {
 	t.Run("find process instances by createdAt in past by default created_at desc", func(t *testing.T) {
 		processInstances, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
 			BpmnProcessId: &definition.BpmnProcessId,
-			CreatedFrom:   ptr.To(past),
-			SortBy:        ptr.To(zenclient.GetProcessInstancesParamsSortByCreatedAt),
+			CreatedFrom:   new(past),
+			SortBy:        new(zenclient.GetProcessInstancesParamsSortByCreatedAt),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 2, processInstances.JSON200.TotalCount)
@@ -340,7 +340,7 @@ func TestCreatedAt(t *testing.T) {
 	t.Run("find process instances by createdAt in future", func(t *testing.T) {
 		processInstances, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
 			BpmnProcessId: &definition.BpmnProcessId,
-			CreatedFrom:   ptr.To(future),
+			CreatedFrom:   new(future),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 0, processInstances.JSON200.TotalCount)
@@ -383,16 +383,22 @@ func TestState(t *testing.T) {
 	invalidDefinition, _ := deployGetUniqueDefinition(t, "service-task-invalid-input.bpmn")
 
 	t.Run("create process instance for service-task-input-output.bpmn", func(t *testing.T) {
-		instance1, err := createProcessInstance(t, &validDefinition.Key, map[string]any{
+		activeInstance, err := createProcessInstance(t, &validDefinition.Key, map[string]any{
 			"testVar": 123,
 		})
-		assert.NoError(t, err)
-		assert.NotEmpty(t, instance1.Key)
-		instance2, err := createProcessInstance(t, &validDefinition.Key, map[string]any{
+		require.NoError(t, err)
+		require.NotEmpty(t, activeInstance.Key)
+		require.Equal(t, zenclient.ProcessInstanceStateActive, activeInstance.State)
+
+		terminatedInstance, err := createProcessInstance(t, &validDefinition.Key, map[string]any{
 			"testVar": 123,
 		})
-		assert.NoError(t, err)
-		assert.NotEmpty(t, instance2.Key)
+		require.NoError(t, err)
+		require.NotEmpty(t, terminatedInstance.Key)
+
+		response, err := app.restClient.CancelProcessInstanceWithResponse(t.Context(), terminatedInstance.Key)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, response.StatusCode())
 	})
 	t.Run("create process instance for service-task-invalid-input.bpmn", func(t *testing.T) {
 		invalidInstance, err := createProcessInstance(t, &invalidDefinition.Key, map[string]any{
@@ -405,7 +411,7 @@ func TestState(t *testing.T) {
 	t.Run("find process instances by state=failed", func(t *testing.T) {
 		processInstances, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
 			BpmnProcessId: &invalidDefinition.BpmnProcessId,
-			State:         ptr.To(zenclient.GetProcessInstancesParamsStateFailed),
+			State:         new(zenclient.GetProcessInstancesParamsStateFailed),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, processInstances.JSON200.TotalCount)
@@ -416,30 +422,36 @@ func TestState(t *testing.T) {
 	t.Run("find process instances sorted by state asc", func(t *testing.T) {
 		processInstances, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
 			BpmnProcessId: &validDefinition.BpmnProcessId,
-			SortBy:        ptr.To(zenclient.GetProcessInstancesParamsSortByState),
-			SortOrder:     ptr.To(zenclient.GetProcessInstancesParamsSortOrderAsc),
+			SortBy:        new(zenclient.GetProcessInstancesParamsSortByState),
+			SortOrder:     new(zenclient.GetProcessInstancesParamsSortOrderAsc),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 2, processInstances.JSON200.TotalCount)
-		stateSlice := make([]string, 0, len(processInstances.JSON200.Partitions[0].Items))
+		stateSlice := make([]zenclient.ProcessInstanceState, 0, len(processInstances.JSON200.Partitions[0].Items))
 		for _, part := range processInstances.JSON200.Partitions[0].Items {
-			stateSlice = append(stateSlice, (string)(part.State))
+			stateSlice = append(stateSlice, part.State)
 		}
-		assert.True(t, sort.SliceIsSorted(stateSlice, func(p, q int) bool { return stateSlice[p] < stateSlice[q] }))
+		assert.Equal(t, []zenclient.ProcessInstanceState{
+			zenclient.ProcessInstanceStateActive,
+			zenclient.ProcessInstanceStateTerminated,
+		}, stateSlice)
 	})
 	t.Run("find process instances sorted by state desc", func(t *testing.T) {
 		processInstances, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
 			BpmnProcessId: &validDefinition.BpmnProcessId,
-			SortBy:        ptr.To(zenclient.GetProcessInstancesParamsSortByState),
-			SortOrder:     ptr.To(zenclient.GetProcessInstancesParamsSortOrderAsc),
+			SortBy:        new(zenclient.GetProcessInstancesParamsSortByState),
+			SortOrder:     new(zenclient.GetProcessInstancesParamsSortOrderDesc),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 2, processInstances.JSON200.TotalCount)
-		stateSlice := make([]string, 0, len(processInstances.JSON200.Partitions[0].Items))
+		stateSlice := make([]zenclient.ProcessInstanceState, 0, len(processInstances.JSON200.Partitions[0].Items))
 		for _, part := range processInstances.JSON200.Partitions[0].Items {
-			stateSlice = append(stateSlice, (string)(part.State))
+			stateSlice = append(stateSlice, part.State)
 		}
-		assert.True(t, sort.SliceIsSorted(stateSlice, func(p, q int) bool { return stateSlice[p] > stateSlice[q] }))
+		assert.Equal(t, []zenclient.ProcessInstanceState{
+			zenclient.ProcessInstanceStateTerminated,
+			zenclient.ProcessInstanceStateActive,
+		}, stateSlice)
 	})
 }
 
@@ -481,8 +493,8 @@ func TestIncludeChildProcesses(t *testing.T) {
 
 	t.Run("find process instances by IncludeChildProcesses=true", func(t *testing.T) {
 		processInstances, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
-			IncludeChildProcesses: ptr.To(true),
-			State:                 ptr.To(zenclient.GetProcessInstancesParamsState("active")),
+			IncludeChildProcesses: new(true),
+			State:                 new(zenclient.GetProcessInstancesParamsState("active")),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 6, processInstances.JSON200.TotalCount)
@@ -494,8 +506,8 @@ func TestIncludeChildProcesses(t *testing.T) {
 
 	t.Run("find process instances by IncludeChildProcesses=false", func(t *testing.T) {
 		processInstances, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
-			IncludeChildProcesses: ptr.To(false),
-			State:                 ptr.To(zenclient.GetProcessInstancesParamsState("active")),
+			IncludeChildProcesses: new(false),
+			State:                 new(zenclient.GetProcessInstancesParamsState("active")),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 4, processInstances.JSON200.TotalCount)
@@ -507,7 +519,7 @@ func TestIncludeChildProcesses(t *testing.T) {
 
 	t.Run("find process instances by IncludeChildProcesses not filled out", func(t *testing.T) {
 		processInstances, err := app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
-			State: ptr.To(zenclient.GetProcessInstancesParamsState("active")),
+			State: new(zenclient.GetProcessInstancesParamsState("active")),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, 4, processInstances.JSON200.TotalCount)
@@ -677,7 +689,7 @@ func TestGetProcessInstancesBadRequest(t *testing.T) {
 	t.Run("GetProcessInstances with invalid state would return a BadRequest", func(t *testing.T) {
 		var resp *zenclient.GetProcessInstancesResponse
 		resp, _ = app.restClient.GetProcessInstancesWithResponse(t.Context(), &zenclient.GetProcessInstancesParams{
-			State: (*zenclient.GetProcessInstancesParamsState)(ptr.To("invalid-state")),
+			State: (*zenclient.GetProcessInstancesParamsState)(new("invalid-state")),
 		})
 
 		assert.Nil(t, resp.JSON200)

--- a/test/e2e/timer_boundary_event_cycle_test.go
+++ b/test/e2e/timer_boundary_event_cycle_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	bpmnruntime "github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/pbinitiative/zenbpm/pkg/zenflake"
 	"github.com/stretchr/testify/assert"
@@ -49,9 +48,9 @@ func TestTimerBoundaryEventNonInterruptingTimeCycle(t *testing.T) {
 	var downstreamJobs []zenclient.Job
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		jobs, err := getJobs(t, zenclient.GetJobsParams{
-			JobType:            ptr.To(downstreamJobType),
-			ProcessInstanceKey: ptr.To(instance.Key),
-			State:              ptr.To(zenclient.JobStateActive),
+			JobType:            new(downstreamJobType),
+			ProcessInstanceKey: new(instance.Key),
+			State:              new(zenclient.JobStateActive),
 		})
 		if !assert.NoError(collect, err) {
 			return
@@ -103,9 +102,9 @@ func TestTimerBoundaryEventNonInterruptingTimeCycle(t *testing.T) {
 
 	// Now complete the main service task job — this should drive the process to Completed.
 	mainJobs, err := getJobs(t, zenclient.GetJobsParams{
-		JobType:            ptr.To(mainJobType),
-		ProcessInstanceKey: ptr.To(instance.Key),
-		State:              ptr.To(zenclient.JobStateActive),
+		JobType:            new(mainJobType),
+		ProcessInstanceKey: new(instance.Key),
+		State:              new(zenclient.JobStateActive),
 	})
 	require.NoError(t, err)
 	mainCollected := collectJobs(mainJobs)
@@ -129,9 +128,9 @@ func assertActiveJobsOfType(t *testing.T, instanceKey int64, jobType string, exp
 	t.Helper()
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		jobs, err := getJobs(t, zenclient.GetJobsParams{
-			JobType:            ptr.To(jobType),
-			ProcessInstanceKey: ptr.To(instanceKey),
-			State:              ptr.To(zenclient.JobStateActive),
+			JobType:            new(jobType),
+			ProcessInstanceKey: new(instanceKey),
+			State:              new(zenclient.JobStateActive),
 		})
 		if !assert.NoError(collect, err) {
 			return

--- a/test/e2e/timer_event_subprocess_test.go
+++ b/test/e2e/timer_event_subprocess_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	bpmnruntime "github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
-	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/storage"
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/pbinitiative/zenbpm/pkg/zenflake"
@@ -43,8 +42,8 @@ func TestTimerEventSubProcess(t *testing.T) {
 
 		// Read and complete the active job for the service task
 		jobs, err := getJobs(t, zenclient.GetJobsParams{
-			JobType:            ptr.To("input-task-timer-event-subprocess-interrupting"),
-			ProcessInstanceKey: ptr.To(instance.Key),
+			JobType:            new("input-task-timer-event-subprocess-interrupting"),
+			ProcessInstanceKey: new(instance.Key),
 		})
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(jobs.Partitions), "Should have exactly one partition with jobs")
@@ -412,7 +411,7 @@ func assertSingleJobState(t *testing.T, instanceKey int64, expectedJobState zenc
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		jobs, err := getJobs(t, zenclient.GetJobsParams{
-			ProcessInstanceKey: ptr.To(instanceKey),
+			ProcessInstanceKey: new(instanceKey),
 		})
 		assert.NoError(collect, err)
 		assert.Equal(collect, 1, len(jobs.Partitions), "Should have one partition with jobs")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced the deprecated pointer helper with Go’s built-in pointer construction throughout the application and test suite.
  * Removed the obsolete helper implementation and unused imports.
  * Preserved existing API behavior, runtime functionality, and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->