### PR TITLE
fix: handle legacy "<nil>" assignee sentinel and improve job assignme…

### DIFF
--- a/internal/rest/job_assignee_test.go
+++ b/internal/rest/job_assignee_test.go
@@ -1,0 +1,59 @@
+package rest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/internal/cluster/proto"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapProtoJobAssignee(t *testing.T) {
+	t.Run("omits the legacy nil sentinel", func(t *testing.T) {
+		assignee := "<nil>"
+
+		mapped, err := (&Server{}).mapProtoJob(testProtoJobWithAssignee(&assignee))
+		require.NoError(t, err)
+		require.Nil(t, mapped.Assignee)
+
+		encoded, err := json.Marshal(mapped)
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded), `"assignee"`)
+	})
+
+	t.Run("preserves an empty assignee", func(t *testing.T) {
+		assignee := ""
+
+		mapped, err := (&Server{}).mapProtoJob(testProtoJobWithAssignee(&assignee))
+		require.NoError(t, err)
+		require.NotNil(t, mapped.Assignee)
+		require.Empty(t, *mapped.Assignee)
+
+		encoded, err := json.Marshal(mapped)
+		require.NoError(t, err)
+		require.Contains(t, string(encoded), `"assignee":""`)
+	})
+
+	t.Run("preserves a configured assignee", func(t *testing.T) {
+		assignee := "john.doe"
+
+		mapped, err := (&Server{}).mapProtoJob(testProtoJobWithAssignee(&assignee))
+		require.NoError(t, err)
+		require.NotNil(t, mapped.Assignee)
+		require.Equal(t, assignee, *mapped.Assignee)
+
+		encoded, err := json.Marshal(mapped)
+		require.NoError(t, err)
+		require.Contains(t, string(encoded), `"assignee":"john.doe"`)
+	})
+}
+
+func testProtoJobWithAssignee(assignee *string) *proto.Job {
+	state := int64(runtime.ActivityStateActive)
+	return &proto.Job{
+		State:          &state,
+		InputVariables: []byte(`{}`),
+		Assignee:       assignee,
+	}
+}

--- a/internal/rest/job_assignee_test.go
+++ b/internal/rest/job_assignee_test.go
@@ -10,6 +10,16 @@ import (
 )
 
 func TestMapProtoJobAssignee(t *testing.T) {
+	t.Run("omits a nil assignee", func(t *testing.T) {
+		mapped, err := (&Server{}).mapProtoJob(testProtoJobWithAssignee(nil))
+		require.NoError(t, err)
+		require.Nil(t, mapped.Assignee)
+
+		encoded, err := json.Marshal(mapped)
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded), `"assignee"`)
+	})
+
 	t.Run("omits the legacy nil sentinel", func(t *testing.T) {
 		assignee := "<nil>"
 

--- a/internal/rest/server.go
+++ b/internal/rest/server.go
@@ -1957,6 +1957,11 @@ func (s *Server) mapProtoJob(job *proto.Job) (public.Job, error) {
 		return public.Job{}, stateErr
 	}
 
+	assignee := job.Assignee
+	if assignee != nil && *assignee == "<nil>" {
+		assignee = nil
+	}
+
 	return public.Job{
 		CreatedAt:          time.UnixMilli(job.GetCreatedAt()),
 		ElementId:          job.GetElementId(),
@@ -1968,7 +1973,7 @@ func (s *Server) mapProtoJob(job *proto.Job) (public.Job, error) {
 		Type:               job.GetType(),
 		InputVariables:     inputVars,
 		OutputVariables:    outputVars,
-		Assignee:           job.Assignee,
+		Assignee:           assignee,
 	}, nil
 }
 

--- a/pkg/bpmn/jobs.go
+++ b/pkg/bpmn/jobs.go
@@ -46,12 +46,13 @@ func (engine *Engine) createInternalTask(
 			return job.State, fmt.Errorf("failed to create job: %w", err)
 		}
 
-		// Cast the result to string
-		assigneeStr, ok := assigneeResult.(string)
-		if !ok {
-			assigneeStr = fmt.Sprintf("%v", assigneeResult)
+		if assigneeResult != nil {
+			assigneeStr, ok := assigneeResult.(string)
+			if !ok {
+				assigneeStr = fmt.Sprintf("%v", assigneeResult)
+			}
+			job.Assignee = new(assigneeStr)
 		}
-		job.Assignee = new(assigneeStr)
 	}
 
 	err := batch.SaveJob(ctx, job)

--- a/test/e2e/flow_element_test.go
+++ b/test/e2e/flow_element_test.go
@@ -74,9 +74,7 @@ func TestGetFlowElementInstanceHistory(t *testing.T) {
 		assert.Equal(t, 1, children.JSON200.TotalCount)
 		assert.Equal(t, zenclient.ProcessInstanceProcessType("multiInstance"), children.JSON200.Partitions[0].Items[0].ProcessType)
 		childKey := children.JSON200.Partitions[0].Items[0].Key
-		history, err := app.restClient.GetHistoryWithResponse(t.Context(), childKey, &zenclient.GetHistoryParams{})
-		assert.NoError(t, err)
-		assert.Equal(t, 1, history.JSON200.TotalCount)
+		requireHistoryTotalCount(t, childKey, 1)
 	})
 
 	t.Run("get history callActivity", func(t *testing.T) {
@@ -99,9 +97,7 @@ func TestGetFlowElementInstanceHistory(t *testing.T) {
 		assert.Equal(t, 1, children.JSON200.TotalCount)
 		assert.Equal(t, zenclient.ProcessInstanceProcessType("callActivity"), children.JSON200.Partitions[0].Items[0].ProcessType)
 		childKey := children.JSON200.Partitions[0].Items[0].Key
-		history, err := app.restClient.GetHistoryWithResponse(t.Context(), childKey, &zenclient.GetHistoryParams{})
-		assert.NoError(t, err)
-		assert.Equal(t, 3, history.JSON200.TotalCount)
+		requireHistoryTotalCount(t, childKey, 3)
 	})
 
 	t.Run("get history subprocess", func(t *testing.T) {
@@ -124,9 +120,7 @@ func TestGetFlowElementInstanceHistory(t *testing.T) {
 		assert.Equal(t, 1, children.JSON200.TotalCount)
 		assert.Equal(t, zenclient.ProcessInstanceProcessType("subprocess"), children.JSON200.Partitions[0].Items[0].ProcessType)
 		childKey := children.JSON200.Partitions[0].Items[0].Key
-		history, err := app.restClient.GetHistoryWithResponse(t.Context(), childKey, &zenclient.GetHistoryParams{})
-		assert.NoError(t, err)
-		assert.Equal(t, 3, history.JSON200.TotalCount)
+		requireHistoryTotalCount(t, childKey, 3)
 	})
 
 	assert.NoError(t, err)
@@ -231,4 +225,19 @@ func TestGetFlowElementHistoryElementType(t *testing.T) {
 		assert.Equal(t, expectedType, fe.ElementType,
 			"element %s should be reported as %s", elementID, expectedType)
 	}
+}
+
+func requireHistoryTotalCount(t testing.TB, processInstanceKey int64, expected int) {
+	t.Helper()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		history, err := app.restClient.GetHistoryWithResponse(t.Context(), processInstanceKey, &zenclient.GetHistoryParams{})
+		if !assert.NoError(collect, err) || !assert.NotNil(collect, history) {
+			return
+		}
+		if !assert.NotNil(collect, history.JSON200) {
+			return
+		}
+		assert.Equal(collect, expected, history.JSON200.TotalCount)
+	}, 15*time.Second, 100*time.Millisecond,
+		"process instance %d should reach history size %d", processInstanceKey, expected)
 }

