### PR TITLE
fix(#746): avoid empty output variable keys in multi-instance activities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,4 @@ docs/docusaurus/
 dist/
 .release-env
 .gocache
-.gomodcache
 .cache/

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ docs/docusaurus/
 dist/
 .release-env
 .gocache
+.gomodcache
 .cache/

--- a/docs/reference/bpmn/supported-elements/activities/activity-multi-instance.md
+++ b/docs/reference/bpmn/supported-elements/activities/activity-multi-instance.md
@@ -35,11 +35,11 @@ Add a `bpmn:multiInstanceLoopCharacteristics` element to the activity and config
 
 Execution flow:
 
-1. A token arrives at the activity and `inputCollection` is evaluated against the process scope. A non-list value fails the activity; an empty list completes it immediately with an empty output collection.
+1. A token arrives at the activity and `inputCollection` is evaluated against the process scope. A non-list value fails the activity; an empty list completes it immediately. If `outputCollection` is configured, it receives an empty list; otherwise, no output variable is produced.
 2. The engine creates a dedicated child process instance for the iterations, linked to the parent and running on the same [partition](../../../cluster.md). The parent token waits at the activity, and boundary events attached to the activity cover the entire multi-instance execution.
 3. Iterations run inside the child instance — all at once in parallel mode, one at a time in collection order in sequential mode. Each iteration executes the activity with its own local scope holding the current element under `inputElement`; the process variables remain readable by expressions and input mappings.
-4. After an iteration completes, `outputElement` is evaluated against the iteration's input variables plus the variables created by the activity's **output mappings**. **Raw variables returned by a job are not visible to `outputElement`** — map every value it needs with an output mapping on the activity first.
-5. When all iterations have completed, the collected results are written to the parent process scope as `outputCollection` — one entry per iteration, in collection order for sequential execution; the order is not guaranteed for parallel execution. The parent token then continues along the outgoing sequence flow.
+4. When `outputCollection` and `outputElement` are configured, `outputElement` is evaluated after an iteration completes against the iteration's input variables plus the variables created by the activity's **output mappings**. **Raw variables returned by a job are not visible to `outputElement`** — map every value it needs with an output mapping on the activity first.
+5. When all iterations have completed and `outputCollection` is configured, the collected results are written to the parent process scope — one entry per iteration, in collection order for sequential execution; the order is not guaranteed for parallel execution. If `outputCollection` is omitted, per-iteration results are not collected and no output variable is produced. The parent token then continues along the outgoing sequence flow.
 
 ## Related documentation
 

--- a/pkg/bpmn/multi_instance.go
+++ b/pkg/bpmn/multi_instance.go
@@ -52,17 +52,18 @@ func (engine *Engine) handleMultiInstanceActivity(ctx context.Context, batch *En
 			if err != nil {
 				return nil, fmt.Errorf("failed to process %s flow transition %d: %w", element.GetType(), activity.GetKey(), err)
 			}
+
 			// The start helpers only report Completed for an empty input collection. No
 			// multi-instance instance is created in that case, so the parent continuation
 			// that normally completes this history row never runs.
-			outputCollectionName := element.GetMultiInstance().LoopCharacteristics.OutputCollectionName
+			outputVariables := emptyMultiInstanceOutputVariables(element)
 			if err := batch.UpdateOutputFlowElementInstance(ctx, runtime.FlowElementInstance{
 				Key:                currentToken.ElementInstanceKey,
 				ProcessInstanceKey: instance.ProcessInstance().Key,
 				ElementId:          element.GetId(),
 				ElementType:        string(element.GetType()),
 				ExecutionTokenKey:  currentToken.Key,
-				OutputVariables:    map[string]any{outputCollectionName: []interface{}{}},
+				OutputVariables:    outputVariables,
 				CompletedAt:        new(time.Now()),
 			}); err != nil {
 				return nil, fmt.Errorf("failed to complete %s history %d: %w", element.GetType(), activity.GetKey(), err)
@@ -202,7 +203,8 @@ func (engine *Engine) startParallelMultiInstance(
 	}
 
 	if len(inputCollection) == 0 {
-		instance.ProcessInstance().VariableHolder.SetLocalVariable(element.GetMultiInstance().LoopCharacteristics.OutputCollectionName, []interface{}{})
+		outputVariables := emptyMultiInstanceOutputVariables(element)
+		instance.ProcessInstance().VariableHolder.SetLocalVariables(outputVariables)
 		return runtime.ActivityStateCompleted, nil
 	}
 
@@ -280,7 +282,8 @@ func (engine *Engine) startSequentialMultiInstance(ctx context.Context, batch *E
 	}
 
 	if len(inputCollection) == 0 {
-		instance.ProcessInstance().VariableHolder.SetLocalVariable(element.GetMultiInstance().LoopCharacteristics.OutputCollectionName, []interface{}{})
+		outputVariables := emptyMultiInstanceOutputVariables(element)
+		instance.ProcessInstance().VariableHolder.SetLocalVariables(outputVariables)
 		return runtime.ActivityStateCompleted, nil
 	}
 
@@ -364,11 +367,11 @@ func (engine *Engine) handleParentProcessContinuationForMultiInstance(ctx contex
 		return fmt.Errorf("failed to find flow node by id %s", parentProcessTargetElementId)
 	}
 
-	outputCollection, err := engine.collectMultiInstanceOutputCollection(ctx, instance.ProcessInstance().Key, parentElement, parentInstance.ProcessInstance().Key)
+	outputVariables, err := engine.collectMultiInstanceOutputVariables(ctx, instance.ProcessInstance().Key, parentElement, parentInstance.ProcessInstance().Key)
 	if err != nil {
 		return err
 	}
-	parentInstance.ProcessInstance().VariableHolder.SetLocalVariable(parentElement.GetMultiInstance().LoopCharacteristics.OutputCollectionName, outputCollection)
+	parentInstance.ProcessInstance().VariableHolder.SetLocalVariables(outputVariables)
 
 	err = engine.cancelBoundarySubscriptions(ctx, batch, parentInstance.ProcessInstance().Key, updatedParentToken)
 	if err != nil {
@@ -397,7 +400,7 @@ func (engine *Engine) handleParentProcessContinuationForMultiInstance(ctx contex
 		ElementId:          parentElement.GetId(),
 		ElementType:        string(parentElement.GetType()),
 		ExecutionTokenKey:  updatedParentToken.Key,
-		OutputVariables:    map[string]any{parentElement.GetMultiInstance().LoopCharacteristics.OutputCollectionName: outputCollection},
+		OutputVariables:    outputVariables,
 		CompletedAt:        new(time.Now()),
 	})
 	if err != nil {
@@ -416,12 +419,17 @@ func (engine *Engine) handleParentProcessContinuationForMultiInstance(ctx contex
 	return nil
 }
 
-func (engine *Engine) collectMultiInstanceOutputCollection(
+func (engine *Engine) collectMultiInstanceOutputVariables(
 	ctx context.Context,
 	multiInstanceProcessKey int64,
 	parentElement bpmn20.Activity,
 	parentProcessInstanceKey int64,
-) ([]interface{}, error) {
+) (map[string]any, error) {
+	outputCollectionName := parentElement.GetMultiInstance().LoopCharacteristics.OutputCollectionName
+	if outputCollectionName == "" {
+		return nil, nil
+	}
+
 	elementInstances, err := engine.persistence.GetFlowElementInstancesByProcessInstanceKey(ctx, multiInstanceProcessKey, false)
 
 	if err != nil {
@@ -444,7 +452,21 @@ func (engine *Engine) collectMultiInstanceOutputCollection(
 		outputCollection = append(outputCollection, evaluatedOutput)
 	}
 
-	return outputCollection, nil
+	return multiInstanceOutputVariables(outputCollectionName, outputCollection), nil
+}
+
+func multiInstanceOutputVariables(outputCollectionName string, outputCollection []interface{}) map[string]any {
+	if outputCollectionName == "" {
+		return nil
+	}
+	return map[string]any{outputCollectionName: outputCollection}
+}
+
+func emptyMultiInstanceOutputVariables(element bpmn20.Activity) map[string]any {
+	return multiInstanceOutputVariables(
+		element.GetMultiInstance().LoopCharacteristics.OutputCollectionName,
+		[]interface{}{},
+	)
 }
 
 func (engine *Engine) buildActivityOutputEvaluationScope(elementInstance runtime.FlowElementInstance, element bpmn20.Activity) (map[string]any, error) {

--- a/test/e2e/multi_instance_helpers_test.go
+++ b/test/e2e/multi_instance_helpers_test.go
@@ -1,0 +1,40 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func completeMultiInstanceJobs(t *testing.T, parentProcessInstanceKey int64, activityElementID string, count int, parallel bool) int64 {
+	t.Helper()
+
+	childProcessInstance := waitForChildProcessInstance(t, parentProcessInstanceKey, 0)
+	if parallel {
+		jobs := waitForProcessInstanceActiveJobsByElementId(t, childProcessInstance.Key, activityElementID, count)
+		for _, job := range jobs {
+			require.NoError(t, completeJob(t, job.Key, nil))
+		}
+		return childProcessInstance.Key
+	}
+
+	for range count {
+		job := waitForProcessInstanceActiveJobByElementId(t, childProcessInstance.Key, activityElementID)
+		require.NoError(t, completeJob(t, job.Key, nil))
+	}
+	return childProcessInstance.Key
+}
+
+func assertNoMultiInstanceOutputVariables(t *testing.T, processInstanceKey int64, activityElementID string, expectedHistoryEntries int) {
+	t.Helper()
+
+	processInstance, err := getProcessInstance(t, processInstanceKey)
+	require.NoError(t, err)
+	require.NotContains(t, processInstance.Variables, "", "process variables must not contain an empty key")
+
+	history := getFlowElementInstancesByElementId(t, processInstanceKey, activityElementID)
+	require.Len(t, history, expectedHistoryEntries)
+	for _, elementInstance := range history {
+		require.Empty(t, elementInstance.OutputVariables, "activity history must not contain output variables when outputCollection is omitted")
+	}
+}

--- a/test/e2e/multi_instance_service_task_parallel_output_collection_test.go
+++ b/test/e2e/multi_instance_service_task_parallel_output_collection_test.go
@@ -1,0 +1,39 @@
+package e2e
+
+import "testing"
+
+func TestParallelMultiInstanceServiceTaskOutputCollection(t *testing.T) {
+	t.Run("empty input collection does not create output variables", func(t *testing.T) {
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/multi_instance/multi_instance_service_task_parallel_without_output_collection.bpmn", map[string]any{
+			"items": []string{},
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"items": []interface{}{},
+		})
+		assertNoMultiInstanceOutputVariables(t, processInstance.Key, "service_task", 1)
+	})
+
+	t.Run("missing output collection and non-empty input collection does not create output variables", func(t *testing.T) {
+		inputCollection := []string{"first", "second"}
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/multi_instance/multi_instance_service_task_parallel_without_output_collection.bpmn", map[string]any{
+			"items": inputCollection,
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		childProcessInstanceKey := completeMultiInstanceJobs(t, processInstance.Key, "service_task", len(inputCollection), true)
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"items": []interface{}{"first", "second"},
+		})
+		assertNoMultiInstanceOutputVariables(t, processInstance.Key, "service_task", 1)
+		assertNoMultiInstanceOutputVariables(t, childProcessInstanceKey, "service_task", len(inputCollection))
+	})
+}

--- a/test/e2e/multi_instance_service_task_sequential_output_collection_test.go
+++ b/test/e2e/multi_instance_service_task_sequential_output_collection_test.go
@@ -1,0 +1,39 @@
+package e2e
+
+import "testing"
+
+func TestSequentialMultiInstanceServiceTaskOutputCollection(t *testing.T) {
+	t.Run("empty input collection does not create output variables", func(t *testing.T) {
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/multi_instance/multi_instance_service_task_sequential_without_output_collection.bpmn", map[string]any{
+			"items": []string{},
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"items": []interface{}{},
+		})
+		assertNoMultiInstanceOutputVariables(t, processInstance.Key, "service_task", 1)
+	})
+
+	t.Run("missing output collection and non-empty input collection does not create output variables", func(t *testing.T) {
+		inputCollection := []string{"first", "second"}
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/multi_instance/multi_instance_service_task_sequential_without_output_collection.bpmn", map[string]any{
+			"items": inputCollection,
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		childProcessInstanceKey := completeMultiInstanceJobs(t, processInstance.Key, "service_task", len(inputCollection), false)
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"items": []interface{}{"first", "second"},
+		})
+		assertNoMultiInstanceOutputVariables(t, processInstance.Key, "service_task", 1)
+		assertNoMultiInstanceOutputVariables(t, childProcessInstanceKey, "service_task", len(inputCollection))
+	})
+}

