### PR TITLE
feat(#775): hash canonical XML form to avoid duplicate definitions

### DIFF
--- a/docs/reference/dmn/dmn-engine.md
+++ b/docs/reference/dmn/dmn-engine.md
@@ -23,11 +23,19 @@ Deploy over REST with `POST /dmn-resource-definitions`, which returns the `dmnRe
 
 ### Versioning
 
-Versions are derived on deployment, not declared in the file:
+Versions are derived on deployment, not declared in the file. The engine uses a two-step comparison:
 
-1. The engine computes an MD5 checksum of the XML and looks for existing resource definitions with the same `<definitions>` id.
-2. **If the checksum matches the latest existing version, nothing is stored** and the existing definition is returned. Redeploying an unchanged file is a no-op.
-3. Otherwise the resource definition is stored with `latest version + 1`, and every decision it contains is stored as `latest version of that decision id + 1`.
+1. The engine computes an MD5 checksum of the **raw** XML bytes and looks for existing resource definitions with the same `<definitions>` id.
+2. **Fast path — raw checksum matches:** if the raw checksum equals the latest existing version's checksum, the normalizer is skipped and the existing definition is returned. (The XML has already been unmarshalled and validated earlier in the deploy path, so this only avoids re-hashing for an identical re-deploy.)
+3. **Formatting-insensitive fallback:** if the raw checksums differ, both payloads are normalized and re-hashed. The normalizer sorts attributes, ignores inter-element whitespace inside structural elements (BPMN/DMN model and DI elements, plus the zenbpm/zeebe extension namespaces), and treats CDATA and entity spellings as equivalent. If the normalized hashes match, the redeploy is treated as a no-op and the existing definition is returned.
+4. **Otherwise** the resource definition is stored with `latest version + 1`, and every decision it contains is stored as `latest version of that decision id + 1`.
+
+The normalizer intentionally treats the following as semantically significant, so they always create a new version:
+
+- Any change to text content, including whitespace inside `xml:space="preserve"` regions and inside non-structural elements.
+- Any change to an attribute value, including the URI bound to a namespace prefix (renaming `xmlns:b="…"` to `xmlns:x="…"` is significant).
+- Adding, removing, or reordering child elements or comments.
+- Adding, removing, or renaming namespace declarations.
 
 Because decision versions are counted per decision id, a decision's version can differ from the version of the file that carries it.
 

--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"bytes"
 	"context"
 	"crypto/md5"
 	"encoding/json"
@@ -31,8 +30,10 @@ import (
 	"github.com/pbinitiative/zenbpm/internal/sql"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/model/bpmn20"
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	dmnmodel "github.com/pbinitiative/zenbpm/pkg/dmn/model/dmn"
 	"github.com/pbinitiative/zenbpm/pkg/ptr"
 	"github.com/pbinitiative/zenbpm/pkg/storage"
+	"github.com/pbinitiative/zenbpm/pkg/xmlutil"
 	"github.com/pbinitiative/zenbpm/pkg/zenflake"
 	"github.com/rqlite/rqlite/v10/cluster"
 	"github.com/rqlite/rqlite/v10/command"
@@ -389,12 +390,45 @@ func (node *ZenNode) getDmnResourceDefinitionKeyByBytes(ctx context.Context, dat
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database for dmn resource definition key lookup: %w", err)
 	}
-	md5sum := md5.Sum(data)
-	key, err := db.Queries.GetDmnResourceDefinitionKeyByChecksum(ctx, md5sum[:])
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return 0, fmt.Errorf("failed to find dmn resource definition by checksum: %w", err)
+
+	newChecksum := md5.Sum(data)
+	key, err := db.Queries.GetDmnResourceDefinitionKeyByChecksum(ctx, newChecksum[:])
+	if err == nil {
+		return key, nil
 	}
-	return key, nil
+	if !errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf("failed to find DMN resource definition by checksum: %w", err)
+	}
+
+	var definition dmnmodel.TDefinitions
+	if err := xml.Unmarshal(data, &definition); err != nil {
+		return 0, fmt.Errorf("failed to unmarshal DMN data: %w", err)
+	}
+	if definition.Id == "" {
+		return 0, fmt.Errorf("DMN resource definition ID is empty")
+	}
+
+	latest, err := db.Queries.FindLatestDmnResourceDefinitionById(ctx, definition.Id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to find latest DMN resource definition by id %s: %w", definition.Id, err)
+	}
+
+	sameContent, err := xmlutil.SameContent(
+		latest.DmnChecksum,
+		newChecksum[:],
+		[]byte(latest.DmnData),
+		data,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to compare DMN content for resource %s: %w", definition.Id, err)
+	}
+	if sameContent {
+		return latest.Key, nil
+	}
+	return 0, nil
 }
 
 func (node *ZenNode) EvaluateDecision(ctx context.Context, bindingType string, decisionId string, versionTag string, variables map[string]any) (*proto.EvaluatedDRDResult, error) {
@@ -516,8 +550,16 @@ func (node *ZenNode) GetDefinitionKeyByProcessId(ctx context.Context, processId 
 	}
 
 	newDefinitionMD5Sum := md5.Sum(newDefinitionData)
-
-	if bytes.Equal(latestDefinition.BpmnChecksum, newDefinitionMD5Sum[:]) {
+	sameContent, err := xmlutil.SameContent(
+		latestDefinition.BpmnChecksum,
+		newDefinitionMD5Sum[:],
+		[]byte(latestDefinition.BpmnData),
+		newDefinitionData,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to compare BPMN content for process %s: %w", processId, err)
+	}
+	if sameContent {
 		return latestDefinition.Key, nil
 	}
 	return 0, nil

--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -395,15 +395,10 @@ func (node *ZenNode) getDmnResourceDefinitionKeyByBytes(ctx context.Context, dat
 		return 0, fmt.Errorf("failed to get database for dmn resource definition key lookup: %w", err)
 	}
 
-	newChecksum := md5.Sum(data)
-	key, err := db.Queries.GetDmnResourceDefinitionKeyByChecksum(ctx, newChecksum[:])
-	if err == nil {
-		return key, nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return 0, fmt.Errorf("failed to find DMN resource definition by checksum: %w", err)
-	}
-
+	// Parse and validate the payload before any reuse lookup so the latest-definition
+	// comparison (and any validation errors) apply to every deployment. Looking up by
+	// raw checksum first would let an older version be reused after a newer one was
+	// deployed with different content, silently skipping the required new version.
 	var definition dmnmodel.TDefinitions
 	if err := xml.Unmarshal(data, &definition); err != nil {
 		return 0, zenerr.BadRequest(fmt.Errorf("failed to unmarshal DMN data: %w", err))
@@ -420,6 +415,7 @@ func (node *ZenNode) getDmnResourceDefinitionKeyByBytes(ctx context.Context, dat
 		return 0, fmt.Errorf("failed to find latest DMN resource definition by id %s: %w", definition.Id, err)
 	}
 
+	newChecksum := md5.Sum(data)
 	sameContent, err := xmlutil.SameContent(
 		latest.DmnChecksum,
 		newChecksum[:],

--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -323,6 +323,10 @@ func (node *ZenNode) GetDmnResourceDefinition(ctx context.Context, key int64) (p
 func (node *ZenNode) DeployDmnResourceDefinitionToAllPartitions(ctx context.Context, data []byte) (int64, bool, error) {
 	key, err := node.getDmnResourceDefinitionKeyByBytes(ctx, data)
 	if err != nil {
+		var zerr *zenerr.ZenError
+		if errors.As(err, &zerr) {
+			return key, false, zerr
+		}
 		return key, false, zenerr.TechnicalError(fmt.Errorf("failed to get dmn resource definition key by bytes: %w", err))
 	}
 	if key != 0 {
@@ -402,10 +406,10 @@ func (node *ZenNode) getDmnResourceDefinitionKeyByBytes(ctx context.Context, dat
 
 	var definition dmnmodel.TDefinitions
 	if err := xml.Unmarshal(data, &definition); err != nil {
-		return 0, fmt.Errorf("failed to unmarshal DMN data: %w", err)
+		return 0, zenerr.BadRequest(fmt.Errorf("failed to unmarshal DMN data: %w", err))
 	}
 	if definition.Id == "" {
-		return 0, fmt.Errorf("DMN resource definition ID is empty")
+		return 0, zenerr.BadRequest(fmt.Errorf("DMN resource definition ID is empty"))
 	}
 
 	latest, err := db.Queries.FindLatestDmnResourceDefinitionById(ctx, definition.Id)

--- a/internal/sql/dmn_resource_definition.sql.go
+++ b/internal/sql/dmn_resource_definition.sql.go
@@ -208,23 +208,6 @@ func (q *Queries) FindLatestDmnResourceDefinitionById(ctx context.Context, dmnRe
 	return i, err
 }
 
-const getDmnResourceDefinitionKeyByChecksum = `-- name: GetDmnResourceDefinitionKeyByChecksum :one
-SELECT
-    key
-FROM
-    dmn_resource_definition
-WHERE
-    dmn_checksum = ?1
-LIMIT 1
-`
-
-func (q *Queries) GetDmnResourceDefinitionKeyByChecksum(ctx context.Context, dmnChecksum []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getDmnResourceDefinitionKeyByChecksum, dmnChecksum)
-	var key int64
-	err := row.Scan(&key)
-	return key, err
-}
-
 const saveDmnResourceDefinition = `-- name: SaveDmnResourceDefinition :exec
 INSERT INTO dmn_resource_definition(key, version, dmn_resource_definition_id, dmn_data, dmn_checksum, dmn_definition_name)
     VALUES (?, ?, ?, ?, ?, ?)

--- a/internal/sql/querier.go
+++ b/internal/sql/querier.go
@@ -129,7 +129,6 @@ type Querier interface {
 	FindTokenMessageSubscriptions(ctx context.Context, arg FindTokenMessageSubscriptionsParams) ([]MessageSubscription, error)
 	FindTokenTimers(ctx context.Context, arg FindTokenTimersParams) ([]Timer, error)
 	GetAllTokensForProcessInstance(ctx context.Context, processInstanceKey int64) ([]ExecutionToken, error)
-	GetDmnResourceDefinitionKeyByChecksum(ctx context.Context, dmnChecksum []byte) (int64, error)
 	GetElementStatisticsByProcessDefinitionKey(ctx context.Context, processDefinitionKey int64) ([]GetElementStatisticsByProcessDefinitionKeyRow, error)
 	GetElementStatisticsByProcessInstanceKey(ctx context.Context, processInstanceKey int64) ([]GetElementStatisticsByProcessInstanceKeyRow, error)
 	GetFlowElementInstanceByKey(ctx context.Context, key int64) (FlowElementInstance, error)

--- a/internal/sql/queries/dmn_resource_definition.sql
+++ b/internal/sql/queries/dmn_resource_definition.sql
@@ -80,12 +80,3 @@ ORDER BY
 
 LIMIT @size OFFSET @offset;
 
--- name: GetDmnResourceDefinitionKeyByChecksum :one
-SELECT
-    key
-FROM
-    dmn_resource_definition
-WHERE
-    dmn_checksum = @dmn_checksum
-LIMIT 1;
-

--- a/pkg/bpmn/content_dedup_test.go
+++ b/pkg/bpmn/content_dedup_test.go
@@ -71,3 +71,50 @@ func TestLoadFromBytes_ContentChangeCreatesNewVersion(t *testing.T) {
 	assert.Equal(t, int32(2), second.Version)
 	assert.Equal(t, md5.Sum(changed), second.BpmnChecksum)
 }
+
+func TestLoadFromBytes_FormattingOnlyRedeployReusesDefinitionWithZenbpmExtensions(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+	require.NoError(t, engine.Start(t.Context()))
+	defer engine.Stop()
+
+	original := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="definitions" targetNamespace="urn:test">
+  <bpmn:process id="zenbpm-ext-test" name="ZenBPM ext test" isExecutable="true">
+    <bpmn:serviceTask id="task">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=a" target="x"/>
+          <zenbpm:output source="=x" target="y"/>
+        </zenbpm:ioMapping>
+        <zenbpm:taskDefinition type="worker"/>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+</bpmn:definitions>`)
+	formatted := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions id="definitions" targetNamespace="urn:test" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process name="ZenBPM ext test" id="zenbpm-ext-test" isExecutable="true">
+    <bpmn:serviceTask id="task">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping><zenbpm:input source="=a" target="x"/><zenbpm:output source="=x" target="y"/></zenbpm:ioMapping>
+        <zenbpm:taskDefinition type="worker"/>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+</bpmn:definitions>`)
+	require.NotEqual(t, md5.Sum(original), md5.Sum(formatted), "test inputs must exercise the fallback")
+
+	first, err := engine.LoadFromBytes(t.Context(), original, engine.generateKey())
+	require.NoError(t, err)
+	second, err := engine.LoadFromBytes(t.Context(), formatted, engine.generateKey())
+	require.NoError(t, err)
+
+	assert.Equal(t, first.Key, second.Key)
+	assert.Equal(t, int32(1), second.Version)
+	assert.Equal(t, md5.Sum(original), second.BpmnChecksum, "the stored checksum must remain the raw MD5")
+
+	definitions, err := store.FindProcessDefinitionsById(t.Context(), "zenbpm-ext-test")
+	require.NoError(t, err)
+	assert.Len(t, definitions, 1)
+}

--- a/pkg/bpmn/content_dedup_test.go
+++ b/pkg/bpmn/content_dedup_test.go
@@ -1,0 +1,73 @@
+package bpmn
+
+import (
+	"crypto/md5"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFromBytes_FormattingOnlyRedeployReusesDefinition(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+	require.NoError(t, engine.Start(t.Context()))
+	defer engine.Stop()
+
+	original := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="definitions" targetNamespace="urn:test">
+  <bpmn:process id="formatting-test" name="Formatting test" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+    <bpmn:endEvent id="end"/>
+    <bpmn:sequenceFlow id="flow" sourceRef="start" targetRef="end"/>
+  </bpmn:process>
+</bpmn:definitions>`)
+	formatted := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+
+<bpmn:definitions targetNamespace = 'urn:test' id = 'definitions' xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+  <bpmn:process isExecutable = 'true' name = 'Formatting test' id = 'formatting-test'>
+    <bpmn:startEvent id = 'start'></bpmn:startEvent>
+
+    <bpmn:endEvent id = 'end'></bpmn:endEvent>
+    <bpmn:sequenceFlow targetRef = 'end' sourceRef = 'start' id = 'flow'></bpmn:sequenceFlow>
+  </bpmn:process>
+
+</bpmn:definitions>
+`)
+	require.NotEqual(t, md5.Sum(original), md5.Sum(formatted), "test inputs must exercise the fallback")
+
+	first, err := engine.LoadFromBytes(t.Context(), original, engine.generateKey())
+	require.NoError(t, err)
+	second, err := engine.LoadFromBytes(t.Context(), formatted, engine.generateKey())
+	require.NoError(t, err)
+
+	assert.Equal(t, first.Key, second.Key)
+	assert.Equal(t, int32(1), second.Version)
+	assert.Equal(t, string(original), second.BpmnData)
+	assert.Equal(t, md5.Sum(original), second.BpmnChecksum, "the stored checksum must remain the raw MD5")
+
+	definitions, err := store.FindProcessDefinitionsById(t.Context(), "formatting-test")
+	require.NoError(t, err)
+	assert.Len(t, definitions, 1)
+}
+
+func TestLoadFromBytes_ContentChangeCreatesNewVersion(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+	require.NoError(t, engine.Start(t.Context()))
+	defer engine.Stop()
+
+	original := []byte(`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="definitions" targetNamespace="urn:test"><bpmn:process id="content-change" name="Original" isExecutable="true"><bpmn:startEvent id="start"/></bpmn:process></bpmn:definitions>`)
+	changed := []byte(`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="definitions" targetNamespace="urn:test"><bpmn:process id="content-change" name="Changed" isExecutable="true"><bpmn:startEvent id="start"/></bpmn:process></bpmn:definitions>`)
+
+	first, err := engine.LoadFromBytes(t.Context(), original, engine.generateKey())
+	require.NoError(t, err)
+	second, err := engine.LoadFromBytes(t.Context(), changed, engine.generateKey())
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first.Key, second.Key)
+	assert.Equal(t, int32(2), second.Version)
+	assert.Equal(t, md5.Sum(changed), second.BpmnChecksum)
+}