--- a/test/e2e/user_task_assignment_test.go
+++ b/test/e2e/user_task_assignment_test.go
@@ -1,17 +1,15 @@
 package e2e
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/pbinitiative/zenbpm/internal/rest/public"
 	"github.com/pbinitiative/zenbpm/pkg/ptr"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
 	"github.com/stretchr/testify/require"
 )
 
-// TestUserTaskAssignment verifies that a User Task with a configured
-// non-default job type ("approval") is correctly assigned to its static
-// assignee and that the dynamic-assignment path still resolves a job type
-// to its configured assignee via process variables.
 func TestUserTaskAssignment(t *testing.T) {
 
 	t.Run("The user task assignee is mapped from the configured static value.", func(t *testing.T) {
@@ -41,5 +39,40 @@ func TestUserTaskAssignment(t *testing.T) {
 
 		job := waitForProcessInstanceJobByElementId(t, processInstance.Key, "user_task_dynamic", public.JobStateActive)
 		require.Equal(t, assignee, ptr.Deref(job.Assignee, ""))
+	})
+
+	t.Run("A user task without assignment returns an empty assignee.", func(t *testing.T) {
+
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/user_task/user_task_minimal.bpmn", nil)
+
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		job := waitForProcessInstanceJobByElementId(t, processInstance.Key, "user_task", public.JobStateActive)
+		require.NotNil(t, job.Assignee)
+		require.Empty(t, *job.Assignee)
+	})
+
+	t.Run("A missing dynamic assignee is omitted from the jobs response.", func(t *testing.T) {
+
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/user_task/user_tasks_with_dynamic_assignment.bpmn", nil)
+
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		job := waitForProcessInstanceJobByElementId(t, processInstance.Key, "user_task_dynamic", public.JobStateActive)
+		require.Nil(t, job.Assignee)
+
+		state := zenclient.JobStateActive
+		response, err := app.restClient.GetJobsWithResponse(t.Context(), &zenclient.GetJobsParams{
+			ProcessInstanceKey: &processInstance.Key,
+			State:              &state,
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, response.StatusCode())
+		require.NotContains(t, string(response.Body), `"assignee"`)
+		require.NotContains(t, string(response.Body), "<nil>")
 	})
 }


### PR DESCRIPTION
…nt logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected job assignee handling when no assignee is provided.
  * Prevented the literal `"<nil>"` value from appearing in job responses.
  * Unassigned tasks now correctly omit the assignee field from JSON responses.
  * Dynamic assignees that cannot be resolved are no longer reported as assigned.

* **Tests**
  * Added coverage for empty, missing, legacy, and configured assignee values across REST and end-to-end workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->