--- a/test/e2e/multi_instance_user_task_parallel_output_collection_test.go
+++ b/test/e2e/multi_instance_user_task_parallel_output_collection_test.go
@@ -1,0 +1,39 @@
+package e2e
+
+import "testing"
+
+func TestParallelMultiInstanceUserTaskOutputCollection(t *testing.T) {
+	t.Run("empty input collection does not create output variables", func(t *testing.T) {
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/multi_instance/multi_instance_user_task_parallel_without_output_collection.bpmn", map[string]any{
+			"approvers": []string{},
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"approvers": []interface{}{},
+		})
+		assertNoMultiInstanceOutputVariables(t, processInstance.Key, "user_task", 1)
+	})
+
+	t.Run("missing output collection and non-empty input collection does not create output variables", func(t *testing.T) {
+		inputCollection := []string{"first", "second"}
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/multi_instance/multi_instance_user_task_parallel_without_output_collection.bpmn", map[string]any{
+			"approvers": inputCollection,
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		childProcessInstanceKey := completeMultiInstanceJobs(t, processInstance.Key, "user_task", len(inputCollection), true)
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"approvers": []interface{}{"first", "second"},
+		})
+		assertNoMultiInstanceOutputVariables(t, processInstance.Key, "user_task", 1)
+		assertNoMultiInstanceOutputVariables(t, childProcessInstanceKey, "user_task", len(inputCollection))
+	})
+}