--- a/pkg/bpmn/xml_loader.go
+++ b/pkg/bpmn/xml_loader.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/xmlutil"
 
 	"github.com/pbinitiative/zenbpm/pkg/bpmn/model/bpmn20"
 )
@@ -61,7 +62,16 @@ func (engine *Engine) load(ctx context.Context, xmlData []byte, key int64) (*run
 				latest = &processes[i]
 			}
 		}
-		if latest.BpmnChecksum == md5sum {
+		sameContent, err := xmlutil.SameContent(
+			latest.BpmnChecksum[:],
+			md5sum[:],
+			[]byte(latest.BpmnData),
+			xmlData,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compare BPMN content for process %s: %w", definitions.Process.Id, err)
+		}
+		if sameContent {
 			return latest, nil
 		}
 		if err := engine.deleteProcessDefinitionSubscriptions(ctx, latest); err != nil {

--- a/pkg/dmn/content_dedup_test.go
+++ b/pkg/dmn/content_dedup_test.go
@@ -1,0 +1,62 @@
+package dmn
+
+import (
+	"bytes"
+	"crypto/md5"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveDmnResourceDefinition_FormattingOnlyRedeployReusesDefinition(t *testing.T) {
+	store := inmemory.NewStorage()
+	engine := NewEngine(EngineWithStorage(store))
+	defer engine.Stop()
+
+	original, err := os.ReadFile(filepath.Join("test-data", "bulk-evaluation-test", "can-autoliquidate-rule.dmn"))
+	require.NoError(t, err)
+	formatted := bytes.Replace(
+		original,
+		[]byte(">\n  <decision"),
+		[]byte(">\n\n\n  <decision"),
+		1,
+	)
+	require.NotEqual(t, original, formatted, "test fixture must contain the formatting insertion point")
+	require.NotEqual(t, md5.Sum(original), md5.Sum(formatted), "test inputs must exercise the fallback")
+
+	originalDefinition, err := engine.ParseDmnFromBytes("original.dmn", original)
+	require.NoError(t, err)
+	formattedDefinition, err := engine.ParseDmnFromBytes("formatted.dmn", formatted)
+	require.NoError(t, err)
+
+	first, firstDecisions, err := engine.SaveDmnResourceDefinition(
+		t.Context(),
+		originalDefinition,
+		original,
+		engine.generateKey(),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstDecisions)
+
+	second, secondDecisions, err := engine.SaveDmnResourceDefinition(
+		t.Context(),
+		formattedDefinition,
+		formatted,
+		engine.generateKey(),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, first.Key, second.Key)
+	assert.Equal(t, int64(1), second.Version)
+	assert.Equal(t, original, second.DmnData)
+	assert.Equal(t, md5.Sum(original), second.DmnChecksum, "the stored checksum must remain the raw MD5")
+	assert.Empty(t, secondDecisions)
+
+	definitions, err := store.FindDmnResourceDefinitionsById(t.Context(), originalDefinition.Id)
+	require.NoError(t, err)
+	assert.Len(t, definitions, 1)
+}

--- a/pkg/dmn/dmn_engine.go
+++ b/pkg/dmn/dmn_engine.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pbinitiative/zenbpm/pkg/script/feel"
 	"github.com/pbinitiative/zenbpm/pkg/storage"
 	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/pbinitiative/zenbpm/pkg/xmlutil"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -188,7 +189,16 @@ func (engine *ZenDmnEngine) saveDmnResourceDefinition(
 			}
 		}
 
-		if latest.DmnChecksum == dmnResourceDefinition.DmnChecksum {
+		sameContent, err := xmlutil.SameContent(
+			latest.DmnChecksum[:],
+			dmnResourceDefinition.DmnChecksum[:],
+			latest.DmnData,
+			dmnResourceDefinition.DmnData,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to compare DMN content for resource %s: %w", dmnResourceDefinition.Id, err)
+		}
+		if sameContent {
 			return latest, nil, nil
 		}
 		dmnResourceDefinition.Version = latest.Version + 1

--- a/pkg/xmlutil/content.go
+++ b/pkg/xmlutil/content.go
@@ -1,0 +1,244 @@
+// Package xmlutil provides XML content comparison helpers.
+package xmlutil
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/xml"
+	"fmt"
+	"hash"
+	"io"
+	"sort"
+)
+
+const (
+	xmlNamespace = "http://www.w3.org/XML/1998/namespace"
+
+	bpmnModelNamespace = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+	bpmnDINamespace    = "http://www.omg.org/spec/BPMN/20100524/DI"
+	ddDCNamespace      = "http://www.omg.org/spec/DD/20100524/DC"
+	ddDINamespace      = "http://www.omg.org/spec/DD/20100524/DI"
+
+	dmnModelNamespace   = "https://www.omg.org/spec/DMN/20191111/MODEL/"
+	dmnDINamespace      = "https://www.omg.org/spec/DMN/20191111/DMNDI/"
+	dmnDCNamespace      = "http://www.omg.org/spec/DMN/20180521/DC/"
+	dmnDiagramNamespace = "http://www.omg.org/spec/DMN/20180521/DI/"
+)
+
+// SameContent reports whether newData is the same XML document as storedData
+// ignoring XML formatting differences. Both checksums must be md5(raw).
+func SameContent(storedChecksum, newChecksum, storedData, newData []byte) (bool, error) {
+	if bytes.Equal(storedChecksum, newChecksum) {
+		return true, nil
+	}
+
+	storedNormalized, err := normalizedXMLHash(storedData)
+	if err != nil {
+		return false, fmt.Errorf("failed to normalize stored XML: %w", err)
+	}
+	newNormalized, err := normalizedXMLHash(newData)
+	if err != nil {
+		return false, fmt.Errorf("failed to normalize new XML: %w", err)
+	}
+	return storedNormalized == newNormalized, nil
+}
+
+// normalizedXMLHash hashes a length-prefixed token stream so attribute order,
+// quoting, and namespace-prefix spellings are normalized.
+func normalizedXMLHash(data []byte) ([sha256.Size]byte, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	digest := sha256.New()
+	writer := tokenHashWriter{Hash: digest}
+	writer.writeBytes([]byte("zenbpm:xml-format-v2"))
+
+	// Stack entries: xml:space=preserve?, has child element?, structural namespace?
+	preserveWhitespace := []bool{false}
+	elementHasChild := []bool{true}
+	structuralWhitespace := []bool{true}
+	var text []byte
+	flushText := func() {
+		if len(text) == 0 {
+			return
+		}
+		if preserveWhitespace[len(preserveWhitespace)-1] ||
+			!structuralWhitespace[len(structuralWhitespace)-1] ||
+			!elementHasChild[len(elementHasChild)-1] ||
+			!isXMLWhitespace(text) {
+			writer.writeToken('T', text)
+		}
+		text = text[:0]
+	}
+
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			flushText()
+			break
+		}
+		if err != nil {
+			return [sha256.Size]byte{}, err
+		}
+
+		if charData, ok := token.(xml.CharData); ok {
+			// Accumulate consecutive CharData tokens; CDATA and entity spellings
+			// decode to the same bytes, so coalescing is intentional.
+			text = append(text, charData...)
+			continue
+		}
+		if _, isStart := token.(xml.StartElement); isStart {
+			elementHasChild[len(elementHasChild)-1] = true
+		}
+		flushText()
+
+		switch typed := token.(type) {
+		case xml.StartElement:
+			attributes := append([]xml.Attr(nil), typed.Attr...)
+			sort.Slice(attributes, func(i, j int) bool {
+				left, right := attributes[i], attributes[j]
+				if left.Name.Space != right.Name.Space {
+					return left.Name.Space < right.Name.Space
+				}
+				if left.Name.Local != right.Name.Local {
+					return left.Name.Local < right.Name.Local
+				}
+				return left.Value < right.Value
+			})
+			for i := 1; i < len(attributes); i++ {
+				if attributes[i-1].Name == attributes[i].Name {
+					return [sha256.Size]byte{}, fmt.Errorf(
+						"duplicate attribute {%s}%s",
+						attributes[i].Name.Space,
+						attributes[i].Name.Local,
+					)
+				}
+			}
+
+			writer.writeByte('S')
+			writer.writeName(typed.Name)
+			writer.writeUint64(uint64(len(attributes)))
+			for _, attribute := range attributes {
+				writer.writeName(attribute.Name)
+				writer.writeBytes([]byte(attribute.Value))
+			}
+
+			preserve := preserveWhitespace[len(preserveWhitespace)-1]
+			for _, attribute := range attributes {
+				if attribute.Name.Space == xmlNamespace && attribute.Name.Local == "space" {
+					switch attribute.Value {
+					case "preserve":
+						preserve = true
+					case "default":
+						preserve = false
+					}
+				}
+			}
+			preserveWhitespace = append(preserveWhitespace, preserve)
+			elementHasChild = append(elementHasChild, false)
+			structuralWhitespace = append(structuralWhitespace, isStructuralElement(typed.Name))
+
+		case xml.EndElement:
+			writer.writeByte('E')
+			writer.writeName(typed.Name)
+			preserveWhitespace = preserveWhitespace[:len(preserveWhitespace)-1]
+			elementHasChild = elementHasChild[:len(elementHasChild)-1]
+			structuralWhitespace = structuralWhitespace[:len(structuralWhitespace)-1]
+		case xml.Comment:
+			writer.writeToken('C', typed)
+		case xml.ProcInst:
+			writer.writeToken('P', []byte(typed.Target), typed.Inst)
+		case xml.Directive:
+			writer.writeToken('D', typed)
+		default:
+			return [sha256.Size]byte{}, fmt.Errorf("unsupported XML token %T", token)
+		}
+	}
+
+	var result [sha256.Size]byte
+	copy(result[:], digest.Sum(nil))
+	return result, nil
+}
+
+type tokenHashWriter struct {
+	hash.Hash
+}
+
+func (writer tokenHashWriter) writeToken(kind byte, fields ...[]byte) {
+	writer.writeByte(kind)
+	writer.writeUint64(uint64(len(fields)))
+	for _, field := range fields {
+		writer.writeBytes(field)
+	}
+}
+
+func (writer tokenHashWriter) writeName(name xml.Name) {
+	writer.writeBytes([]byte(name.Space))
+	writer.writeBytes([]byte(name.Local))
+}
+
+func (writer tokenHashWriter) writeBytes(value []byte) {
+	writer.writeUint64(uint64(len(value)))
+	_, _ = writer.Write(value)
+}
+
+func (writer tokenHashWriter) writeUint64(value uint64) {
+	var encoded [8]byte
+	binary.BigEndian.PutUint64(encoded[:], value)
+	_, _ = writer.Write(encoded[:])
+}
+
+func (writer tokenHashWriter) writeByte(value byte) {
+	_, _ = writer.Write([]byte{value})
+}
+
+func isStructuralElement(name xml.Name) bool {
+	if name.Space == bpmnModelNamespace {
+		switch name.Local {
+		case "documentation",
+			"script",
+			"text",
+			"expression",
+			"formalExpression",
+			"completionCondition",
+			"from",
+			"to",
+			"activationCondition",
+			"condition",
+			"loopCardinality",
+			"conditionExpression",
+			"loopCondition",
+			"timeDate",
+			"timeDuration",
+			"timeCycle",
+			"transformation",
+			"baseElementWithMixedContent":
+			return false
+		default:
+			return true
+		}
+	}
+
+	switch name.Space {
+	case bpmnDINamespace,
+		ddDCNamespace,
+		ddDINamespace,
+		dmnModelNamespace,
+		dmnDINamespace,
+		dmnDCNamespace,
+		dmnDiagramNamespace:
+		return true
+	default:
+		return false
+	}
+}
+
+func isXMLWhitespace(value []byte) bool {
+	for _, character := range value {
+		switch character {
+		case ' ', '\t', '\r', '\n':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/xmlutil/content.go
+++ b/pkg/xmlutil/content.go
@@ -24,10 +24,27 @@ const (
 	dmnDINamespace      = "https://www.omg.org/spec/DMN/20191111/DMNDI/"
 	dmnDCNamespace      = "http://www.omg.org/spec/DMN/20180521/DC/"
 	dmnDiagramNamespace = "http://www.omg.org/spec/DMN/20180521/DI/"
+
+	zenbpmExtensionNamespace = "http://zenbpm.pbinitiative.org/1.0"
+	zeebeExtensionNamespace  = "http://camunda.org/schema/zeebe/1.0"
 )
 
 // SameContent reports whether newData is the same XML document as storedData
 // ignoring XML formatting differences. Both checksums must be md5(raw).
+//
+// The comparison first matches raw MD5 checksums as a fast path. If they differ,
+// both payloads are normalized and re-hashed. The normalizer ignores attribute
+// order, quote style, inter-element whitespace inside structural elements
+// (BPMN/DMN model and DI elements, plus zenbpm/zeebe extension namespaces), and
+// CDATA vs entity spellings.
+//
+// The normalizer intentionally treats the following as significant:
+//   - any text node content, including whitespace inside xml:space="preserve"
+//     regions and inside non-structural elements
+//   - attribute values, including the URI bound to a namespace prefix
+//     (renaming xmlns:b="…" to xmlns:x="…" is NOT considered equivalent)
+//   - namespace-prefix bindings themselves
+//   - comments, processing instructions, and document type declarations
 func SameContent(storedChecksum, newChecksum, storedData, newData []byte) (bool, error) {
 	if bytes.Equal(storedChecksum, newChecksum) {
 		return true, nil
@@ -45,7 +62,9 @@ func SameContent(storedChecksum, newChecksum, storedData, newData []byte) (bool,
 }
 
 // normalizedXMLHash hashes a length-prefixed token stream so attribute order,
-// quoting, and namespace-prefix spellings are normalized.
+// quoting, and inter-element whitespace inside structural elements are
+// normalized. Namespace-prefix bindings (xmlns:*) are NOT normalized — they
+// are part of the canonical content.
 func normalizedXMLHash(data []byte) ([sha256.Size]byte, error) {
 	decoder := xml.NewDecoder(bytes.NewReader(data))
 	digest := sha256.New()
@@ -225,7 +244,9 @@ func isStructuralElement(name xml.Name) bool {
 		dmnModelNamespace,
 		dmnDINamespace,
 		dmnDCNamespace,
-		dmnDiagramNamespace:
+		dmnDiagramNamespace,
+		zenbpmExtensionNamespace,
+		zeebeExtensionNamespace:
 		return true
 	default:
 		return false

--- a/pkg/xmlutil/content_test.go
+++ b/pkg/xmlutil/content_test.go
@@ -113,6 +113,68 @@ func TestSameContent_WhitespacePolicy(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, same)
 	})
+
+	t.Run("zenbpm:ioMapping structural indentation", func(t *testing.T) {
+		stored := []byte(`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0">
+  <bpmn:process id="p">
+    <zenbpm:ioMapping>
+      <zenbpm:input source="=a" target="x"/>
+      <zenbpm:input source="=b" target="y"/>
+    </zenbpm:ioMapping>
+  </bpmn:process>
+</bpmn:definitions>`)
+		formatted := []byte(`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0"><bpmn:process id="p"><zenbpm:ioMapping><zenbpm:input source="=a" target="x"/><zenbpm:input source="=b" target="y"/></zenbpm:ioMapping></bpmn:process></bpmn:definitions>`)
+		storedChecksum := md5.Sum(stored)
+		formattedChecksum := md5.Sum(formatted)
+
+		same, err := SameContent(storedChecksum[:], formattedChecksum[:], stored, formatted)
+
+		require.NoError(t, err)
+		assert.True(t, same)
+	})
+
+	t.Run("zeebe:ioMapping structural indentation (legacy namespace)", func(t *testing.T) {
+		stored := []byte(`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">
+  <bpmn:process id="p">
+    <zeebe:ioMapping>
+      <zeebe:input source="=a" target="x"/>
+      <zeebe:output source="=x" target="y"/>
+    </zeebe:ioMapping>
+  </bpmn:process>
+</bpmn:definitions>`)
+		formatted := []byte(`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"><bpmn:process id="p"><zeebe:ioMapping><zeebe:input source="=a" target="x"/><zeebe:output source="=x" target="y"/></zeebe:ioMapping></bpmn:process></bpmn:definitions>`)
+		storedChecksum := md5.Sum(stored)
+		formattedChecksum := md5.Sum(formatted)
+
+		same, err := SameContent(storedChecksum[:], formattedChecksum[:], stored, formatted)
+
+		require.NoError(t, err)
+		assert.True(t, same)
+	})
+
+	t.Run("zenbpm:taskHeaders and assignmentDefinition structural indentation", func(t *testing.T) {
+		stored := []byte(`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0">
+  <bpmn:process id="p">
+    <bpmn:userTask id="u">
+      <bpmn:extensionElements>
+        <zenbpm:taskHeaders>
+          <zenbpm:header key="a" value="1"/>
+          <zenbpm:header key="b" value="2"/>
+        </zenbpm:taskHeaders>
+        <zenbpm:assignmentDefinition assignee="x" candidateGroups="g1, g2"/>
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+  </bpmn:process>
+</bpmn:definitions>`)
+		formatted := []byte(`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0"><bpmn:process id="p"><bpmn:userTask id="u"><bpmn:extensionElements><zenbpm:taskHeaders><zenbpm:header key="a" value="1"/><zenbpm:header key="b" value="2"/></zenbpm:taskHeaders><zenbpm:assignmentDefinition assignee="x" candidateGroups="g1, g2"/></bpmn:extensionElements></bpmn:userTask></bpmn:process></bpmn:definitions>`)
+		storedChecksum := md5.Sum(stored)
+		formattedChecksum := md5.Sum(formatted)
+
+		same, err := SameContent(storedChecksum[:], formattedChecksum[:], stored, formatted)
+
+		require.NoError(t, err)
+		assert.True(t, same)
+	})
 }
 
 func TestSameContent_IsConservative(t *testing.T) {
@@ -170,6 +232,21 @@ func TestSameContent_IsConservative(t *testing.T) {
 			name:   "xml space preserve",
 			stored: `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xml:space="preserve"> <bpmn:process/></bpmn:definitions>`,
 			new:    `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xml:space="preserve"><bpmn:process/></bpmn:definitions>`,
+		},
+		{
+			name:   "zenbpm:ioMapping attribute value change",
+			stored: `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0"><zenbpm:ioMapping><zenbpm:input source="=a" target="x"/></zenbpm:ioMapping></bpmn:definitions>`,
+			new:    `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0"><zenbpm:ioMapping><zenbpm:input source="=b" target="x"/></zenbpm:ioMapping></bpmn:definitions>`,
+		},
+		{
+			name:   "zenbpm:ioMapping child added",
+			stored: `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0"><zenbpm:ioMapping><zenbpm:input source="=a" target="x"/></zenbpm:ioMapping></bpmn:definitions>`,
+			new:    `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0"><zenbpm:ioMapping><zenbpm:input source="=a" target="x"/><zenbpm:output source="=x" target="y"/></zenbpm:ioMapping></bpmn:definitions>`,
+		},
+		{
+			name:   "zeebe:ioMapping attribute value change (legacy namespace)",
+			stored: `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"><zeebe:ioMapping><zeebe:input source="=a" target="x"/></zeebe:ioMapping></bpmn:definitions>`,
+			new:    `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"><zeebe:ioMapping><zeebe:input source="=b" target="x"/></zeebe:ioMapping></bpmn:definitions>`,
 		},
 		{
 			name:   "BPMN DI coordinate",

--- a/pkg/xmlutil/content_test.go
+++ b/pkg/xmlutil/content_test.go
@@ -1,0 +1,224 @@
+package xmlutil
+
+import (
+	"crypto/md5"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSameContent_RawChecksumFastPath(t *testing.T) {
+	data := []byte(`not XML, but the raw bytes are identical`)
+	checksum := md5.Sum(data)
+
+	same, err := SameContent(checksum[:], checksum[:], nil, data)
+
+	require.NoError(t, err)
+	assert.True(t, same)
+}
+
+func TestSameContent_IgnoresXMLFormatting(t *testing.T) {
+	stored := []byte(`<?xml version="1.0"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:ext="urn:extension" id="definitions">
+  <bpmn:process id="process" name="Example">
+    <ext:value enabled="true">a&lt;b</ext:value>
+  </bpmn:process>
+</bpmn:definitions>`)
+	formatted := []byte(`<?xml version="1.0"?>
+
+<bpmn:definitions id = 'definitions' xmlns:ext="urn:extension" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+  <bpmn:process name='Example' id='process'>
+    <ext:value enabled = 'true'><![CDATA[a<b]]></ext:value>
+  </bpmn:process>
+
+</bpmn:definitions>
+`)
+	checksum := md5.Sum(stored)
+	formattedChecksum := md5.Sum(formatted)
+	require.NotEqual(t, checksum, formattedChecksum, "test inputs must exercise the fallback")
+
+	same, err := SameContent(checksum[:], formattedChecksum[:], stored, formatted)
+
+	require.NoError(t, err)
+	assert.True(t, same)
+}
+
+func TestSameContent_WhitespacePolicy(t *testing.T) {
+	t.Run("BPMN structural indentation", func(t *testing.T) {
+		stored := []byte(`<process xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+  <startEvent/>
+  <endEvent/>
+</process>`)
+		formatted := []byte(`<process xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"><startEvent/><endEvent/></process>`)
+		storedChecksum := md5.Sum(stored)
+		formattedChecksum := md5.Sum(formatted)
+
+		same, err := SameContent(storedChecksum[:], formattedChecksum[:], stored, formatted)
+
+		require.NoError(t, err)
+		assert.True(t, same)
+	})
+
+	t.Run("DMN structural indentation and line endings", func(t *testing.T) {
+		stored := []byte("<definitions xmlns=\"https://www.omg.org/spec/DMN/20191111/MODEL/\">\r\n  <decision/>\r\n  <decisionService/>\r\n</definitions>")
+		formatted := []byte(`<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"><decision/><decisionService/></definitions>`)
+		storedChecksum := md5.Sum(stored)
+		formattedChecksum := md5.Sum(formatted)
+
+		same, err := SameContent(storedChecksum[:], formattedChecksum[:], stored, formatted)
+
+		require.NoError(t, err)
+		assert.True(t, same)
+	})
+
+	t.Run("mixed-content whitespace in an extension namespace", func(t *testing.T) {
+		stored := []byte(`<definitions xmlns:e="urn:extension"><e:value><e:a/> <e:b/></e:value></definitions>`)
+		formatted := []byte(`<definitions xmlns:e="urn:extension"><e:value><e:a/><e:b/></e:value></definitions>`)
+		storedChecksum := md5.Sum(stored)
+		formattedChecksum := md5.Sum(formatted)
+
+		same, err := SameContent(storedChecksum[:], formattedChecksum[:], stored, formatted)
+
+		require.NoError(t, err)
+		assert.False(t, same)
+	})
+
+	t.Run("mixed-content whitespace in BPMN documentation", func(t *testing.T) {
+		stored := []byte(`<bpmn:documentation xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:e="urn:extension"><e:a/> <e:b/></bpmn:documentation>`)
+		formatted := []byte(`<bpmn:documentation xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:e="urn:extension"><e:a/><e:b/></bpmn:documentation>`)
+		storedChecksum := md5.Sum(stored)
+		formattedChecksum := md5.Sum(formatted)
+
+		same, err := SameContent(storedChecksum[:], formattedChecksum[:], stored, formatted)
+
+		require.NoError(t, err)
+		assert.False(t, same)
+	})
+
+	t.Run("BPMN DI structural indentation", func(t *testing.T) {
+		stored := []byte(`<bpmndi:BPMNDiagram xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC">
+  <bpmndi:BPMNPlane>
+    <bpmndi:BPMNShape><dc:Bounds x="10" y="20"/></bpmndi:BPMNShape>
+  </bpmndi:BPMNPlane>
+</bpmndi:BPMNDiagram>`)
+		formatted := []byte(`<bpmndi:BPMNDiagram xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"><bpmndi:BPMNPlane><bpmndi:BPMNShape><dc:Bounds x="10" y="20"/></bpmndi:BPMNShape></bpmndi:BPMNPlane></bpmndi:BPMNDiagram>`)
+		storedChecksum := md5.Sum(stored)
+		formattedChecksum := md5.Sum(formatted)
+
+		same, err := SameContent(storedChecksum[:], formattedChecksum[:], stored, formatted)
+
+		require.NoError(t, err)
+		assert.True(t, same)
+	})
+}
+
+func TestSameContent_IsConservative(t *testing.T) {
+	tests := []struct {
+		name   string
+		stored string
+		new    string
+	}{
+		{
+			name:   "element text whitespace",
+			stored: `<definitions><condition>${x > 10}</condition></definitions>`,
+			new:    `<definitions><condition>${x >  10}</condition></definitions>`,
+		},
+		{
+			name:   "whitespace-only BPMN expression",
+			stored: `<bpmn:conditionExpression xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"> </bpmn:conditionExpression>`,
+			new:    `<bpmn:conditionExpression xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"></bpmn:conditionExpression>`,
+		},
+		{
+			name:   "attribute value",
+			stored: `<definitions><extension value="one"/></definitions>`,
+			new:    `<definitions><extension value="two"/></definitions>`,
+		},
+		{
+			name:   "unknown extension content",
+			stored: `<definitions xmlns:e="urn:extension"><e:value>one</e:value></definitions>`,
+			new:    `<definitions xmlns:e="urn:extension"><e:value>two</e:value></definitions>`,
+		},
+		{
+			name:   "comment",
+			stored: `<definitions><!-- deployment note --><process/></definitions>`,
+			new:    `<definitions><process/></definitions>`,
+		},
+		{
+			name:   "namespace declaration",
+			stored: `<b:definitions xmlns:b="urn:bpmn"><b:process/></b:definitions>`,
+			new:    `<x:definitions xmlns:x="urn:bpmn"><x:process/></x:definitions>`,
+		},
+		{
+			name:   "XML declaration",
+			stored: `<?xml version="1.0"?><definitions/>`,
+			new:    `<definitions/>`,
+		},
+		{
+			name:   "non-XML whitespace text",
+			stored: "<definitions>\u00a0</definitions>",
+			new:    `<definitions/>`,
+		},
+		{
+			name:   "whitespace-only extension value",
+			stored: `<definitions xmlns:e="urn:extension"><e:value> </e:value></definitions>`,
+			new:    `<definitions xmlns:e="urn:extension"><e:value></e:value></definitions>`,
+		},
+		{
+			name:   "xml space preserve",
+			stored: `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xml:space="preserve"> <bpmn:process/></bpmn:definitions>`,
+			new:    `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xml:space="preserve"><bpmn:process/></bpmn:definitions>`,
+		},
+		{
+			name:   "BPMN DI coordinate",
+			stored: `<bpmndi:BPMNDiagram xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"><bpmndi:BPMNShape><dc:Bounds x="10" y="20"/></bpmndi:BPMNShape></bpmndi:BPMNDiagram>`,
+			new:    `<bpmndi:BPMNDiagram xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"><bpmndi:BPMNShape><dc:Bounds x="11" y="20"/></bpmndi:BPMNShape></bpmndi:BPMNDiagram>`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checksum := md5.Sum([]byte(test.stored))
+			newChecksum := md5.Sum([]byte(test.new))
+			same, err := SameContent(checksum[:], newChecksum[:], []byte(test.stored), []byte(test.new))
+			require.NoError(t, err)
+			assert.False(t, same)
+		})
+	}
+}
+
+func TestSameContent_ReturnsXMLParsingErrors(t *testing.T) {
+	t.Run("stored XML", func(t *testing.T) {
+		stored := []byte(`<definitions>`)
+		newData := []byte(`<definitions/>`)
+		newChecksum := md5.Sum(newData)
+		_, err := SameContent(make([]byte, md5.Size), newChecksum[:], stored, newData)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to normalize stored XML")
+	})
+
+	t.Run("new XML", func(t *testing.T) {
+		stored := []byte(`<definitions><process/></definitions>`)
+		checksum := md5.Sum(stored)
+		newData := []byte(`<definitions>`)
+		newChecksum := md5.Sum(newData)
+		_, err := SameContent(checksum[:], newChecksum[:], stored, newData)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to normalize new XML")
+	})
+
+	t.Run("duplicate attributes", func(t *testing.T) {
+		stored := []byte(`<definitions><process name="A"/></definitions>`)
+		checksum := md5.Sum(stored)
+		newData := []byte(`<definitions><process name="A" name="B"/></definitions>`)
+		newChecksum := md5.Sum(newData)
+		_, err := SameContent(checksum[:], newChecksum[:], stored, newData)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "duplicate attribute")
+	})
+}

--- a/test/e2e/decision_deployment_test.go
+++ b/test/e2e/decision_deployment_test.go
@@ -433,6 +433,56 @@ func TestDmnFormattingOnlyRedeployReturnsExistingDefinition(t *testing.T) {
 	require.Equal(t, 1, definitions[0].Version)
 }
 
+// TestDmnContentChangeAfterNewerVersionCreatesNewVersion guards against a regression where
+// redeploying an older DMN version after a newer one was already accepted would silently
+// reuse the older version's key. The deduplication must always compare the new payload
+// against the latest stored definition, not the first definition that happens to share a
+// raw checksum.
+func TestDmnContentChangeAfterNewerVersionCreatesNewVersion(t *testing.T) {
+	definitionID := uniqueDmnResourceDefinitionTestValue("contentChangeAfterNewer")
+	original := dmnDeploymentValidationDefinition(t, definitionID, "string", "value", `"VIP"`)
+	changed := dmnDeploymentValidationDefinition(t, definitionID, "string", "value", `"STANDARD"`)
+
+	first, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+		t.Context(),
+		"application/xml",
+		strings.NewReader(original),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, first.StatusCode())
+	require.NotNil(t, first.JSON201)
+	require.NotZero(t, first.JSON201.DmnResourceDefinitionKey)
+
+	second, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+		t.Context(),
+		"application/xml",
+		strings.NewReader(changed),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, second.StatusCode())
+	require.NotNil(t, second.JSON201)
+	require.NotZero(t, second.JSON201.DmnResourceDefinitionKey)
+	require.NotEqual(t, first.JSON201.DmnResourceDefinitionKey, second.JSON201.DmnResourceDefinitionKey, "content changes must produce a new definition key")
+
+	third, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+		t.Context(),
+		"application/xml",
+		strings.NewReader(original),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, third.StatusCode(), "redeploying an older version after a newer one was accepted must create a new version, not reuse the older one")
+	require.NotNil(t, third.JSON201)
+	require.NotZero(t, third.JSON201.DmnResourceDefinitionKey)
+	require.NotEqual(t, first.JSON201.DmnResourceDefinitionKey, third.JSON201.DmnResourceDefinitionKey, "the older version must not be reused after a newer one was accepted")
+	require.NotEqual(t, second.JSON201.DmnResourceDefinitionKey, third.JSON201.DmnResourceDefinitionKey, "the older version must not collide with the latest accepted version")
+
+	definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+		DmnResourceDefinitionId: &definitionID,
+	})
+	require.NoError(t, err)
+	require.Len(t, definitions, 3)
+}
+
 func dmnDeploymentValidationDefinition(t testing.TB, definitionID string, inputType string, inputExpression string, inputEntry string) string {
 	t.Helper()
 

--- a/test/e2e/decision_deployment_test.go
+++ b/test/e2e/decision_deployment_test.go
@@ -324,6 +324,39 @@ func TestDmnDeploymentValidation(t *testing.T) {
 	})
 }
 
