### PR TITLE
fix(#676): add validation for DMN definitions

### DIFF
--- a/docs/reference/dmn/dmn-engine.md
+++ b/docs/reference/dmn/dmn-engine.md
@@ -56,6 +56,8 @@ A file is validated **before anything is stored** — a rejected file deploys no
 
 The syntax checks parse only. A cell or output may reference variables that do not exist yet (`customer_type`, `low`), because whether a name resolves is a runtime question — see [FEEL evaluation](#feel-evaluation). Structural checks that need the whole graph — cyclic requirements, duplicate ids, hit-policy conformance, `typeRef` matching — are still deferred to evaluation.
 
+Custom FEEL runtimes supplied through `EngineWithFeel` must implement the complete `script.DmnFeelRuntime` contract: strict unary-test evaluation plus parse-only validation for expressions and unary tests. A runtime that only implements the legacy `script.FeelRuntime` contract can still be used for ordinary expression evaluation, but deployment or evaluation of a DMN decision table fails explicitly. The engine never falls back to lenient unary testing or evaluates expressions to validate their syntax.
+
 ## Evaluating a decision
 
 A decision can be evaluated in three ways:

--- a/docs/reference/dmn/dmn-engine.md
+++ b/docs/reference/dmn/dmn-engine.md
@@ -46,6 +46,16 @@ A decision can carry a version tag, which lets callers pin a named version inste
 
 The `zenbpm` namespace is declared as `xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0"`.
 
+### Validation
+
+A file is validated **before anything is stored** — a rejected file deploys nothing and the API answers `400 Bad Request`. Validation is deliberately shallow and variable-free; for every decision table (including tables nested in contexts) it checks:
+
+- **Rule shape** — every rule must carry exactly one input entry per input and one output entry per output.
+- **Input entry syntax** — every cell must parse as a FEEL unary test.
+- **Output entry syntax** — every output entry must parse as a FEEL expression.
+
+The syntax checks parse only. A cell or output may reference variables that do not exist yet (`customer_type`, `low`), because whether a name resolves is a runtime question — see [FEEL evaluation](#feel-evaluation). Structural checks that need the whole graph — cyclic requirements, duplicate ids, hit-policy conformance, `typeRef` matching — are still deferred to evaluation.
+
 ## Evaluating a decision
 
 A decision can be evaluated in three ways:
@@ -109,12 +119,15 @@ Every expression in a DMN file is evaluated by the FEEL runtime against the deci
 | Decision table output entry       | FEEL expression | The decision's variables. `?` is **not** available.                         |
 | Literal expression                | FEEL expression | The decision's variables.                                                   |
 
-Two details are worth knowing:
+A few details are worth knowing:
 
-- **An empty input entry means "any"**. A cell with no text is treated as `-` and always matches, which is how modellers leave a column unconstrained for a rule.
+- **An empty input entry means "any"**. A cell with no text — or only whitespace — is treated as `-` and always matches, which is how modellers leave a column unconstrained for a rule.
+- **A name in an input entry cell must resolve**. Cells are evaluated in _strict_ mode: a name that is neither a variable in the decision's context nor a FEEL built-in fails the evaluation with `unknown variable(s) in unary test: <name>`. This catches an unquoted string — `VIP` written where the literal `"VIP"` was meant. Left lenient, such a cell tests the input against the unbound name's `null`, i.e. `? = null`; since `null = null` is `true` in FEEL, it **matches whenever that input column is itself `null`** (a missing input) and misses otherwise — so it quietly fires the _wrong_ rule rather than erroring. Expression positions are not strict: a missing variable in an input expression, output entry or literal expression is `null`, as in FEEL generally.
 - **Newlines inside string literals are normalised**. XML formatting can introduce line breaks into an expression; the engine rewrites newlines that occur inside FEEL string literals to `\n` before evaluating, so a multi-line literal keeps its intended value instead of becoming a syntax error.
 
 The expression language of a literal expression must be `feel` or absent — any other `expressionLanguage` fails the evaluation.
+
+**Compatibility with Camunda.** Camunda 7 and Camunda 8 (feel-scala) resolve a missing variable to `null` and never raise: an input entry referencing an unknown name becomes a `null` comparison, which _matches_ when that input column is `null` and misses otherwise — so a forgotten pair of quotes can silently fire the wrong rule. ZenBPM is stricter **for input entry cells only** — an unknown name there fails the evaluation, turning that quiet mis-match into a visible incident. Because every other position keeps FEEL's lenient `null`, a decision table ported from Camunda evaluates identically as long as the names its cells reference actually resolve at runtime.
 
 ## Decision instances
 
@@ -128,7 +141,7 @@ A failed evaluation does not produce a decision instance.
 
 ## Error handling
 
-Errors surface at evaluation time rather than at deployment. The engine performs no semantic validation when a file is deployed, so a decision that cannot be evaluated still deploys successfully.
+Structural and syntactic problems are caught at [deployment](#validation) and reject the file. Everything semantic surfaces at evaluation time: a file that deploys can still fail to evaluate, because deployment does not check that the names an expression references actually exist.
 
 Evaluation fails when:
 
@@ -136,6 +149,7 @@ Evaluation fails when:
 - A required input variable is missing, or a required decision is missing or fails.
 - A decision has no supported logic — an empty decision node.
 - A FEEL expression cannot be evaluated, or a literal expression's result does not match its `typeRef`.
+- An input entry cell references a name that is neither a variable in the context nor a FEEL built-in — reported as `unknown variable(s) in unary test: <name>`. See [FEEL evaluation](#feel-evaluation).
 - A decision table uses an unsupported hit policy, has duplicate output names, or violates its hit policy at runtime — several rules matching under `UNIQUE`, or differing outputs under `ANY`.
 
 Called from a [business rule task](../bpmn/supported-elements/activities/tasks/business-rule-task.md), any of these fails the task and raises an incident. The failure can be handled in the process with an error boundary event.

--- a/internal/cluster/server/server.go
+++ b/internal/cluster/server/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pbinitiative/zenbpm/pkg/dmn/model/dmn"
 	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/storage"
+	"github.com/pbinitiative/zenbpm/pkg/validation"
 	"github.com/pbinitiative/zenbpm/pkg/zenflake"
 	"go.opentelemetry.io/otel"
 	otelpropagation "go.opentelemetry.io/otel/propagation"
@@ -604,12 +605,18 @@ func (s *Server) DeployDmnResourceDefinition(ctx context.Context, req *proto.Dep
 			definition, err = bpmnEngine.GetDmnEngine().ParseDmnFromBytes("", req.Data)
 			if err != nil {
 				return &proto.DeployDmnResourceDefinitionResponse{
-					Error: zenerr.TechnicalError(fmt.Errorf("failed to parse request data: %w", err)).ToProtoError(),
+					Error: zenerr.BadRequest(fmt.Errorf("failed to parse request data: %w", err)).ToProtoError(),
 				}, nil
 			}
 		}
 		_, _, err = bpmnEngine.GetDmnEngine().SaveDmnResourceDefinition(ctx, definition, req.GetData(), req.GetKey())
 		if err != nil {
+			var validationErr *validation.Error
+			if errors.As(err, &validationErr) {
+				return &proto.DeployDmnResourceDefinitionResponse{
+					Error: zenerr.BadRequest(fmt.Errorf("failed to deploy dmn resource definition: %w", err)).ToProtoError(),
+				}, nil
+			}
 			return &proto.DeployDmnResourceDefinitionResponse{
 				Error: zenerr.TechnicalError(fmt.Errorf("failed to deploy dmn resource definition: %w", err)).ToProtoError(),
 			}, nil

--- a/internal/rest/server.go
+++ b/internal/rest/server.go
@@ -329,6 +329,8 @@ func (s *Server) CreateDmnResourceDefinition(ctx context.Context, request public
 		var zerr *zenerr.ZenError
 		if errors.As(err, &zerr) {
 			switch zerr.Code {
+			case zenerr.BadRequestCode:
+				return public.CreateDmnResourceDefinition400JSONResponse(zerr.ToApiError()), nil
 			case zenerr.ClusterErrorCode:
 				return public.CreateDmnResourceDefinition502JSONResponse(zerr.ToApiError()), nil
 			default:

--- a/pkg/dmn/dmn_custom_runtime_test.go
+++ b/pkg/dmn/dmn_custom_runtime_test.go
@@ -1,0 +1,131 @@
+package dmn
+
+import (
+	"errors"
+	"testing"
+
+	dmnModel "github.com/pbinitiative/zenbpm/pkg/dmn/model/dmn"
+	"github.com/stretchr/testify/require"
+)
+
+type legacyTrackingFeelRuntime struct {
+	evaluateCalls  int
+	unaryTestCalls int
+}
+
+func (r *legacyTrackingFeelRuntime) UnaryTest(string, map[string]any) (bool, error) {
+	r.unaryTestCalls++
+	return true, nil
+}
+
+func (r *legacyTrackingFeelRuntime) Evaluate(string, map[string]any) (any, error) {
+	r.evaluateCalls++
+	return nil, nil
+}
+
+func (r *legacyTrackingFeelRuntime) Stop() {}
+
+type trackingDmnFeelRuntime struct {
+	legacyTrackingFeelRuntime
+	strictUnaryTestCalls    int
+	validateExpressionCalls int
+	validateUnaryTestCalls  int
+	strictUnaryTestErr      error
+}
+
+func (r *trackingDmnFeelRuntime) UnaryTestStrict(string, map[string]any) (bool, error) {
+	r.strictUnaryTestCalls++
+	return false, r.strictUnaryTestErr
+}
+
+func (r *trackingDmnFeelRuntime) ValidateExpression(string) error {
+	r.validateExpressionCalls++
+	return nil
+}
+
+func (r *trackingDmnFeelRuntime) ValidateUnaryTest(string) error {
+	r.validateUnaryTestCalls++
+	return nil
+}
+
+func customRuntimeTestDefinitions(inputEntry string, outputEntry string) *dmnModel.TDefinitions {
+	return &dmnModel.TDefinitions{
+		Id: "definitions",
+		Decisions: []dmnModel.TDecision{
+			{
+				Id:            "decision",
+				DecisionTable: validationTestDecisionTable(inputEntry, outputEntry),
+			},
+		},
+	}
+}
+
+func TestDmnCustomRuntimeContract(t *testing.T) {
+	t.Run("rejects an incomplete runtime before deployment validation executes expressions", func(t *testing.T) {
+		feelRuntime := &legacyTrackingFeelRuntime{}
+		engine := NewEngine(EngineWithFeel(feelRuntime))
+
+		_, _, err := engine.SaveDmnResourceDefinition(
+			t.Context(),
+			customRuntimeTestDefinitions("VIP", "customerCategory"),
+			[]byte("custom runtime test definition"),
+			1,
+		)
+
+		require.ErrorContains(t, err, "does not support DMN decision tables")
+		require.Zero(t, feelRuntime.evaluateCalls)
+		require.Zero(t, feelRuntime.unaryTestCalls)
+	})
+
+	t.Run("rejects an incomplete runtime before decision evaluation executes expressions", func(t *testing.T) {
+		feelRuntime := &legacyTrackingFeelRuntime{}
+		engine := NewEngine(EngineWithFeel(feelRuntime))
+
+		_, _, _, err := engine.evaluateDecisionTable(
+			validationTestDecisionTable("VIP", "1"),
+			"decision",
+			map[string]interface{}{"value": nil},
+		)
+
+		require.ErrorContains(t, err, "does not support DMN decision tables")
+		require.Zero(t, feelRuntime.evaluateCalls)
+		require.Zero(t, feelRuntime.unaryTestCalls)
+	})
+
+	t.Run("deployment validation uses only parse-only capability methods", func(t *testing.T) {
+		feelRuntime := &trackingDmnFeelRuntime{}
+		engine := NewEngine(EngineWithFeel(feelRuntime))
+
+		_, _, err := engine.SaveDmnResourceDefinition(
+			t.Context(),
+			customRuntimeTestDefinitions("VIP", "customerCategory"),
+			[]byte("custom runtime test definition"),
+			1,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, feelRuntime.validateExpressionCalls)
+		require.Equal(t, 1, feelRuntime.validateUnaryTestCalls)
+		require.Zero(t, feelRuntime.evaluateCalls)
+		require.Zero(t, feelRuntime.unaryTestCalls)
+		require.Zero(t, feelRuntime.strictUnaryTestCalls)
+	})
+
+	t.Run("decision evaluation always uses strict unary tests", func(t *testing.T) {
+		feelRuntime := &trackingDmnFeelRuntime{
+			strictUnaryTestErr: errors.New("unknown variable(s) in unary test: VIP"),
+		}
+		engine := NewEngine(EngineWithFeel(feelRuntime))
+
+		_, _, _, err := engine.evaluateDecisionTable(
+			validationTestDecisionTable("VIP", "1"),
+			"decision",
+			map[string]interface{}{"value": nil},
+		)
+
+		require.ErrorContains(t, err, "unknown variable(s) in unary test: VIP")
+		require.Equal(t, 1, feelRuntime.evaluateCalls)
+		require.Zero(t, feelRuntime.unaryTestCalls)
+		require.Equal(t, 1, feelRuntime.strictUnaryTestCalls)
+	})
+}

--- a/pkg/dmn/dmn_engine.go
+++ b/pkg/dmn/dmn_engine.go
@@ -139,6 +139,10 @@ func (engine *ZenDmnEngine) SaveDmnResourceDefinition(
 		DmnChecksum:       md5sum,
 		DmnDefinitionName: definition.Name,
 	}
+	if err := engine.Validate(ctx, &dmnResourceDefinition); err != nil {
+		return nil, nil, err
+	}
+
 	decisionDefinitions := make([]runtime.DecisionDefinition, 0)
 	for _, definition := range definition.Decisions {
 		decisionDefinition := runtime.DecisionDefinition{
@@ -206,16 +210,11 @@ func (engine *ZenDmnEngine) saveDmnResourceDefinition(
 		resultDecisions = append(resultDecisions, decisionDefinition)
 	}
 
-	return &dmnResourceDefinition, resultDecisions, engine.Validate(ctx, &dmnResourceDefinition)
+	return &dmnResourceDefinition, resultDecisions, nil
 }
 
 func (engine *ZenDmnEngine) generateKey() int64 {
 	return engine.persistence.GenerateId()
-}
-
-func (engine *ZenDmnEngine) Validate(ctx context.Context, dmnDefinition *runtime.DmnResourceDefinition) error {
-	// TODO: Implement validation - Cyclic Requirements, unique ids, etc.
-	return nil
 }
 
 // TODO: improve tests
@@ -695,16 +694,18 @@ func (engine *ZenDmnEngine) evaluateDecisionTable(decisionTable *dmn.TDecisionTa
 	//this map is edited each cycle dont use it after this for loop
 	cellMatchVariables := map[string]interface{}{}
 	maps.Copy(cellMatchVariables, localVariableContext)
+	unaryTest := engine.feelRuntime.UnaryTest
+	if strictRuntime, ok := engine.feelRuntime.(script.StrictFeelRuntime); ok {
+		unaryTest = strictRuntime.UnaryTestStrict
+	}
 	for ruleIndex, rule := range decisionTable.Rules {
 		allColumnsMatch := true
 		for i, inputEntry := range rule.InputEntry {
 			cellMatchVariables["?"] = evaluatedInputs[i].InputValue
-			if inputEntry.Text == "" {
-				inputEntry.Text = "-"
-			}
-			match, err := engine.feelRuntime.UnaryTest(inputEntry.Text, cellMatchVariables)
+			expression := normalizeUnaryTestExpression(inputEntry.Text)
+			match, err := unaryTest(expression, cellMatchVariables)
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("error while evaluating cell match:  \"%s\" %s ,%v", inputEntry.Text, cellMatchVariables, err)
+				return nil, nil, nil, fmt.Errorf("error while evaluating cell match:  \"%s\" %s ,%v", expression, cellMatchVariables, err)
 			}
 			if !match {
 				allColumnsMatch = false

--- a/pkg/dmn/dmn_engine.go
+++ b/pkg/dmn/dmn_engine.go
@@ -81,7 +81,9 @@ func EngineWithStorage(persistence storage.DecisionStorage) EngineOption {
 }
 
 // EngineWithFeel sets the FEEL runtime used for expression evaluation and hands
-// its ownership to the caller. It is meant for construction time only (through
+// its ownership to the caller. DMN decision tables require the supplied runtime
+// to implement script.DmnFeelRuntime; incomplete runtimes are rejected during
+// deployment and evaluation. It is meant for construction time only (through
 // NewEngine): applying it to a running engine stops an already owned runtime and
 // with it any FEEL evaluation in flight.
 func EngineWithFeel(feel script.FeelRuntime) EngineOption {
@@ -90,6 +92,17 @@ func EngineWithFeel(feel script.FeelRuntime) EngineOption {
 		engine.feelRuntime = feel
 		engine.ownsFeelRuntime = false
 	}
+}
+
+func (engine *ZenDmnEngine) decisionTableFeelRuntime() (script.DmnFeelRuntime, error) {
+	feelRuntime, ok := engine.feelRuntime.(script.DmnFeelRuntime)
+	if !ok {
+		return nil, fmt.Errorf(
+			"configured FEEL runtime %T does not support DMN decision tables: it must implement UnaryTestStrict, ValidateExpression, and ValidateUnaryTest",
+			engine.feelRuntime,
+		)
+	}
+	return feelRuntime, nil
 }
 
 // Stop releases resources created and owned by the DMN engine. A runtime
@@ -665,6 +678,11 @@ func (engine *ZenDmnEngine) evaluateLiteralExpression(literalExpression *dmn.TLi
 }
 
 func (engine *ZenDmnEngine) evaluateDecisionTable(decisionTable *dmn.TDecisionTable, decisionId string, localVariableContext map[string]interface{}) (map[string]interface{}, []EvaluatedRule, []EvaluatedInput, error) {
+	feelRuntime, err := engine.decisionTableFeelRuntime()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	//TODO: move to parsing checks
 	if len(decisionTable.Outputs) > 1 && !isUnique(decisionTable.Outputs) {
 		return nil, nil, nil, fmt.Errorf("decision table contains more than one output and all of them have to have unique names, decision id %s", decisionId)
@@ -674,7 +692,7 @@ func (engine *ZenDmnEngine) evaluateDecisionTable(decisionTable *dmn.TDecisionTa
 	for i, input := range decisionTable.Inputs {
 		originalInputExpr := input.InputExpression.Text
 		normalizedInputExpr := normalizeFeelStringLiteral(originalInputExpr)
-		value, err := engine.feelRuntime.Evaluate(normalizedInputExpr, localVariableContext)
+		value, err := feelRuntime.Evaluate(normalizedInputExpr, localVariableContext)
 		if err != nil {
 			if normalizedInputExpr != originalInputExpr {
 				return nil, nil, nil, fmt.Errorf("error while evaluating expression \"%s\" (normalized: \"%s\") with variables %s: %v", originalInputExpr, normalizedInputExpr, localVariableContext, err)
@@ -694,16 +712,12 @@ func (engine *ZenDmnEngine) evaluateDecisionTable(decisionTable *dmn.TDecisionTa
 	//this map is edited each cycle dont use it after this for loop
 	cellMatchVariables := map[string]interface{}{}
 	maps.Copy(cellMatchVariables, localVariableContext)
-	unaryTest := engine.feelRuntime.UnaryTest
-	if strictRuntime, ok := engine.feelRuntime.(script.StrictFeelRuntime); ok {
-		unaryTest = strictRuntime.UnaryTestStrict
-	}
 	for ruleIndex, rule := range decisionTable.Rules {
 		allColumnsMatch := true
 		for i, inputEntry := range rule.InputEntry {
 			cellMatchVariables["?"] = evaluatedInputs[i].InputValue
 			expression := normalizeUnaryTestExpression(inputEntry.Text)
-			match, err := unaryTest(expression, cellMatchVariables)
+			match, err := feelRuntime.UnaryTestStrict(expression, cellMatchVariables)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("error while evaluating cell match:  \"%s\" %s ,%v", expression, cellMatchVariables, err)
 			}
@@ -718,7 +732,7 @@ func (engine *ZenDmnEngine) evaluateDecisionTable(decisionTable *dmn.TDecisionTa
 			for i, output := range decisionTable.Outputs {
 				originalOutputExpr := rule.OutputEntry[i].Text
 				normalizedOutputExpr := normalizeFeelStringLiteral(originalOutputExpr)
-				value, err := engine.feelRuntime.Evaluate(normalizedOutputExpr, localVariableContext)
+				value, err := feelRuntime.Evaluate(normalizedOutputExpr, localVariableContext)
 				if err != nil {
 					if normalizedOutputExpr != originalOutputExpr {
 						return nil, nil, nil, fmt.Errorf("error while evaluating output \"%s\" (normalized: \"%s\") with variables %s: %v", originalOutputExpr, normalizedOutputExpr, localVariableContext, err)

--- a/pkg/dmn/dmn_validation.go
+++ b/pkg/dmn/dmn_validation.go
@@ -1,0 +1,133 @@
+package dmn
+
+import (
+	"context"
+	"strings"
+
+	dmnModel "github.com/pbinitiative/zenbpm/pkg/dmn/model/dmn"
+	"github.com/pbinitiative/zenbpm/pkg/dmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/script"
+	"github.com/pbinitiative/zenbpm/pkg/validation"
+)
+
+func (engine *ZenDmnEngine) Validate(_ context.Context, dmnDefinition *runtime.DmnResourceDefinition) error {
+	for _, decision := range dmnDefinition.Definitions.Decisions {
+		if decision.DecisionTable != nil {
+			if err := engine.validateDecisionTable(decision.Id, decision.DecisionTable); err != nil {
+				return err
+			}
+		}
+
+		if decision.Context != nil {
+			if err := engine.validateContextDecisionTables(decision.Id, decision.Context); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (engine *ZenDmnEngine) validateContextDecisionTables(decisionID string, decisionContext *dmnModel.TContext) error {
+	for _, contextEntry := range decisionContext.ContextEntries {
+		if contextEntry.DecisionTable != nil {
+			if err := engine.validateDecisionTable(decisionID, contextEntry.DecisionTable); err != nil {
+				return err
+			}
+		}
+
+		if contextEntry.Context != nil {
+			if err := engine.validateContextDecisionTables(decisionID, contextEntry.Context); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (engine *ZenDmnEngine) validateDecisionTable(decisionID string, decisionTable *dmnModel.TDecisionTable) error {
+	for _, input := range decisionTable.Inputs {
+		expression := normalizeFeelStringLiteral(input.InputExpression.Text)
+		if err := engine.validateFeelExpression(expression); err != nil {
+			return validation.Errorf(
+				"decision %q input %q expression %q contains invalid or unsupported FEEL expression %q: %v",
+				decisionID,
+				input.Id,
+				input.InputExpression.Id,
+				expression,
+				err,
+			)
+		}
+	}
+
+	for _, rule := range decisionTable.Rules {
+		if len(rule.InputEntry) != len(decisionTable.Inputs) {
+			return validation.Errorf(
+				"decision %q rule %q has %d input entries, expected %d",
+				decisionID,
+				rule.Id,
+				len(rule.InputEntry),
+				len(decisionTable.Inputs),
+			)
+		}
+
+		if len(rule.OutputEntry) != len(decisionTable.Outputs) {
+			return validation.Errorf(
+				"decision %q rule %q has %d output entries, expected %d",
+				decisionID,
+				rule.Id,
+				len(rule.OutputEntry),
+				len(decisionTable.Outputs),
+			)
+		}
+
+		for _, inputEntry := range rule.InputEntry {
+			expression := normalizeUnaryTestExpression(inputEntry.Text)
+
+			if _, err := engine.feelRuntime.UnaryTest(expression, map[string]any{"?": nil}); err != nil {
+				return validation.Errorf(
+					"decision %q rule %q input entry %q contains invalid or unsupported FEEL unary test %q: %v",
+					decisionID,
+					rule.Id,
+					inputEntry.Id,
+					expression,
+					err,
+				)
+			}
+		}
+
+		for _, outputEntry := range rule.OutputEntry {
+			expression := normalizeFeelStringLiteral(outputEntry.Text)
+			if err := engine.validateFeelExpression(expression); err != nil {
+				return validation.Errorf(
+					"decision %q rule %q output entry %q contains invalid or unsupported FEEL expression %q: %v",
+					decisionID,
+					rule.Id,
+					outputEntry.Id,
+					expression,
+					err,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (engine *ZenDmnEngine) validateFeelExpression(expression string) error {
+	if validator, ok := engine.feelRuntime.(script.FeelExpressionValidator); ok {
+		return validator.ValidateExpression(expression)
+	}
+
+	_, err := engine.feelRuntime.Evaluate(expression, nil)
+	return err
+}
+
+func normalizeUnaryTestExpression(expression string) string {
+	expression = strings.TrimSpace(expression)
+	if expression == "" {
+		return "-"
+	}
+	return expression
+}

--- a/pkg/dmn/dmn_validation.go
+++ b/pkg/dmn/dmn_validation.go
@@ -6,7 +6,6 @@ import (
 
 	dmnModel "github.com/pbinitiative/zenbpm/pkg/dmn/model/dmn"
 	"github.com/pbinitiative/zenbpm/pkg/dmn/runtime"
-	"github.com/pbinitiative/zenbpm/pkg/script"
 	"github.com/pbinitiative/zenbpm/pkg/validation"
 )
 
@@ -47,9 +46,14 @@ func (engine *ZenDmnEngine) validateContextDecisionTables(decisionID string, dec
 }
 
 func (engine *ZenDmnEngine) validateDecisionTable(decisionID string, decisionTable *dmnModel.TDecisionTable) error {
+	feelRuntime, err := engine.decisionTableFeelRuntime()
+	if err != nil {
+		return validation.Errorf("decision %q cannot be validated: %v", decisionID, err)
+	}
+
 	for _, input := range decisionTable.Inputs {
 		expression := normalizeFeelStringLiteral(input.InputExpression.Text)
-		if err := engine.validateFeelExpression(expression); err != nil {
+		if err := feelRuntime.ValidateExpression(expression); err != nil {
 			return validation.Errorf(
 				"decision %q input %q expression %q contains invalid or unsupported FEEL expression %q: %v",
 				decisionID,
@@ -85,7 +89,7 @@ func (engine *ZenDmnEngine) validateDecisionTable(decisionID string, decisionTab
 		for _, inputEntry := range rule.InputEntry {
 			expression := normalizeUnaryTestExpression(inputEntry.Text)
 
-			if _, err := engine.feelRuntime.UnaryTest(expression, map[string]any{"?": nil}); err != nil {
+			if err := feelRuntime.ValidateUnaryTest(expression); err != nil {
 				return validation.Errorf(
 					"decision %q rule %q input entry %q contains invalid or unsupported FEEL unary test %q: %v",
 					decisionID,
@@ -99,7 +103,7 @@ func (engine *ZenDmnEngine) validateDecisionTable(decisionID string, decisionTab
 
 		for _, outputEntry := range rule.OutputEntry {
 			expression := normalizeFeelStringLiteral(outputEntry.Text)
-			if err := engine.validateFeelExpression(expression); err != nil {
+			if err := feelRuntime.ValidateExpression(expression); err != nil {
 				return validation.Errorf(
 					"decision %q rule %q output entry %q contains invalid or unsupported FEEL expression %q: %v",
 					decisionID,
@@ -113,15 +117,6 @@ func (engine *ZenDmnEngine) validateDecisionTable(decisionID string, decisionTab
 	}
 
 	return nil
-}
-
-func (engine *ZenDmnEngine) validateFeelExpression(expression string) error {
-	if validator, ok := engine.feelRuntime.(script.FeelExpressionValidator); ok {
-		return validator.ValidateExpression(expression)
-	}
-
-	_, err := engine.feelRuntime.Evaluate(expression, nil)
-	return err
 }
 
 func normalizeUnaryTestExpression(expression string) string {

--- a/pkg/dmn/dmn_validation_test.go
+++ b/pkg/dmn/dmn_validation_test.go
@@ -52,6 +52,15 @@ func TestDecisionTableValidationRegressions(t *testing.T) {
 		require.ErrorContains(t, err, `output entry "output-entry" contains invalid or unsupported FEEL expression "1 +"`)
 	})
 
+	t.Run("rejects an input entry with invalid FEEL unary-test syntax", func(t *testing.T) {
+		decisionTable := validationTestDecisionTable("1 +", "1")
+
+		err := engine.validateDecisionTable("decision", decisionTable)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, `input entry "input-entry" contains invalid or unsupported FEEL unary test "1 +"`)
+	})
+
 	t.Run("rejects an input expression with invalid FEEL syntax", func(t *testing.T) {
 		decisionTable := validationTestDecisionTable("-", "1")
 		decisionTable.Inputs[0].InputExpression.Text = "1 +"

--- a/pkg/dmn/dmn_validation_test.go
+++ b/pkg/dmn/dmn_validation_test.go
@@ -1,0 +1,98 @@
+package dmn
+
+import (
+	"testing"
+
+	dmnModel "github.com/pbinitiative/zenbpm/pkg/dmn/model/dmn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecisionTableValidationRegressions(t *testing.T) {
+	engine := NewEngine()
+	t.Cleanup(engine.Stop)
+
+	t.Run("accepts and evaluates comma-separated variable references", func(t *testing.T) {
+		decisionTable := validationTestDecisionTable("low, high", "1")
+
+		err := engine.validateDecisionTable("decision", decisionTable)
+		require.NoError(t, err)
+
+		_, matchedRules, _, err := engine.evaluateDecisionTable(
+			decisionTable,
+			"decision",
+			map[string]interface{}{"value": 5, "low": 5, "high": 10},
+		)
+		require.NoError(t, err)
+		require.Len(t, matchedRules, 1)
+		require.Equal(t, "rule", matchedRules[0].RuleId)
+	})
+
+	t.Run("treats a whitespace-only input entry as a wildcard during validation and evaluation", func(t *testing.T) {
+		decisionTable := validationTestDecisionTable(" \t\n", "1")
+
+		err := engine.validateDecisionTable("decision", decisionTable)
+		require.NoError(t, err)
+
+		_, matchedRules, _, err := engine.evaluateDecisionTable(
+			decisionTable,
+			"decision",
+			map[string]interface{}{"value": 5},
+		)
+		require.NoError(t, err)
+		require.Len(t, matchedRules, 1)
+		require.Equal(t, "rule", matchedRules[0].RuleId)
+	})
+
+	t.Run("rejects an output entry with invalid FEEL syntax", func(t *testing.T) {
+		decisionTable := validationTestDecisionTable("-", "1 +")
+
+		err := engine.validateDecisionTable("decision", decisionTable)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, `output entry "output-entry" contains invalid or unsupported FEEL expression "1 +"`)
+	})
+
+	t.Run("rejects an input expression with invalid FEEL syntax", func(t *testing.T) {
+		decisionTable := validationTestDecisionTable("-", "1")
+		decisionTable.Inputs[0].InputExpression.Text = "1 +"
+
+		err := engine.validateDecisionTable("decision", decisionTable)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, `input "input" expression "input-expression" contains invalid or unsupported FEEL expression "1 +"`)
+	})
+
+	t.Run("accepts a syntactically valid output variable reference without evaluating it", func(t *testing.T) {
+		decisionTable := validationTestDecisionTable("-", "customerCategory")
+
+		err := engine.validateDecisionTable("decision", decisionTable)
+
+		require.NoError(t, err)
+	})
+}
+
+func validationTestDecisionTable(inputEntry string, outputEntry string) *dmnModel.TDecisionTable {
+	return &dmnModel.TDecisionTable{
+		HitPolicy: dmnModel.HitPolicyFirst,
+		Inputs: []dmnModel.TInput{
+			{
+				Id: "input",
+				InputExpression: dmnModel.TInputExpression{
+					Id:      "input-expression",
+					TypeRef: "number",
+					Text:    "value",
+				},
+			},
+		},
+		Outputs: []dmnModel.TOutput{
+			{Id: "output", Name: "result", TypeRef: "number"},
+		},
+		Rules: []dmnModel.TRule{
+			{
+				Id:          "rule",
+				InputEntry:  []dmnModel.TInputEntry{{Id: "input-entry", Text: inputEntry}},
+				OutputEntry: []dmnModel.TOutputEntry{{Id: "output-entry", Text: outputEntry}},
+			},
+		},
+	}
+}

--- a/pkg/script/feel/feel_runtime.go
+++ b/pkg/script/feel/feel_runtime.go
@@ -18,6 +18,8 @@ type FeelinRuntime struct {
 	pool *script.RunnerPool
 }
 
+var _ script.DmnFeelRuntime = (*FeelinRuntime)(nil)
+
 func NewFeelinRuntime(maxVmPoolSize int, minVmPoolSize int) script.FeelRuntime {
 	return &FeelinRuntime{
 		pool: script.NewRunnerPool(FeelinRunnerFactory{}, maxVmPoolSize, minVmPoolSize),
@@ -47,6 +49,13 @@ func (r *FeelinRuntime) ValidateExpression(expression string) error {
 	defer r.pool.ReturnRunnerToPool(runner)
 
 	return (*runner.(*FeelinRunner).validateExpression)(expression)
+}
+
+func (r *FeelinRuntime) ValidateUnaryTest(expression string) error {
+	var runner = r.pool.GetRunnerFromPool()
+	defer r.pool.ReturnRunnerToPool(runner)
+
+	return (*runner.(*FeelinRunner).validateUnaryTest)(expression)
 }
 
 func (r *FeelinRuntime) Evaluate(expression string, variableContext map[string]any) (any, error) {
@@ -112,6 +121,7 @@ type FeelinRunner struct {
 	unaryTest          *func(expression string, variableContext map[string]any) (bool, error)
 	unaryTestStrict    *func(expression string, variableContext map[string]any) (bool, error)
 	validateExpression *func(expression string) error
+	validateUnaryTest  *func(expression string) error
 }
 
 func (r *FeelinRunner) Runner() {}
@@ -133,6 +143,7 @@ func newFeelRunner() *FeelinRunner {
 	r.exportUnaryTest()
 	r.exportUnaryTestStrict()
 	r.exportValidateExpression()
+	r.exportValidateUnaryTest()
 	return &r
 }
 
@@ -172,6 +183,15 @@ func (r *FeelinRunner) exportValidateExpression() {
 	r.validateExpression = &validateExpression
 }
 
+func (r *FeelinRunner) exportValidateUnaryTest() {
+	var validateUnaryTest func(expression string) error
+	err := r.vm.ExportTo(r.vm.Get("validateUnaryTest"), &validateUnaryTest)
+	if err != nil {
+		panic(err)
+	}
+	r.validateUnaryTest = &validateUnaryTest
+}
+
 const feelRuntimeExtensions = `
 function unaryTestStrict(expression, context, dialect) {
   var missingVariables = [];
@@ -201,5 +221,9 @@ function unaryTestStrict(expression, context, dialect) {
 
 function validateExpression(expression, dialect) {
   interpreter.evaluate(expression, {}, dialect);
+}
+
+function validateUnaryTest(expression, dialect) {
+  interpreter.unaryTest(expression, {}, dialect);
 }
 `

--- a/pkg/script/feel/feel_runtime.go
+++ b/pkg/script/feel/feel_runtime.go
@@ -35,6 +35,20 @@ func (r *FeelinRuntime) UnaryTest(expression string, variableContext map[string]
 	return (*runner.(*FeelinRunner).unaryTest)(expression, variableContext)
 }
 
+func (r *FeelinRuntime) UnaryTestStrict(expression string, variableContext map[string]any) (bool, error) {
+	var runner = r.pool.GetRunnerFromPool()
+	defer r.pool.ReturnRunnerToPool(runner)
+
+	return (*runner.(*FeelinRunner).unaryTestStrict)(expression, variableContext)
+}
+
+func (r *FeelinRuntime) ValidateExpression(expression string) error {
+	var runner = r.pool.GetRunnerFromPool()
+	defer r.pool.ReturnRunnerToPool(runner)
+
+	return (*runner.(*FeelinRunner).validateExpression)(expression)
+}
+
 func (r *FeelinRuntime) Evaluate(expression string, variableContext map[string]any) (any, error) {
 	var runner = r.pool.GetRunnerFromPool()
 	defer r.pool.ReturnRunnerToPool(runner)
@@ -93,9 +107,11 @@ if (typeof Intl === 'undefined') {
 `
 
 type FeelinRunner struct {
-	vm        *goja.Runtime
-	evalFunc  *func(expression string, variableContext map[string]any) (any, error)
-	unaryTest *func(expression string, variableContext map[string]any) (bool, error)
+	vm                 *goja.Runtime
+	evalFunc           *func(expression string, variableContext map[string]any) (any, error)
+	unaryTest          *func(expression string, variableContext map[string]any) (bool, error)
+	unaryTestStrict    *func(expression string, variableContext map[string]any) (bool, error)
+	validateExpression *func(expression string) error
 }
 
 func (r *FeelinRunner) Runner() {}
@@ -110,8 +126,13 @@ func newFeelRunner() *FeelinRunner {
 	if err != nil {
 		panic(err)
 	}
+	if _, err := r.vm.RunString(feelRuntimeExtensions); err != nil {
+		panic(err)
+	}
 	r.exportEvaluate()
 	r.exportUnaryTest()
+	r.exportUnaryTestStrict()
+	r.exportValidateExpression()
 	return &r
 }
 
@@ -132,3 +153,53 @@ func (r *FeelinRunner) exportUnaryTest() {
 	}
 	r.unaryTest = &unaryTest
 }
+
+func (r *FeelinRunner) exportUnaryTestStrict() {
+	var unaryTestStrict func(expression string, variableContext map[string]any) (bool, error)
+	err := r.vm.ExportTo(r.vm.Get("unaryTestStrict"), &unaryTestStrict)
+	if err != nil {
+		panic(err)
+	}
+	r.unaryTestStrict = &unaryTestStrict
+}
+
+func (r *FeelinRunner) exportValidateExpression() {
+	var validateExpression func(expression string) error
+	err := r.vm.ExportTo(r.vm.Get("validateExpression"), &validateExpression)
+	if err != nil {
+		panic(err)
+	}
+	r.validateExpression = &validateExpression
+}
+
+const feelRuntimeExtensions = `
+function unaryTestStrict(expression, context, dialect) {
+  var missingVariables = [];
+  var strictContext = new Proxy(context || {}, {
+    has: function (target, name) {
+      if (Reflect.has(target, name)) {
+        return true;
+      }
+      if (typeof name === 'string' &&
+          !Object.keys(target).some(function (key) {
+            return normalizeContextKey(key) === normalizeContextKey(name);
+          }) &&
+          typeof getBuiltin(name) === 'undefined') {
+        missingVariables.push(name);
+      }
+      return false;
+    }
+  });
+
+  var result = unaryTest(expression, strictContext, dialect);
+  if (missingVariables.length > 0) {
+    var names = Array.from(new Set(missingVariables));
+    throw new Error('unknown variable(s) in unary test: ' + names.join(', '));
+  }
+  return result;
+}
+
+function validateExpression(expression, dialect) {
+  interpreter.evaluate(expression, {}, dialect);
+}
+`

--- a/pkg/script/runtime.go
+++ b/pkg/script/runtime.go
@@ -18,6 +18,24 @@ type FeelExpressionValidator interface {
 	ValidateExpression(expression string) error
 }
 
+// FeelUnaryTestValidator can validate FEEL unary test syntax without
+// evaluating the unary test against a runtime context.
+type FeelUnaryTestValidator interface {
+	ValidateUnaryTest(expression string) error
+}
+
+// DmnFeelRuntime is the complete FEEL runtime contract required to validate
+// and evaluate DMN decision tables safely. Keeping these capabilities separate
+// from FeelRuntime preserves source compatibility for runtimes used only for
+// expression evaluation, while DMN engines can reject incomplete runtimes
+// instead of silently falling back to non-strict or execution-based behavior.
+type DmnFeelRuntime interface {
+	FeelRuntime
+	StrictFeelRuntime
+	FeelExpressionValidator
+	FeelUnaryTestValidator
+}
+
 type JsRuntime interface {
 	RunScript(script string) (any, error)
 	Stop()

--- a/pkg/script/runtime.go
+++ b/pkg/script/runtime.go
@@ -6,6 +6,18 @@ type FeelRuntime interface {
 	Stop()
 }
 
+// StrictFeelRuntime can report references to variables that are missing from
+// the runtime context instead of evaluating them as null.
+type StrictFeelRuntime interface {
+	UnaryTestStrict(expression string, variableContext map[string]any) (bool, error)
+}
+
+// FeelExpressionValidator can validate FEEL expression syntax without
+// evaluating the expression against a runtime context.
+type FeelExpressionValidator interface {
+	ValidateExpression(expression string) error
+}
+
 type JsRuntime interface {
 	RunScript(script string) (any, error)
 	Stop()

--- a/pkg/validation/error.go
+++ b/pkg/validation/error.go
@@ -1,0 +1,22 @@
+// Package validation provides errors for domain validation failures.
+package validation
+
+import "fmt"
+
+// Error identifies invalid user-provided domain data.
+type Error struct {
+	err error
+}
+
+// Errorf formats a validation error.
+func Errorf(format string, args ...any) *Error {
+	return &Error{err: fmt.Errorf(format, args...)}
+}
+
+func (e *Error) Error() string {
+	return e.err.Error()
+}
+
+func (e *Error) Unwrap() error {
+	return e.err
+}

--- a/test/e2e/business_rule_local_test.go
+++ b/test/e2e/business_rule_local_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/pbinitiative/zenbpm/pkg/zenclient"
@@ -60,4 +61,27 @@ func TestBusinessRuleLocalMultiInstance(t *testing.T) {
 		},
 	})
 	assertProcessInstanceIncidentsLength(t, processInstance.Key, 0)
+}
+
+func TestBusinessRuleMissingDmnInputEntryReferenceCreatesIncident(t *testing.T) {
+	response, err := deployDmnResourceDefinitionE2e(t, "testdata/dmn/missing_input_entry_reference.dmn")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, response.StatusCode())
+
+	processInstance := deployAndCreateUniqueProcessDefinitionWithDmnDefinitionId(
+		t,
+		"testdata/dmn/business_rule_local_dynamic_decision_id.bpmn",
+		"dmn_missing_input_entry_reference",
+		map[string]any{"amount": 10},
+	)
+
+	waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateFailed)
+	assertProcessInstanceVariables(t, processInstance.Key, map[string]any{"amount": float64(10)})
+	assertProcessInstanceTokenElements(t, processInstance.Key, []string{"business_rule"}, []string{"end_event"})
+	assertNoDecisionInstance(t, processInstance.Key)
+
+	incidents, err := getProcessInstanceIncidents(t, processInstance.Key)
+	require.NoError(t, err)
+	require.Len(t, incidents, 1)
+	require.Contains(t, incidents[0].Message, "unknown variable(s) in unary test: VIP")
 }

--- a/test/e2e/decision_deployment_test.go
+++ b/test/e2e/decision_deployment_test.go
@@ -1,0 +1,491 @@
+package e2e
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDmnDeploymentValidation(t *testing.T) {
+	validDeployments := []struct {
+		name       string
+		inputType  string
+		expression string
+	}{
+		{name: "accepts quoted text", inputType: "string", expression: `"VIP"`},
+		{name: "accepts quoted text followed by numbers", inputType: "string", expression: `"VIP123"`},
+		{name: "accepts quoted numbers followed by text", inputType: "string", expression: `"123VIP"`},
+		{name: "accepts quoted text with spaces and numbers", inputType: "string", expression: `"VIP CUSTOMER 123"`},
+		{name: "accepts quoted text with punctuation and numbers", inputType: "string", expression: `"VIP-123/PLUS.2"`},
+		{name: "accepts quoted unicode text with numbers", inputType: "string", expression: `"ZÁKAZNÍK42"`},
+		{name: "accepts a list of quoted values", inputType: "string", expression: `"VIP1", "STANDARD2"`},
+		{name: "accepts a variable reference for a string input", inputType: "string", expression: "VIP"},
+		{name: "accepts null for a string input", inputType: "string", expression: "null"},
+		{name: "accepts true for a string input", inputType: "string", expression: "true"},
+		{name: "accepts false for a string input", inputType: "string", expression: "false"},
+		{name: "accepts commas inside nested expressions", inputType: "string", expression: `not("INTERNAL, TEST")`},
+		{name: "accepts comma-separated variable references", inputType: "number", expression: "low, high"},
+		{name: "accepts an empty string input entry as a wildcard", inputType: "string", expression: ""},
+		{name: "accepts a whitespace-only input entry as a wildcard", inputType: "string", expression: " \t "},
+		{name: "accepts an unquoted number for a number input", inputType: "number", expression: "123"},
+	}
+	for _, testCase := range validDeployments {
+		t.Run(testCase.name, func(t *testing.T) {
+			definitionID := uniqueDmnResourceDefinitionTestValue("validDmnInputEntry")
+			definition := dmnDeploymentValidationDefinition(t, definitionID, testCase.inputType, "value", testCase.expression)
+
+			response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+				t.Context(),
+				"application/xml",
+				strings.NewReader(definition),
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, http.StatusCreated, response.StatusCode())
+			require.NotNil(t, response.JSON201)
+			require.NotZero(t, response.JSON201.DmnResourceDefinitionKey)
+
+			definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+				DmnResourceDefinitionId: &definitionID,
+			})
+			require.NoError(t, err)
+			require.Len(t, definitions, 1)
+			require.Equal(t, definitionID, definitions[0].DmnResourceDefinitionId)
+			require.Equal(t, response.JSON201.DmnResourceDefinitionKey, definitions[0].Key)
+		})
+	}
+
+	t.Run("evaluates a variable reference in a string input entry", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("stringInputVariableReference")
+		decisionID := definitionID + "Decision"
+		definition := dmnDeploymentValidationDefinition(t, definitionID, "string", "value", "expectedValue")
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(definition),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, response.StatusCode())
+
+		result, err := evaluateDecision(
+			t,
+			zenclient.EvaluateDecisionJSONBodyBindingTypeLatest,
+			&definitionID,
+			decisionID,
+			nil,
+			map[string]any{
+				"expectedValue": "VIP",
+				"value":         "VIP",
+			},
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.EvaluatedDecisions, 1)
+		require.Len(t, result.EvaluatedDecisions[0].MatchedRules, 1)
+		require.Equal(t, "rule", result.EvaluatedDecisions[0].MatchedRules[0].RuleId)
+	})
+
+	t.Run("fails evaluation when an input entry references a missing variable", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("missingStringInputVariableReference")
+		decisionID := definitionID + "Decision"
+		definition := dmnDeploymentValidationMissingVariableReferenceDefinition(definitionID)
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(definition),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, response.StatusCode())
+
+		result, err := evaluateDecision(
+			t,
+			zenclient.EvaluateDecisionJSONBodyBindingTypeLatest,
+			&definitionID,
+			decisionID,
+			nil,
+			map[string]any{"amount": 10},
+		)
+
+		require.Nil(t, result)
+		require.ErrorContains(t, err, "unknown variable(s) in unary test: VIP")
+	})
+
+	t.Run("evaluates comma-separated variable references", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("inputVariableReferences")
+		decisionID := definitionID + "Decision"
+		definition := dmnDeploymentValidationDefinition(t, definitionID, "number", "value", "low, high")
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(definition),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, response.StatusCode())
+
+		result, err := evaluateDecision(
+			t,
+			zenclient.EvaluateDecisionJSONBodyBindingTypeLatest,
+			&definitionID,
+			decisionID,
+			nil,
+			map[string]any{
+				"value": 5,
+				"low":   5,
+				"high":  10,
+			},
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.EvaluatedDecisions, 1)
+		require.Len(t, result.EvaluatedDecisions[0].MatchedRules, 1)
+		require.Equal(t, "rule", result.EvaluatedDecisions[0].MatchedRules[0].RuleId)
+	})
+
+	t.Run("evaluates a whitespace-only input entry as a wildcard", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("whitespaceInputWildcard")
+		decisionID := definitionID + "Decision"
+		definition := dmnDeploymentValidationDefinition(t, definitionID, "number", "value", " \t ")
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(definition),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, response.StatusCode())
+
+		result, err := evaluateDecision(
+			t,
+			zenclient.EvaluateDecisionJSONBodyBindingTypeLatest,
+			&definitionID,
+			decisionID,
+			nil,
+			map[string]any{"value": 5},
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.EvaluatedDecisions, 1)
+		require.Len(t, result.EvaluatedDecisions[0].MatchedRules, 1)
+		require.Equal(t, "rule", result.EvaluatedDecisions[0].MatchedRules[0].RuleId)
+	})
+
+	t.Run("rejects invalid FEEL unary test syntax", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("invalidFeelUnaryTest")
+		definition := dmnDeploymentValidationDefinition(t, definitionID, "number", "value", "1 +")
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(definition),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, response.StatusCode())
+		require.NotNil(t, response.JSON400)
+		require.Equal(t, "BAD_REQUEST", response.JSON400.Code)
+		require.Contains(t, response.JSON400.Message, `input entry "input-entry" contains invalid or unsupported FEEL unary test "1 +"`)
+
+		definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+			DmnResourceDefinitionId: &definitionID,
+		})
+		require.NoError(t, err)
+		require.Empty(t, definitions)
+	})
+
+	t.Run("rejects invalid FEEL input expression syntax", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("invalidFeelInputExpression")
+		definition := dmnDeploymentValidationDefinition(t, definitionID, "number", "1 +", "-")
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(definition),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, response.StatusCode())
+		require.NotNil(t, response.JSON400)
+		require.Equal(t, "BAD_REQUEST", response.JSON400.Code)
+		require.Contains(t, response.JSON400.Message, `input "input" expression "input-expression" contains invalid or unsupported FEEL expression "1 +"`)
+
+		definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+			DmnResourceDefinitionId: &definitionID,
+		})
+		require.NoError(t, err)
+		require.Empty(t, definitions)
+	})
+
+	t.Run("rejects invalid FEEL output expression syntax", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("invalidFeelOutputExpression")
+		definition := dmnDeploymentValidationStringOutputDefinition(t, definitionID, "1 +")
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(definition),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, response.StatusCode())
+		require.NotNil(t, response.JSON400)
+		require.Equal(t, "BAD_REQUEST", response.JSON400.Code)
+		require.Contains(t, response.JSON400.Message, `output entry "output-entry" contains invalid or unsupported FEEL expression "1 +"`)
+
+		definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+			DmnResourceDefinitionId: &definitionID,
+		})
+		require.NoError(t, err)
+		require.Empty(t, definitions)
+	})
+
+	t.Run("rejects a rule with fewer output entries than outputs", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("invalidOutputEntryCount")
+		definition := dmnDeploymentValidationOutputCountDefinition(definitionID)
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(definition),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, response.StatusCode())
+		require.NotNil(t, response.JSON400)
+		require.Equal(t, "BAD_REQUEST", response.JSON400.Code)
+		require.Contains(t, response.JSON400.Message, `rule "rule" has 1 output entries, expected 2`)
+
+		definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+			DmnResourceDefinitionId: &definitionID,
+		})
+		require.NoError(t, err)
+		require.Empty(t, definitions)
+	})
+
+	t.Run("rejects an invalid decision table nested in contexts", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("invalidNestedDecisionTable")
+		definition := dmnDeploymentValidationNestedContextDefinition(t, definitionID, "1 +")
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(definition),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, response.StatusCode())
+		require.NotNil(t, response.JSON400)
+		require.Equal(t, "BAD_REQUEST", response.JSON400.Code)
+		require.Contains(t, response.JSON400.Message, `input entry "nested-input-entry" contains invalid or unsupported FEEL unary test "1 +"`)
+
+		definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+			DmnResourceDefinitionId: &definitionID,
+		})
+		require.NoError(t, err)
+		require.Empty(t, definitions)
+	})
+
+	t.Run("accepts a string output expression that references a variable", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("validOutputVariable")
+		definition := dmnDeploymentValidationStringOutputDefinition(t, definitionID, "customerCategory")
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(definition),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, response.StatusCode())
+		require.NotNil(t, response.JSON201)
+		require.NotZero(t, response.JSON201.DmnResourceDefinitionKey)
+
+		definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+			DmnResourceDefinitionId: &definitionID,
+		})
+		require.NoError(t, err)
+		require.Len(t, definitions, 1)
+		require.Equal(t, definitionID, definitions[0].DmnResourceDefinitionId)
+		require.Equal(t, response.JSON201.DmnResourceDefinitionKey, definitions[0].Key)
+	})
+}
+
+func dmnDeploymentValidationDefinition(t testing.TB, definitionID string, inputType string, inputExpression string, inputEntry string) string {
+	t.Helper()
+
+	var escapedInputExpression strings.Builder
+	require.NoError(t, xml.EscapeText(&escapedInputExpression, []byte(inputExpression)))
+
+	var escapedInputEntry strings.Builder
+	require.NoError(t, xml.EscapeText(&escapedInputEntry, []byte(inputEntry)))
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="%s" name="DMN deployment validation" namespace="https://pbinitiative.com/zenbpm">
+  <decision id="%sDecision" name="DMN deployment validation decision">
+    <decisionTable id="decision-table" hitPolicy="FIRST">
+      <input id="input" label="Input">
+        <inputExpression id="input-expression" typeRef="%s">
+          <text>%s</text>
+        </inputExpression>
+      </input>
+      <output id="output" name="result" typeRef="number" />
+      <rule id="rule">
+        <inputEntry id="input-entry">
+          <text>%s</text>
+        </inputEntry>
+        <outputEntry id="output-entry">
+          <text>1</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>`, definitionID, definitionID, inputType, escapedInputExpression.String(), escapedInputEntry.String())
+}
+
+func dmnDeploymentValidationOutputCountDefinition(definitionID string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="%s" name="DMN deployment validation" namespace="https://pbinitiative.com/zenbpm">
+  <decision id="%sDecision" name="DMN deployment validation decision">
+    <decisionTable id="decision-table" hitPolicy="FIRST">
+      <input id="input" label="Input">
+        <inputExpression id="input-expression" typeRef="string">
+          <text>value</text>
+        </inputExpression>
+      </input>
+      <output id="output" name="result" typeRef="string" />
+      <output id="second-output" name="secondResult" typeRef="string" />
+      <rule id="rule">
+        <inputEntry id="input-entry">
+          <text>"VIP"</text>
+        </inputEntry>
+        <outputEntry id="output-entry">
+          <text>"result"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>`, definitionID, definitionID)
+}
+
+func dmnDeploymentValidationMissingVariableReferenceDefinition(definitionID string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="%s" name="DMN deployment validation" namespace="https://pbinitiative.com/zenbpm">
+  <decision id="%sDecision" name="DMN missing variable reference decision">
+    <decisionTable id="decision-table" hitPolicy="FIRST">
+      <input id="customer-type-input" label="Customer type">
+        <inputExpression id="customer-type-expression" typeRef="string">
+          <text>customer_type</text>
+        </inputExpression>
+      </input>
+      <input id="amount-input" label="Amount">
+        <inputExpression id="amount-expression" typeRef="number">
+          <text>amount</text>
+        </inputExpression>
+      </input>
+      <output id="discount-output" name="discount" typeRef="number" />
+      <rule id="vip-rule">
+        <inputEntry id="vip-customer-type-entry">
+          <text>VIP</text>
+        </inputEntry>
+        <inputEntry id="vip-amount-entry">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="vip-discount-entry">
+          <text>20</text>
+        </outputEntry>
+      </rule>
+      <rule id="low-amount-rule">
+        <inputEntry id="low-amount-customer-type-entry">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="low-amount-entry">
+          <text>&lt; 500</text>
+        </inputEntry>
+        <outputEntry id="low-amount-discount-entry">
+          <text>0</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>`, definitionID, definitionID)
+}
+
+func dmnDeploymentValidationNestedContextDefinition(t testing.TB, definitionID string, inputEntry string) string {
+	t.Helper()
+
+	var escapedInputEntry strings.Builder
+	require.NoError(t, xml.EscapeText(&escapedInputEntry, []byte(inputEntry)))
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="%s" name="DMN deployment validation" namespace="https://pbinitiative.com/zenbpm">
+  <decision id="%sDecision" name="DMN nested context validation decision">
+    <context>
+      <contextEntry>
+        <context>
+          <contextEntry>
+            <decisionTable id="nested-decision-table" hitPolicy="FIRST">
+              <input id="nested-input" label="Input">
+                <inputExpression id="nested-input-expression" typeRef="string">
+                  <text>value</text>
+                </inputExpression>
+              </input>
+              <output id="nested-output" name="result" typeRef="number" />
+              <rule id="nested-rule">
+                <inputEntry id="nested-input-entry">
+                  <text>%s</text>
+                </inputEntry>
+                <outputEntry id="nested-output-entry">
+                  <text>1</text>
+                </outputEntry>
+              </rule>
+            </decisionTable>
+          </contextEntry>
+        </context>
+      </contextEntry>
+    </context>
+  </decision>
+</definitions>`, definitionID, definitionID, escapedInputEntry.String())
+}
+
+func dmnDeploymentValidationStringOutputDefinition(t testing.TB, definitionID string, outputEntry string) string {
+	t.Helper()
+
+	var escapedOutputEntry strings.Builder
+	require.NoError(t, xml.EscapeText(&escapedOutputEntry, []byte(outputEntry)))
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="%s" name="DMN deployment validation" namespace="https://pbinitiative.com/zenbpm">
+  <decision id="%sDecision" name="DMN output expression validation decision">
+    <decisionTable id="decision-table" hitPolicy="FIRST">
+      <input id="input" label="Input">
+        <inputExpression id="input-expression" typeRef="string">
+          <text>value</text>
+        </inputExpression>
+      </input>
+      <output id="output" name="result" typeRef="string" />
+      <rule id="rule">
+        <inputEntry id="input-entry">
+          <text>"VIP"</text>
+        </inputEntry>
+        <outputEntry id="output-entry">
+          <text>%s</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>`, definitionID, definitionID, escapedOutputEntry.String())
+}

--- a/test/e2e/testdata/dmn/missing_input_entry_reference.dmn
+++ b/test/e2e/testdata/dmn/missing_input_entry_reference.dmn
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="Definitions_missing_input_entry_reference" name="Missing input entry reference" namespace="https://pbinitiative.com/zenbpm">
+  <decision id="dmn_missing_input_entry_reference" name="Missing input entry reference">
+    <decisionTable id="missing_input_entry_reference_table" hitPolicy="FIRST">
+      <input id="input_customer_type" label="Customer type">
+        <inputExpression id="input_expression_customer_type" typeRef="string">
+          <text>customer_type</text>
+        </inputExpression>
+      </input>
+      <input id="input_amount" label="Amount">
+        <inputExpression id="input_expression_amount" typeRef="number">
+          <text>amount</text>
+        </inputExpression>
+      </input>
+      <output id="output_discount" name="discount" typeRef="number" />
+      <rule id="rule_vip_customer">
+        <inputEntry id="rule_vip_customer_type">
+          <text>VIP</text>
+        </inputEntry>
+        <inputEntry id="rule_vip_amount">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="rule_vip_discount">
+          <text>20</text>
+        </outputEntry>
+      </rule>
+      <rule id="rule_low_amount">
+        <inputEntry id="rule_low_amount_customer_type">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="rule_low_amount_amount">
+          <text>&lt; 500</text>
+        </inputEntry>
+        <outputEntry id="rule_low_amount_discount">
+          <text>0</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment-time validation for DMN decision-table inputs, outputs, nested tables, and FEEL expressions.
  * Blank input entries are treated as wildcards, with improved variable-reference and expression handling.
* **Bug Fixes**
  * Invalid DMN deployments now return clear HTTP 400 responses instead of technical errors.
  * Decision evaluation more accurately reports unknown input variables and invalid expressions.
  * Custom FEEL runtimes must support the complete DMN runtime capabilities.
* **Tests**
  * Added comprehensive coverage for valid, invalid, nested, and persistence-related deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->