--- a/test/e2e/multi_instance_user_task_sequential_output_collection_test.go
+++ b/test/e2e/multi_instance_user_task_sequential_output_collection_test.go
@@ -1,0 +1,39 @@
+package e2e
+
+import "testing"
+
+func TestSequentialMultiInstanceUserTaskOutputCollection(t *testing.T) {
+	t.Run("empty input collection does not create output variables", func(t *testing.T) {
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/multi_instance/multi_instance_user_task_sequential_without_output_collection.bpmn", map[string]any{
+			"approvers": []string{},
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"approvers": []interface{}{},
+		})
+		assertNoMultiInstanceOutputVariables(t, processInstance.Key, "user_task", 1)
+	})
+
+	t.Run("missing output collection and non-empty input collection does not create output variables", func(t *testing.T) {
+		inputCollection := []string{"first", "second"}
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/multi_instance/multi_instance_user_task_sequential_without_output_collection.bpmn", map[string]any{
+			"approvers": inputCollection,
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		childProcessInstanceKey := completeMultiInstanceJobs(t, processInstance.Key, "user_task", len(inputCollection), false)
+
+		assertProcessInstanceIsCompleted(t, processInstance.Key, "end_event")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"approvers": []interface{}{"first", "second"},
+		})
+		assertNoMultiInstanceOutputVariables(t, processInstance.Key, "user_task", 1)
+		assertNoMultiInstanceOutputVariables(t, childProcessInstanceKey, "user_task", len(inputCollection))
+	})
+}