+func TestDmnFormattingOnlyRedeployReturnsExistingDefinition(t *testing.T) {
+	definitionID := uniqueDmnResourceDefinitionTestValue("formattingOnly")
+	original := dmnDeploymentValidationDefinition(t, definitionID, "string", "value", `"VIP"`)
+	formatted := strings.Replace(original, ">\n  <decision", ">\n\n\n  <decision", 1)
+	require.NotEqual(t, original, formatted, "test inputs must exercise the formatting fallback")
+
+	first, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+		t.Context(),
+		"application/xml",
+		strings.NewReader(original),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, first.StatusCode())
+	require.NotNil(t, first.JSON201)
+
+	second, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+		t.Context(),
+		"application/xml",
+		strings.NewReader(formatted),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, second.StatusCode())
+	require.NotNil(t, second.JSON200)
+	require.Equal(t, first.JSON201.DmnResourceDefinitionKey, second.JSON200.DmnResourceDefinitionKey)
+
+	definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+		DmnResourceDefinitionId: &definitionID,
+	})
+	require.NoError(t, err)
+	require.Len(t, definitions, 1)
+	require.Equal(t, 1, definitions[0].Version)
+}
+
 func dmnDeploymentValidationDefinition(t testing.TB, definitionID string, inputType string, inputExpression string, inputEntry string) string {
 	t.Helper()
 

--- a/test/e2e/decision_deployment_test.go
+++ b/test/e2e/decision_deployment_test.go
@@ -322,6 +322,82 @@ func TestDmnDeploymentValidation(t *testing.T) {
 		require.Equal(t, definitionID, definitions[0].DmnResourceDefinitionId)
 		require.Equal(t, response.JSON201.DmnResourceDefinitionKey, definitions[0].Key)
 	})
