### PR TITLE
feat(#650): embed build metadata (version and commit) into application and REST endpoints

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X github.com/pbinitiative/zenbpm/internal/buildinfo.version={{.Version}} -X github.com/pbinitiative/zenbpm/internal/buildinfo.commit={{.FullCommit}}
     overrides:
       - goos: linux
         goarch: amd64

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,6 +1,7 @@
 FROM golang:1.26 AS builder
 
 ARG BUILD_COMMIT=unknown
+ARG BUILD_VERSION
 
 WORKDIR /build
 
@@ -13,7 +14,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN make build BUILD_COMMIT="${BUILD_COMMIT}"
+RUN make build BUILD_VERSION="${BUILD_VERSION}" BUILD_COMMIT="${BUILD_COMMIT}"
 
 FROM ubuntu:noble-20260410
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,7 @@
 FROM golang:1.26 AS builder
 
+ARG BUILD_COMMIT=unknown
+
 WORKDIR /build
 
 RUN apt-get update \
@@ -11,7 +13,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN make build
+RUN make build BUILD_COMMIT="${BUILD_COMMIT}"
 
 FROM ubuntu:noble-20260410
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ REVIVE ?= $(LOCALBIN)/revive
 PATH := $(LOCALBIN):$(PATH)
 
 PACKAGE_NAME ?= github.com/pbinitiative/zenbpm
+BUILD_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+LOCAL_DOCKER_IMAGE ?= zenbpm:local
 ## Tool Versions
 SQLC_VERSION ?= v1.29.0
 PROTOC_VERSION ?= 33.4
@@ -263,19 +265,19 @@ codeql: codeql-cli ## Run CodeQL security analysis locally. Reports are written 
 run: ## Start this project locally with dev configuration
 	export PROFILE=DEV; \
 	export CONFIG_FILE=$(CURDIR)/conf/zenbpm/conf-dev.yaml; \
-	go run cmd/zenbpm/*.go
+	go run -ldflags "-X $(PACKAGE_NAME)/internal/buildinfo.commit=$(BUILD_COMMIT)" cmd/zenbpm/*.go
 
 .PHONY: run1
 run1: ## Start 1st node
 	export PROFILE=DEV; \
 	export CONFIG_FILE=$(CURDIR)/conf/zenbpm/conf-dev-node1.yaml; \
-	go run cmd/zenbpm/*.go
+	go run -ldflags "-X $(PACKAGE_NAME)/internal/buildinfo.commit=$(BUILD_COMMIT)" cmd/zenbpm/*.go
 
 .PHONY: run2
 run2: ## Start 2nd node
 	export PROFILE=DEV; \
 	export CONFIG_FILE=$(CURDIR)/conf/zenbpm/conf-dev-node2.yaml; \
-	go run cmd/zenbpm/*.go
+	go run -ldflags "-X $(PACKAGE_NAME)/internal/buildinfo.commit=$(BUILD_COMMIT)" cmd/zenbpm/*.go
 
 
 .PHONY: start-monitoring
@@ -407,7 +409,15 @@ test-dmntest:
 
 .PHONY: build
 build: generate ## Build the project
-	go build -o zenbpm cmd/zenbpm/main.go
+	go build -ldflags "-X $(PACKAGE_NAME)/internal/buildinfo.commit=$(BUILD_COMMIT)" -o zenbpm cmd/zenbpm/main.go
+
+.PHONY: docker-build-local
+docker-build-local: ## Build the local Docker image with build metadata
+	@docker build \
+		--build-arg BUILD_COMMIT="$(BUILD_COMMIT)" \
+		--file Dockerfile.local \
+		--tag "$(LOCAL_DOCKER_IMAGE)" \
+		.
 
 .PHONY: release-dry-run
 release-dry-run:

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,13 @@ REVIVE ?= $(LOCALBIN)/revive
 PATH := $(LOCALBIN):$(PATH)
 
 PACKAGE_NAME ?= github.com/pbinitiative/zenbpm
+BUILD_VERSION ?=
 BUILD_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 LOCAL_DOCKER_IMAGE ?= zenbpm:local
+BUILD_LDFLAGS = -X $(PACKAGE_NAME)/internal/buildinfo.commit=$(BUILD_COMMIT)
+ifneq ($(strip $(BUILD_VERSION)),)
+BUILD_LDFLAGS += -X $(PACKAGE_NAME)/internal/buildinfo.version=$(BUILD_VERSION)
+endif
 ## Tool Versions
 SQLC_VERSION ?= v1.29.0
 PROTOC_VERSION ?= 33.4
@@ -265,19 +270,19 @@ codeql: codeql-cli ## Run CodeQL security analysis locally. Reports are written 
 run: ## Start this project locally with dev configuration
 	export PROFILE=DEV; \
 	export CONFIG_FILE=$(CURDIR)/conf/zenbpm/conf-dev.yaml; \
-	go run -ldflags "-X $(PACKAGE_NAME)/internal/buildinfo.commit=$(BUILD_COMMIT)" cmd/zenbpm/*.go
+	go run -ldflags "$(BUILD_LDFLAGS)" cmd/zenbpm/*.go
 
 .PHONY: run1
 run1: ## Start 1st node
 	export PROFILE=DEV; \
 	export CONFIG_FILE=$(CURDIR)/conf/zenbpm/conf-dev-node1.yaml; \
-	go run -ldflags "-X $(PACKAGE_NAME)/internal/buildinfo.commit=$(BUILD_COMMIT)" cmd/zenbpm/*.go
+	go run -ldflags "$(BUILD_LDFLAGS)" cmd/zenbpm/*.go
 
 .PHONY: run2
 run2: ## Start 2nd node
 	export PROFILE=DEV; \
 	export CONFIG_FILE=$(CURDIR)/conf/zenbpm/conf-dev-node2.yaml; \
-	go run -ldflags "-X $(PACKAGE_NAME)/internal/buildinfo.commit=$(BUILD_COMMIT)" cmd/zenbpm/*.go
+	go run -ldflags "$(BUILD_LDFLAGS)" cmd/zenbpm/*.go
 
 
 .PHONY: start-monitoring
@@ -409,11 +414,12 @@ test-dmntest:
 
 .PHONY: build
 build: generate ## Build the project
-	go build -ldflags "-X $(PACKAGE_NAME)/internal/buildinfo.commit=$(BUILD_COMMIT)" -o zenbpm cmd/zenbpm/main.go
+	go build -ldflags "$(BUILD_LDFLAGS)" -o zenbpm cmd/zenbpm/main.go
 
 .PHONY: docker-build-local
 docker-build-local: ## Build the local Docker image with build metadata
 	@docker build \
+		--build-arg BUILD_VERSION="$(BUILD_VERSION)" \
 		--build-arg BUILD_COMMIT="$(BUILD_COMMIT)" \
 		--file Dockerfile.local \
 		--tag "$(LOCAL_DOCKER_IMAGE)" \

--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ To import configs into zen docker image use something like:
 If you want to build and run your own Docker container:
 
 ```bash
-docker build -t zenbpm -f Dockerfile.local .
-docker run --rm zenbpm:latest
+make docker-build-local
+docker run --rm zenbpm:local
 ```
+
+The Make target injects the current Git commit into the image.
+
 ## Architecture
 
 ZenBPM is built with a modular architecture:

--- a/cmd/zenbpm/main.go
+++ b/cmd/zenbpm/main.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/pbinitiative/zenbpm/internal/buildinfo"
 	"github.com/pbinitiative/zenbpm/internal/cluster"
 	"github.com/pbinitiative/zenbpm/internal/config"
 	"github.com/pbinitiative/zenbpm/internal/grpc"
@@ -16,12 +17,14 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/rest"
 )
 
-var version string = "dev"
-
 func main() {
 	profile.InitProfile()
 	log.Init()
-	log.Info("Starting ZenBPM version %s", version)
+	buildInfo, err := buildinfo.Current()
+	if err != nil {
+		log.Warn("Failed to resolve build info: %s", err)
+	}
+	log.Info("Starting ZenBPM version %s", buildInfo.Version)
 
 	appContext, ctxCancel := context.WithCancel(context.Background())
 
@@ -41,7 +44,7 @@ func main() {
 	}
 
 	// Start the public API
-	svr := rest.NewServer(zenNode, conf)
+	svr := rest.NewServer(zenNode, conf, buildInfo)
 	svr.Start()
 
 	// Start ZenBpm GRPC API

--- a/docs/reference/cluster.md
+++ b/docs/reference/cluster.md
@@ -36,6 +36,22 @@ The state of the cluster can be queried through the system API:
 - REST: `/system/status`
 - GRPC: TODO: add grpc endpoint as well
 
+The REST response includes the application version and the Git commit used to build the binary:
+
+```json
+{
+  "version": "1.5.0",
+  "commit": "0123456789abcdef0123456789abcdef01234567",
+  "clusterConfig": {},
+  "partitions": {},
+  "nodes": {}
+}
+```
+
+Release builds inject the application version. Local builds fall back to the
+embedded OpenAPI version. The commit is injected during release builds or read
+from Go build metadata.
+
 ## Partition clusters
 
 Partition clusters are smaller [RqLite](https://rqlite.io/) clusters created for data storage of each partition.

--- a/docs/reference/cluster.md
+++ b/docs/reference/cluster.md
@@ -36,7 +36,7 @@ The state of the cluster can be queried through the system API:
 - REST: `/system/status`
 - GRPC: TODO: add grpc endpoint as well
 
-The REST response includes the application version and the Git commit used to build the binary:
+The REST response includes the application version and the source Git revision associated with the build:
 
 ```json
 {
@@ -48,9 +48,10 @@ The REST response includes the application version and the Git commit used to bu
 }
 ```
 
-Release builds inject the application version. Local builds fall back to the
-embedded OpenAPI version. The commit is injected during release builds or read
-from Go build metadata.
+Release builds inject the application version, while local builds intentionally
+fall back to the embedded OpenAPI version. CI/CD builds inject the source Git
+revision; local builds obtain the source revision from Git or Go build metadata.
+The `commit` field identifies the checkout's base revision.
 
 ## Partition clusters
 

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,85 @@
+// Package buildinfo provides application version and source commit information.
+package buildinfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/pbinitiative/zenbpm/internal/rest/public"
+)
+
+const (
+	unknownVersion = "unknown"
+	unknownCommit  = "unknown"
+)
+
+var (
+	version string
+	commit  = unknownCommit
+)
+
+// Info identifies the source used to build the application binary.
+type Info struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+// Current returns the application version and source commit available to this binary.
+func Current() (Info, error) {
+	resolvedVersion, err := currentVersion()
+	return Info{
+		Version: resolvedVersion,
+		Commit:  currentCommit(),
+	}, err
+}
+
+func currentVersion() (string, error) {
+	if version != "" {
+		return version, nil
+	}
+	specJSON, err := public.GetSpecJSON()
+	return resolveVersion(version, specJSON, err)
+}
+
+func resolveVersion(injectedVersion string, specJSON []byte, specErr error) (string, error) {
+	if injectedVersion != "" {
+		return injectedVersion, nil
+	}
+	if specErr != nil {
+		return unknownVersion, fmt.Errorf("read embedded OpenAPI specification: %w", specErr)
+	}
+
+	var spec struct {
+		Info struct {
+			Version string `json:"version"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal(specJSON, &spec); err != nil {
+		return unknownVersion, fmt.Errorf("decode embedded OpenAPI specification: %w", err)
+	}
+	if spec.Info.Version == "" {
+		return unknownVersion, fmt.Errorf("embedded OpenAPI specification has no info.version")
+	}
+	return spec.Info.Version, nil
+}
+
+func currentCommit() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return commit
+	}
+	return resolveCommit(commit, info.Settings)
+}
+
+func resolveCommit(injectedCommit string, settings []debug.BuildSetting) string {
+	if injectedCommit != unknownCommit {
+		return injectedCommit
+	}
+	for _, setting := range settings {
+		if setting.Key == "vcs.revision" && setting.Value != "" {
+			return setting.Value
+		}
+	}
+	return unknownCommit
+}

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -67,13 +67,13 @@ func resolveVersion(injectedVersion string, specJSON []byte, specErr error) (str
 func currentCommit() string {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		return commit
+		return resolveCommit(commit, nil)
 	}
 	return resolveCommit(commit, info.Settings)
 }
 
 func resolveCommit(injectedCommit string, settings []debug.BuildSetting) string {
-	if injectedCommit != unknownCommit {
+	if injectedCommit != "" && injectedCommit != unknownCommit {
 		return injectedCommit
 	}
 	for _, setting := range settings {

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -54,6 +54,20 @@ func TestBuildInfo(t *testing.T) {
 		assert.Equal(t, "019fcc9239db744b9bd0c0544f71af3a", actual)
 	})
 
+	t.Run("uses the Go VCS revision when an empty commit was injected", func(t *testing.T) {
+		settings := []debug.BuildSetting{{Key: "vcs.revision", Value: "019fcc9239db744b9bd0c0544f71af3a"}}
+
+		actual := resolveCommit("", settings)
+
+		assert.Equal(t, "019fcc9239db744b9bd0c0544f71af3a", actual)
+	})
+
+	t.Run("normalizes an empty commit to unknown when build metadata has no revision", func(t *testing.T) {
+		actual := resolveCommit("", nil)
+
+		assert.Equal(t, unknownCommit, actual)
+	})
+
 	t.Run("returns unknown when build metadata has no revision", func(t *testing.T) {
 		actual := resolveCommit(unknownCommit, []debug.BuildSetting{{Key: "vcs.modified", Value: "true"}})
 

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,62 @@
+package buildinfo
+
+import (
+	"errors"
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildInfo(t *testing.T) {
+	t.Run("prefers the version injected by the release build", func(t *testing.T) {
+		actual, err := resolveVersion("1.5.0-rc1", nil, errors.New("spec unavailable"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "1.5.0-rc1", actual)
+	})
+
+	t.Run("uses the embedded OpenAPI version when no version was injected", func(t *testing.T) {
+		actual, err := resolveVersion("", []byte(`{"info":{"version":"1.5.0"}}`), nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "1.5.0", actual)
+	})
+
+	t.Run("returns unknown when the embedded OpenAPI specification cannot be read", func(t *testing.T) {
+		actual, err := resolveVersion("", nil, errors.New("spec unavailable"))
+
+		assert.Equal(t, unknownVersion, actual)
+		assert.ErrorContains(t, err, "read embedded OpenAPI specification")
+	})
+
+	t.Run("returns unknown when the embedded OpenAPI specification is invalid", func(t *testing.T) {
+		actual, err := resolveVersion("", []byte(`{"info":`), nil)
+
+		assert.Equal(t, unknownVersion, actual)
+		assert.ErrorContains(t, err, "decode embedded OpenAPI specification")
+	})
+
+	t.Run("prefers the commit injected by the build pipeline", func(t *testing.T) {
+		settings := []debug.BuildSetting{{Key: "vcs.revision", Value: "019fcc9239db744b9bd0c0544f71af3a"}}
+
+		actual := resolveCommit("whatever", settings)
+
+		assert.Equal(t, "whatever", actual)
+	})
+
+	t.Run("uses the Go VCS revision when no commit was injected", func(t *testing.T) {
+		settings := []debug.BuildSetting{{Key: "vcs.revision", Value: "019fcc9239db744b9bd0c0544f71af3a"}}
+
+		actual := resolveCommit(unknownCommit, settings)
+
+		assert.Equal(t, "019fcc9239db744b9bd0c0544f71af3a", actual)
+	})
+
+	t.Run("returns unknown when build metadata has no revision", func(t *testing.T) {
+		actual := resolveCommit(unknownCommit, []debug.BuildSetting{{Key: "vcs.modified", Value: "true"}})
+
+		assert.Equal(t, unknownCommit, actual)
+	})
+}

--- a/internal/rest/server.go
+++ b/internal/rest/server.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/pbinitiative/zenbpm/internal/buildinfo"
 	"github.com/pbinitiative/zenbpm/internal/cluster"
 	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
 	"github.com/pbinitiative/zenbpm/internal/cluster/types"
@@ -42,19 +43,22 @@ const (
 
 type Server struct {
 	sync.RWMutex
-	node   *cluster.ZenNode
-	addr   string
-	server *http.Server
+	node      *cluster.ZenNode
+	addr      string
+	server    *http.Server
+	buildInfo buildinfo.Info
 }
 
 // TODO: do we use non strict interface to implement std lib interface directly and use http.Request to reconstruct calls for proxying?
 var _ public.StrictServerInterface = (*Server)(nil)
 
-func NewServer(node *cluster.ZenNode, conf config.Config) *Server {
+// NewServer creates the public HTTP server with the supplied build metadata.
+func NewServer(node *cluster.ZenNode, conf config.Config, buildInfo buildinfo.Info) *Server {
 	r := chi.NewRouter()
 	s := Server{
-		node: node,
-		addr: conf.HttpServer.Addr,
+		node:      node,
+		addr:      conf.HttpServer.Addr,
+		buildInfo: buildInfo,
 		server: &http.Server{
 			ReadHeaderTimeout: 3 * time.Second,
 			Handler:           r,
@@ -103,8 +107,8 @@ func NewServer(node *cluster.ZenNode, conf config.Config) *Server {
 		// verbose diagnostic endpoint. Deliberately keeps the legacy contract
 		// (raw cluster state, always 200) for existing consumers; readiness
 		// semantics live exclusively on /system/health/ready below.
-		r.Get("/status", func(w http.ResponseWriter, r *http.Request) {
-			body, err := json.MarshalIndent(node.GetStatus(), "", " ")
+		r.Get("/status", func(w http.ResponseWriter, _ *http.Request) {
+			body, err := json.MarshalIndent(newSystemStatusResponse(s.buildInfo, node.GetStatus()), "", " ")
 			if err != nil {
 				restLogger.Error("failed to marshal status", "error", err)
 				w.WriteHeader(http.StatusInternalServerError)

--- a/internal/rest/system_status.go
+++ b/internal/rest/system_status.go
@@ -1,0 +1,18 @@
+package rest
+
+import (
+	"github.com/pbinitiative/zenbpm/internal/buildinfo"
+	"github.com/pbinitiative/zenbpm/internal/cluster/state"
+)
+
+type systemStatusResponse struct {
+	buildinfo.Info
+	state.Cluster
+}
+
+func newSystemStatusResponse(info buildinfo.Info, cluster state.Cluster) systemStatusResponse {
+	return systemStatusResponse{
+		Info:    info,
+		Cluster: cluster,
+	}
+}

--- a/internal/rest/system_status_test.go
+++ b/internal/rest/system_status_test.go
@@ -1,0 +1,41 @@
+package rest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/buildinfo"
+	"github.com/pbinitiative/zenbpm/internal/cluster/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSystemStatusResponse(t *testing.T) {
+	t.Run("includes build metadata and cluster state", systemStatusResponseIncludesBuildMetadataAndClusterState)
+}
+
+func systemStatusResponseIncludesBuildMetadataAndClusterState(t *testing.T) {
+	response := newSystemStatusResponse(
+		buildinfo.Info{
+			Version: "1.5.0",
+			Commit:  "0123456789abcdef0123456789abcdef01234567",
+		},
+		state.Cluster{
+			Config: state.ClusterConfig{DesiredPartitions: 3},
+			Partitions: map[uint32]state.Partition{
+				1: {Id: 1, LeaderId: "node-1"},
+			},
+			Nodes: map[string]state.Node{},
+		},
+	)
+
+	encoded, err := json.Marshal(response)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"version": "1.5.0",
+		"commit": "0123456789abcdef0123456789abcdef01234567",
+		"clusterConfig": {"desiredPartitions": 3},
+		"partitions": {"1": {"id": 1, "leaderId": "node-1"}},
+		"nodes": {}
+	}`, string(encoded))
+}

--- a/scripts/ci/release-security.sh
+++ b/scripts/ci/release-security.sh
@@ -75,7 +75,7 @@ build_scan_image() {
 
   mkdir -p linux/amd64
   CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
-    -ldflags "-s -w -X main.version=${RELEASE_TAG#v}" \
+    -ldflags "-s -w" \
     -o linux/amd64/zenbpm \
     ./cmd/zenbpm
 

--- a/test/acceptance_tests/suite_test.go
+++ b/test/acceptance_tests/suite_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pbinitiative/zenbpm/internal/buildinfo"
 	"github.com/pbinitiative/zenbpm/internal/cluster"
 	"github.com/pbinitiative/zenbpm/internal/cluster/state"
 	"github.com/pbinitiative/zenbpm/internal/config"
@@ -63,7 +64,11 @@ func runTests(m *testing.M) int {
 	}
 	defer func() { _ = zenNode.Stop() }()
 
-	svr := rest.NewServer(zenNode, conf)
+	buildInfo, err := buildinfo.Current()
+	if err != nil {
+		log.Warn("Failed to resolve build info: %s", err)
+	}
+	svr := rest.NewServer(zenNode, conf, buildInfo)
 	ln := svr.Start()
 	defer svr.Stop(appContext)
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 
+	"github.com/pbinitiative/zenbpm/internal/buildinfo"
 	"github.com/pbinitiative/zenbpm/internal/cluster"
 	"github.com/pbinitiative/zenbpm/internal/cluster/state"
 	"github.com/pbinitiative/zenbpm/internal/config"
@@ -38,6 +39,8 @@ func (m testMainWithCleanup) Run() int {
 }
 
 type ClusterStatus struct {
+	Version       string `json:"version"`
+	Commit        string `json:"commit"`
 	ClusterConfig struct {
 		DesiredPartitions int64 `json:"desiredPartitions"`
 	} `json:"clusterConfig"`
@@ -82,7 +85,11 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	// Start the public API
-	svr := rest.NewServer(zenNode, conf)
+	buildInfo, err := buildinfo.Current()
+	if err != nil {
+		log.Warn("Failed to resolve build info: %s", err)
+	}
+	svr := rest.NewServer(zenNode, conf, buildInfo)
 	ln := svr.Start()
 
 	// Create rest client

--- a/test/e2e/system_status_test.go
+++ b/test/e2e/system_status_test.go
@@ -1,0 +1,26 @@
+package e2e
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/buildinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemStatus(t *testing.T) {
+	t.Run("returns build metadata", systemStatusReturnsBuildMetadata)
+}
+
+func systemStatusReturnsBuildMetadata(t *testing.T) {
+	response, err := app.NewRequest(nil).WithPath("/system/status").DoOk()
+	require.NoError(t, err)
+
+	status := ClusterStatus{}
+	require.NoError(t, json.Unmarshal(response, &status))
+	buildInfo, err := buildinfo.Current()
+	require.NoError(t, err)
+	assert.Equal(t, buildInfo.Version, status.Version)
+	assert.Equal(t, buildInfo.Commit, status.Commit)
+}


### PR DESCRIPTION
closes #650 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added build version and Git commit information to the `/system/status` response.
  - Build metadata is now automatically included in release and local Docker builds.
  - Unavailable metadata falls back to clear default values.

- **Documentation**
  - Updated cluster API reference with status response fields and build metadata behavior.
  - Simplified local Docker build and run instructions using the new build target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->