--- a/test/e2e/testdata/multi_instance/multi_instance_service_task_parallel_without_output_collection.bpmn
+++ b/test/e2e/testdata/multi_instance/multi_instance_service_task_parallel_without_output_collection.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_mi_service_par_no_output" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="MultiInstance_Parallel_Service_Task_Without_Output" name="MultiInstance_Parallel_Service_Task_Without_Output" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_service_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_service_task" sourceRef="start_event" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="multi-instance-without-output-collection" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_service_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="false">
+        <bpmn:extensionElements>
+          <zenbpm:loopCharacteristics inputCollection="=items" inputElement="item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_end" sourceRef="service_task" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MultiInstance_Parallel_Service_Task_Without_Output">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="service_task_di" bpmnElement="service_task">
+        <dc:Bounds x="250" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_di" bpmnElement="end_event">
+        <dc:Bounds x="402" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_service_task_di" bpmnElement="flow_to_service_task">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="250" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_end_di" bpmnElement="flow_to_end">
+        <di:waypoint x="350" y="120" />
+        <di:waypoint x="402" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/multi_instance/multi_instance_service_task_sequential_without_output_collection.bpmn
+++ b/test/e2e/testdata/multi_instance/multi_instance_service_task_sequential_without_output_collection.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_mi_service_seq_no_output" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="MultiInstance_Sequential_Service_Task_Without_Output" name="MultiInstance_Sequential_Service_Task_Without_Output" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>flow_to_service_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_service_task" sourceRef="start_event" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="multi-instance-without-output-collection" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_service_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zenbpm:loopCharacteristics inputCollection="=items" inputElement="item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_end" sourceRef="service_task" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MultiInstance_Sequential_Service_Task_Without_Output">
+      <bpmndi:BPMNShape id="start_event_di" bpmnElement="start_event">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="service_task_di" bpmnElement="service_task">
+        <dc:Bounds x="250" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_event_di" bpmnElement="end_event">
+        <dc:Bounds x="402" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow_to_service_task_di" bpmnElement="flow_to_service_task">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="250" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow_to_end_di" bpmnElement="flow_to_end">
+        <di:waypoint x="350" y="120" />
+        <di:waypoint x="402" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/multi_instance/multi_instance_user_task_parallel_without_output_collection.bpmn
+++ b/test/e2e/testdata/multi_instance/multi_instance_user_task_parallel_without_output_collection.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_mi_par_no_output" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="MultiInstance_Parallel_User_Task_Without_Output" name="MultiInstance_Parallel_User_Task_Without_Output" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_to_user_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_to_user_task" sourceRef="start_event" targetRef="user_task" />
+    <bpmn:userTask id="user_task">
+      <bpmn:extensionElements>
+        <zenbpm:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_to_user_task</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="false">
+        <bpmn:extensionElements>
+          <zenbpm:loopCharacteristics inputCollection="=approvers" inputElement="approver" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_to_end" sourceRef="user_task" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>Flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MultiInstance_Parallel_User_Task_Without_Output">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="start_event">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="user_task">
+        <dc:Bounds x="250" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="end_event">
+        <dc:Bounds x="402" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_to_user_task_di" bpmnElement="Flow_to_user_task">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="250" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_end_di" bpmnElement="Flow_to_end">
+        <di:waypoint x="350" y="120" />
+        <di:waypoint x="402" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/multi_instance/multi_instance_user_task_sequential_without_output_collection.bpmn
+++ b/test/e2e/testdata/multi_instance/multi_instance_user_task_sequential_without_output_collection.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_mi_seq_no_output" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="MultiInstance_Sequential_User_Task_Without_Output" name="MultiInstance_Sequential_User_Task_Without_Output" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_to_user_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_to_user_task" sourceRef="start_event" targetRef="user_task" />
+    <bpmn:userTask id="user_task">
+      <bpmn:extensionElements>
+        <zenbpm:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_to_user_task</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zenbpm:loopCharacteristics inputCollection="=approvers" inputElement="approver" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_to_end" sourceRef="user_task" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>Flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MultiInstance_Sequential_User_Task_Without_Output">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="start_event">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="user_task">
+        <dc:Bounds x="250" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="end_event">
+        <dc:Bounds x="402" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_to_user_task_di" bpmnElement="Flow_to_user_task">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="250" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_end_di" bpmnElement="Flow_to_end">
+        <di:waypoint x="350" y="120" />
+        <di:waypoint x="402" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-instance task output handling when no output collection is configured.
  - Empty and non-empty sequential or parallel executions now complete without creating unexpected output variables.
  - Configured output collections correctly receive empty results when there are no items.
  - Input variables remain preserved across multi-instance service and user tasks.

- **Documentation**
  - Clarified output collection behavior, output element evaluation, and parent-scope result handling.

- **Tests**
  - Added end-to-end coverage for sequential and parallel service and user tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->