+
+	t.Run("rejects malformed DMN XML", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("malformedXml")
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(`<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="`+definitionID+`" <<<unclosed`),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, response.StatusCode())
+		require.NotNil(t, response.JSON400)
+		require.Equal(t, "BAD_REQUEST", response.JSON400.Code)
+		require.Contains(t, response.JSON400.Message, "failed to unmarshal DMN data")
+
+		definitions, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+			DmnResourceDefinitionId: &definitionID,
+		})
+		require.NoError(t, err)
+		require.Empty(t, definitions)
+	})
+
+	t.Run("rejects a DMN definition missing a definitions ID", func(t *testing.T) {
+		definitionID := uniqueDmnResourceDefinitionTestValue("missingDefinitionsId")
+
+		missingID := `<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" name="DMN missing definitions id" namespace="https://pbinitiative.com/zenbpm">
+  <decision id="` + definitionID + `Decision" name="decision">
+    <decisionTable id="decision-table" hitPolicy="FIRST">
+      <input id="input" label="Input">
+        <inputExpression id="input-expression" typeRef="string">
+          <text>value</text>
+        </inputExpression>
+      </input>
+      <output id="output" name="result" typeRef="string" />
+      <rule id="rule">
+        <inputEntry id="input-entry">
+          <text>"VIP"</text>
+        </inputEntry>
+        <outputEntry id="output-entry">
+          <text>"ok"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>`
+
+		before, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{})
+		require.NoError(t, err)
+
+		response, err := app.restClient.CreateDmnResourceDefinitionWithBodyWithResponse(
+			t.Context(),
+			"application/xml",
+			strings.NewReader(missingID),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, response.StatusCode())
+		require.NotNil(t, response.JSON400)
+		require.Equal(t, "BAD_REQUEST", response.JSON400.Code)
+		require.Contains(t, response.JSON400.Message, "DMN resource definition ID is empty")
+
+		// The rejected payload has no definitions ID, so a faulty deployment could persist a
+		// row with an empty root ID that the per-definitionID filter below would not surface.
+		// Compare the full list before and after to detect any spurious persistence.
+		definitionsForID, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{
+			DmnResourceDefinitionId: &definitionID,
+		})
+		require.NoError(t, err)
+		require.Empty(t, definitionsForID)
+
+		after, err := listDecisionDefinitions(t, &zenclient.GetDmnResourceDefinitionsParams{})
+		require.NoError(t, err)
+		require.Len(t, after, len(before), "no DMN resource definition should be persisted when validation rejects the payload")
+	})
 }
 
 func TestDmnFormattingOnlyRedeployReturnsExistingDefinition(t *testing.T) {

--- a/test/e2e/process_definition_test.go
+++ b/test/e2e/process_definition_test.go
@@ -550,6 +550,47 @@ func TestRestApiProcessDefinitionErrors(t *testing.T) {
 		assert.Equal(t, 1, definitions[0].Version)
 	})
 
+	t.Run("CreateProcessDefinition - formatting-only inside zenbpm:ioMapping reuses definition", func(t *testing.T) {
+		processID := fmt.Sprintf("zenbpm-formatting-%d", time.Now().UnixNano())
+		original := []byte(fmt.Sprintf(`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="definitions" targetNamespace="urn:test">
+  <bpmn:process id="%s" name="zenbpm-formatting" isExecutable="true">
+    <bpmn:serviceTask id="t">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:input source="=a" target="x"/>
+          <zenbpm:output source="=x" target="y"/>
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+</bpmn:definitions>`, processID))
+		formatted := []byte(fmt.Sprintf(`<bpmn:definitions id="definitions" targetNamespace="urn:test" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process name="zenbpm-formatting" id="%s" isExecutable="true">
+    <bpmn:serviceTask id="t">
+      <bpmn:extensionElements>
+        <zenbpm:ioMapping><zenbpm:input source="=a" target="x"/><zenbpm:output source="=x" target="y"/></zenbpm:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+</bpmn:definitions>`, processID))
+		require.NotEqual(t, original, formatted, "test inputs must exercise the formatting fallback")
+
+		first, err := deployDefinitionFromBytes(t, original, "zenbpm-formatting-original.bpmn")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, first.StatusCode())
+		require.NotNil(t, first.JSON201)
+
+		second, err := deployDefinitionFromBytes(t, formatted, "zenbpm-formatting-redeploy.bpmn")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, second.StatusCode())
+		require.NotNil(t, second.JSON200)
+		assert.Equal(t, first.JSON201.ProcessDefinitionKey, second.JSON200.ProcessDefinitionKey)
+
+		definitions := getProcessDefinitionVersions(t, processID, false)
+		require.Len(t, definitions, 1)
+		assert.Equal(t, 1, definitions[0].Version)
+	})
+
 	t.Run("GetProcessDefinition - 404 for nonexistent key", func(t *testing.T) {
 		resp, err := app.restClient.GetProcessDefinitionWithResponse(t.Context(), int64(999999999))
 		require.NoError(t, err)

--- a/test/e2e/process_definition_test.go
+++ b/test/e2e/process_definition_test.go
@@ -521,6 +521,35 @@ func TestRestApiProcessDefinitionErrors(t *testing.T) {
 		assert.Equal(t, firstKey, resp.JSON200.ProcessDefinitionKey)
 	})
 
+	t.Run("CreateProcessDefinition - formatting-only deploy returns existing definition", func(t *testing.T) {
+		processID := fmt.Sprintf("formatting-only-%d", time.Now().UnixNano())
+		original := []byte(fmt.Sprintf(`<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="definitions" targetNamespace="urn:test"><bpmn:process id="%s" name="Formatting test" isExecutable="true"><bpmn:startEvent id="start"/></bpmn:process></bpmn:definitions>`, processID))
+		formatted := []byte(fmt.Sprintf(`<bpmn:definitions
+		targetNamespace = 'urn:test'
+		id = 'definitions'
+		xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+		<bpmn:process isExecutable = 'true' name = 'Formatting test' id = '%s'>
+			<bpmn:startEvent id = 'start'></bpmn:startEvent>
+		</bpmn:process>
+	</bpmn:definitions>`, processID))
+
+		first, err := deployDefinitionFromBytes(t, original, "formatting-original.bpmn")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, first.StatusCode())
+		require.NotNil(t, first.JSON201)
+
+		second, err := deployDefinitionFromBytes(t, formatted, "formatting-redeploy.bpmn")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, second.StatusCode())
+		require.NotNil(t, second.JSON200)
+		assert.Equal(t, first.JSON201.ProcessDefinitionKey, second.JSON200.ProcessDefinitionKey)
+
+		definitions := getProcessDefinitionVersions(t, processID, false)
+		require.Len(t, definitions, 1)
+		assert.Equal(t, 1, definitions[0].Version)
+	})
+
 	t.Run("GetProcessDefinition - 404 for nonexistent key", func(t *testing.T) {
 		resp, err := app.restClient.GetProcessDefinitionWithResponse(t.Context(), int64(999999999))
 		require.NoError(t, err)


### PR DESCRIPTION
closes #775 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Formatting-only BPMN and DMN redeployments now reuse existing definitions instead of creating unnecessary versions.
  * Substantive XML changes—including text, attributes, ordering, comments, or namespaces—correctly create new versions.
  * Invalid DMN XML or missing identifiers now returns a clear bad-request error.
  * Redeploying an older DMN version after newer changes now creates the correct distinct version.

* **Documentation**
  * Updated DMN versioning documentation to explain XML comparison and versioning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->