### PR TITLE
feat(#538): support start event output mappings and add E2E tests

### DIFF
--- a/docs/reference/bpmn/supported-elements/events/index.mdx
+++ b/docs/reference/bpmn/supported-elements/events/index.mdx
@@ -128,6 +128,8 @@ The trigger depends on the type:
 - **[Message start event](./message-events.md#message-start-event)** — a new instance is created each time a matching message is published.
 - **[Timer start event](./timer-events.md#timer-start-event)** — instances are created on a schedule, without any external trigger.
 
+A none start event can use `zenbpm:output` mappings to initialize or derive process variables from literals and variables supplied when the instance is created. Start events do not support `zenbpm:input` mappings; variables supplied through the create-instance API already belong to the root process scope.
+
 Start events also appear inside an [Event sub process](../activities/event-sub-process.md), where message, timer, and error triggers are supported and the start event may be non-interrupting.
 
 ## Intermediate events

--- a/docs/reference/bpmn/supported-elements/events/index.mdx
+++ b/docs/reference/bpmn/supported-elements/events/index.mdx
@@ -128,7 +128,9 @@ The trigger depends on the type:
 - **[Message start event](./message-events.md#message-start-event)** — a new instance is created each time a matching message is published.
 - **[Timer start event](./timer-events.md#timer-start-event)** — instances are created on a schedule, without any external trigger.
 
-A none start event can use `zenbpm:output` mappings to initialize or derive process variables from literals and variables supplied when the instance is created. Start events do not support `zenbpm:input` mappings; variables supplied through the create-instance API already belong to the root process scope.
+At the top level, none and timer start events can use `zenbpm:output` mappings to initialize or derive root process variables before the outgoing flow runs. A none start event evaluates mappings against the variables supplied when the instance is created; a timer start creates an instance with an empty root scope, which mappings can initialize from literals or expressions. Mapped values add to or overwrite existing root variables.
+
+For a top-level message start event, output mappings evaluate against the message payload before the instance is created. Without mappings, the full payload becomes the instance's initial variables; with mappings, only the mapped values do. Start events do not support `zenbpm:input` mappings; variables supplied through the create-instance API already belong to the root process scope.
 
 Start events also appear inside an [Event sub process](../activities/event-sub-process.md), where message, timer, and error triggers are supported and the start event may be non-interrupting.
 
@@ -163,13 +165,17 @@ What happens when the token arrives depends on the type:
 
 ## Variables
 
-Events handle variables differently from activities — the direction of the event decides which mappings apply:
+Events handle variables differently from activities. The event type determines which mappings apply:
 
 | Event kind                                                                                        | Mappings          | Behavior                                                                                                                                                                                                                                       |
 | ------------------------------------------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Catching events that receive a payload — message start, message catch, message boundary, error boundary | `zenbpm:output`   | **Without output mappings, the entire payload is propagated** to the catching scope as-is. Add output mappings to propagate only selected variables — except on message start events, where the full payload always becomes the new instance's variables. Note that this is the opposite default from activities, which propagate nothing unmapped. |
+| Catching events that receive a payload — message start, message catch, message boundary, error boundary | `zenbpm:output`   | **Without output mappings, the entire payload is propagated** to the catching scope as-is. With output mappings, only mapped values are propagated. For message starts, these become the new instance's initial variables. This is the opposite default from activities, which propagate nothing unmapped. |
 | Throwing message events — message intermediate throw, message end                                  | `zenbpm:input` / `zenbpm:output` | Executed as a job, exactly like a [Send task](../activities/tasks/send-task.md): input mappings prepare the variables the worker sees, output mappings propagate the worker's result following the activity rules.                              |
-| Timer and link events                                                                             | —                 | Carry no payload; the process variables are unchanged.                                                                                                                                                                                         |
+| Top-level none start events                                                                       | `zenbpm:output`   | Evaluate mappings against create-instance root variables and add or overwrite mapped values before the outgoing flow. Without mappings, the supplied variables remain unchanged. |
+| Top-level timer start events                                                                      | `zenbpm:output`   | Carry no payload. Mappings can initialize root variables before the outgoing flow; a scheduled instance starts with an empty root scope. |
+| Timer boundary events                                                                             | `zenbpm:output`   | Carry no payload. When the timer fires, mappings evaluate against the containing process scope and propagate mapped values to it. Without mappings, variables remain unchanged. |
+| Timer intermediate catch events                                                                   | —                 | Carry no payload and do not apply output mappings; process variables remain unchanged, including when the timer follows an event-based gateway. |
+| Link throw and catch events                                                                       | `zenbpm:output`   | Carry no payload. Each event can derive or overwrite process variables; the catch event can read values mapped by the throw event. Without mappings, variables remain unchanged. |
 
 See [Variables](../../variable-mapping.md) for the full propagation rules.
 

--- a/docs/reference/bpmn/supported-elements/events/link-events.md
+++ b/docs/reference/bpmn/supported-elements/events/link-events.md
@@ -41,12 +41,13 @@ Both sides carry a `bpmn:linkEventDefinition` whose `name` pairs them up.
 | Markup                     | Attribute | Required | Description                                                                                      |
 | -------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `bpmn:linkEventDefinition` | `name`    | yes      | The link name. Throw and catch events with the same name in the same process form a pair.        |
+| `zenbpm:ioMapping` → `zenbpm:output` | `source`, `target` | no | Derives or overwrites process variables on either the throw or catch event. Expressions read the current process scope. |
 
 Rules:
 
 - The throw event has one incoming sequence flow and **no outgoing flow**; the catch event has one outgoing sequence flow and **no incoming flow**.
 - Throw and catch must be in the same process — a link cannot cross a process or sub process boundary.
-- When a token reaches the throw event, it continues immediately at the matching catch event's outgoing flow. There is no wait state, and the process variables are unchanged.
+- When a token reaches the throw event, it continues immediately to the matching catch event and its outgoing flow. There is no wait state. Without output mappings, process variables remain unchanged; with mappings, the throw event propagates its mapped values first, and the catch event can read and map those values before continuing.
 - A throw event whose link name has no matching catch event fails the token at runtime.
 
 ### Link intermediate throw event

--- a/docs/reference/bpmn/supported-elements/events/message-events.md
+++ b/docs/reference/bpmn/supported-elements/events/message-events.md
@@ -63,7 +63,7 @@ Message start, message intermediate catch, and message boundary events receive m
 | `bpmn:message`                            | `name`           | yes      | The message name. Publishers address messages by this name.                                                                                                                                        |
 | `bpmn:message` → `zenbpm:subscription`    | `correlationKey` | recommended | A literal value or a FEEL expression (prefixed with `=`) evaluated against the instance variables when the subscription is created; a published message must carry the same key to be correlated. Without it, messages are matched by name alone, so any waiting instance can consume the publish. Not used by message start events. |
 | `bpmn:messageEventDefinition`             | `messageRef`     | yes      | References the `bpmn:message` this event waits for.                                                                                                                                                |
-| `zenbpm:ioMapping` → `zenbpm:output`      | `source`, `target` | no     | Filters which payload variables are propagated to the instance. Catching events have no input side. Not applied on message start events. See [Variables](../../variable-mapping.md).                      |
+| `zenbpm:ioMapping` → `zenbpm:output`      | `source`, `target` | no     | Maps payload values to instance variables, including on message start events. Without mappings, the full payload is propagated; with mappings, only mapped values are propagated. Catching events have no input side. See [Variables](../../variable-mapping.md). |
 
 How a message reaches a catching event:
 
@@ -74,7 +74,9 @@ How a message reaches a catching event:
 
 #### Message start event
 
-Starts a new process instance whenever a matching message is published. The subscription exists at the process definition level, so no correlation key is involved — every published message with the matching name creates a fresh instance, and the full message payload becomes the instance's initial variables (output mappings are not applied on start events). Note that each published message is consumed by exactly one subscription: if several deployed processes subscribe to the same message name, one publish creates a single instance, not one per process.
+Starts a new process instance whenever a matching message is published. The subscription exists at the process definition level, so no correlation key is involved. Without output mappings, the full message payload becomes the instance's initial variables. With `zenbpm:output` mappings, expressions evaluate against the payload before instance creation and only the mapped values become initial variables; unmapped payload fields are omitted. The start-event token does not evaluate these mappings again. If mapping evaluation fails, the subscription remains available and no instance is created.
+
+Each published message is consumed by exactly one subscription: if several deployed processes subscribe to the same message name, one publish creates a single instance, not one per process.
 
 A message start event inside an [Event sub process](../activities/event-sub-process.md) works differently: its subscription is created per instance of the containing scope and **does** use a correlation key.
 

--- a/docs/reference/bpmn/supported-elements/events/timer-events.md
+++ b/docs/reference/bpmn/supported-elements/events/timer-events.md
@@ -65,11 +65,15 @@ Where each specification applies:
 
 Schedules process instance creation without any external trigger. A `timeDate` timer creates one instance at the given moment; a `timeCycle` timer creates an instance at each occurrence and re-arms itself until the cycle's repetitions or end date are exhausted. The schedule is registered when the process definition is deployed.
 
+A top-level timer start carries no payload and creates an instance with an empty root variable scope. It supports `zenbpm:output` mappings that initialize root variables from literals or expressions before the outgoing flow runs. A mapping evaluation failure creates an incident on the start event and leaves the root variables unchanged.
+
 A timer start event inside an [Event sub process](../activities/event-sub-process.md) additionally supports `timeDuration`, measured from when its containing scope becomes active.
 
 ### Timer intermediate catch event
 
 Pauses the flow: the token waits at the event until the timer fires — after a `timeDuration` measured from the token's arrival, or at an absolute `timeDate` — and then continues along the outgoing flow. Together with an [Event-based gateway](../gateways/event-based-gateway.md), a timer catch event commonly models a timeout branch racing against a message.
+
+Timer intermediate catch events carry no payload and do not apply output mappings. Process variables remain unchanged, including when the timer follows an event-based gateway.
 
 ### Timer boundary event
 
@@ -77,6 +81,8 @@ Arms a timer when the attached activity starts and cancels it when the activity 
 
 - **Interrupting** (solid border) — the activity is cancelled and the token continues along the boundary event's outgoing flow. Use for timeouts and SLAs.
 - **Non-interrupting** (dashed border, `cancelActivity="false"`) — the activity keeps running and a parallel token is created on the outgoing flow. With a `timeCycle`, the timer re-arms after each occurrence for as long as the activity is active — use for repeated reminders.
+
+Timer boundary events support `zenbpm:output` mappings. When the timer fires, expressions evaluate against the containing process scope and mapped values are propagated to that scope before the outgoing flow. Without mappings, the timer adds no variables.
 
 ## Related documentation
 

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -1000,12 +1000,16 @@ func (engine *Engine) processFlowNode(
 
 	switch element := activity.Element().(type) {
 	case *bpmn20.TStartEvent:
+		outputVariables, err := engine.applyStartEventOutputMappings(instance, element)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate StartEvent output mappings %d: %w", activity.GetKey(), err)
+		}
 		tokens, err := engine.handleElementTransition(ctx, batch, instance, element, currentToken)
 		if err != nil {
 			flowNodeSpan.SetStatus(codes.Error, err.Error())
 			return nil, fmt.Errorf("failed to process StartEvent flow transition %d: %w", activity.GetKey(), err)
 		}
-		if err := engine.completeStartEventFlowElementInstance(ctx, batch, instance, element, currentToken); err != nil {
+		if err := engine.completeStartEventFlowElementInstance(ctx, batch, instance, element, currentToken, outputVariables); err != nil {
 			return nil, fmt.Errorf("failed to complete StartEvent history %d: %w", activity.GetKey(), err)
 		}
 		return tokens, nil
@@ -1110,16 +1114,8 @@ func (engine *Engine) completeStartEventFlowElementInstance(
 	instance runtime.ProcessInstance,
 	element *bpmn20.TStartEvent,
 	token runtime.ExecutionToken,
+	outputVariables map[string]any,
 ) error {
-	var outputVariables map[string]any
-	// Unmapped message payload already lives on the process instance. Keep history
-	// compact by recording only an explicitly mapped start-event output.
-	if instance.Type() == runtime.ProcessTypeDefault &&
-		isMessageStartEvent(element) &&
-		len(element.GetOutputMapping()) > 0 {
-		outputVariables = maps.Clone(instance.ProcessInstance().VariableHolder.LocalVariables())
-	}
-
 	return batch.UpdateOutputFlowElementInstance(ctx, runtime.FlowElementInstance{
 		Key:                token.ElementInstanceKey,
 		ProcessInstanceKey: instance.ProcessInstance().GetInstanceKey(),
@@ -1129,6 +1125,29 @@ func (engine *Engine) completeStartEventFlowElementInstance(
 		OutputVariables:    outputVariables,
 		CompletedAt:        new(time.Now()),
 	})
+}
+
+func (engine *Engine) applyStartEventOutputMappings(instance runtime.ProcessInstance, element *bpmn20.TStartEvent) (map[string]any, error) {
+	if instance.Type() != runtime.ProcessTypeDefault || len(element.GetOutputMapping()) == 0 {
+		return nil, nil
+	}
+
+	// Message-start output mappings are evaluated before the process instance is created,
+	// so its root variables already contain exactly the mapped payload. Do not evaluate
+	// them a second time when the new instance executes its start-event token.
+	if isMessageStartEvent(element) {
+		return maps.Clone(instance.ProcessInstance().VariableHolder.LocalVariables()), nil
+	}
+
+	// A none (or timer) start event has no trigger-local scope. Evaluate its output
+	// mappings against the variables already present on the root process instance and
+	// propagate the mapped values back into that root scope before the outgoing flow runs.
+	startEventVariables := runtime.NewVariableHolder(&instance.ProcessInstance().VariableHolder, nil)
+	return startEventVariables.PropagateMappedOutputsOrAll(
+		element.GetOutputMapping(),
+		nil,
+		engine.evaluateExpression,
+	)
 }
 
 // completeFlowElementInstance updates the history row keyed by token.ElementInstanceKey.

--- a/pkg/bpmn/engine_api.go
+++ b/pkg/bpmn/engine_api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"strconv"
 	"time"
@@ -326,7 +327,19 @@ mainLoop:
 			continue
 		}
 
-		updatedTokens, err := engine.processFlowNode(ctx, &batch, instance, activity, currentToken)
+		executionInstance := instance
+		if startEvent, ok := activity.Element().(*bpmn20.TStartEvent); ok && len(startEvent.GetOutputMapping()) > 0 && !isMessageStartEvent(startEvent) {
+			if defaultInstance, ok := instance.(*runtime.DefaultProcessInstance); ok {
+				mappedInstance := *defaultInstance
+				mappedInstance.VariableHolder = runtime.NewVariableHolder(nil, maps.Clone(defaultInstance.VariableHolder.LocalVariables()))
+				executionInstance = &mappedInstance
+				batch.AddPostFlushAction(ctx, func() {
+					defaultInstance.VariableHolder = mappedInstance.VariableHolder
+				})
+			}
+		}
+
+		updatedTokens, err := engine.processFlowNode(ctx, &batch, executionInstance, activity, currentToken)
 		if err != nil {
 			runErr = errors.Join(runErr, err)
 			if isTechnicalFailure(err) {
@@ -351,17 +364,12 @@ mainLoop:
 			endErrorSpan(tokenSpan, saveErr)
 			return errors.Join(newEngineErrorf("failed to run process instance %d", instance.ProcessInstance().Key), runErr)
 		}
-		for _, tok := range updatedTokens {
-			if tok.State == runtime.TokenStateRunning {
-				runningExecutionTokens = append(runningExecutionTokens, tok)
-			}
-		}
-
 		// if we encounter any error we switch the instance to failed state
 		if runErr != nil {
 			instance.ProcessInstance().State = runtime.ActivityStateFailed
+			executionInstance.ProcessInstance().State = runtime.ActivityStateFailed
 		}
-		err = batch.SaveProcessInstance(ctx, instance)
+		err = batch.SaveProcessInstance(ctx, executionInstance)
 		if err != nil {
 			outcome.recordTechnicalFailure()
 			runErr = errors.Join(runErr, err)
@@ -427,6 +435,11 @@ mainLoop:
 			continue
 		}
 		instance.ProcessInstance().FlowNodeCount = runFlowNodeCount.count
+		for _, tok := range updatedTokens {
+			if tok.State == runtime.TokenStateRunning {
+				runningExecutionTokens = append(runningExecutionTokens, tok)
+			}
+		}
 		tokenSpan.End()
 	} // end of main loop
 

--- a/pkg/bpmn/runtime/varholder.go
+++ b/pkg/bpmn/runtime/varholder.go
@@ -144,8 +144,10 @@ func (vh *VariableHolder) evaluateAndPropagateMappings(
 			return nil, err
 		}
 		outputVariablesWithOutputMappings[mapping.Target] = evalResult
-		vh.parent.SetLocalVariable(mapping.Target, evalResult)
 	}
+	// Apply the mapped values only after every expression succeeds so callers never
+	// observe or persist a partially evaluated output mapping.
+	vh.parent.SetLocalVariables(outputVariablesWithOutputMappings)
 	return outputVariablesWithOutputMappings, nil
 }
 

--- a/pkg/bpmn/runtime/varholder_output_mapping_test.go
+++ b/pkg/bpmn/runtime/varholder_output_mapping_test.go
@@ -1,0 +1,73 @@
+package runtime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/model/extensions"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVariableHolderOutputMappings(t *testing.T) {
+	t.Run("Does not propagate partial values when a later mapping fails", func(t *testing.T) {
+		parent := NewVariableHolder(nil, map[string]interface{}{
+			"value": "initial",
+		})
+		child := NewVariableHolder(&parent, nil)
+		evaluationError := errors.New("invalid expression")
+
+		mappedVariables, err := child.PropagateMappedOutputsOrAll(
+			[]extensions.TIoMapping{
+				{Source: "valid", Target: "value"},
+				{Source: "invalid", Target: "unused"},
+			},
+			nil,
+			func(expression string, variables map[string]interface{}) (interface{}, error) {
+				switch expression {
+				case "valid":
+					return variables["value"].(string) + "-mapped", nil
+				case "invalid":
+					require.Equal(t, "initial", parent.GetLocalVariable("value"))
+					return nil, evaluationError
+				default:
+					return nil, errors.New("unexpected expression")
+				}
+			},
+		)
+
+		require.ErrorIs(t, err, evaluationError)
+		require.Nil(t, mappedVariables)
+		require.Equal(t, map[string]interface{}{
+			"value": "initial",
+		}, parent.LocalVariables())
+	})
+
+	t.Run("Propagates all values after every mapping succeeds", func(t *testing.T) {
+		parent := NewVariableHolder(nil, map[string]interface{}{
+			"source": "input",
+		})
+		child := NewVariableHolder(&parent, nil)
+
+		mappedVariables, err := child.PropagateMappedOutputsOrAll(
+			[]extensions.TIoMapping{
+				{Source: "first", Target: "first_output"},
+				{Source: "second", Target: "second_output"},
+			},
+			nil,
+			func(expression string, _ map[string]interface{}) (interface{}, error) {
+				return expression + "-value", nil
+			},
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, map[string]interface{}{
+			"first_output":  "first-value",
+			"second_output": "second-value",
+		}, mappedVariables)
+		require.Equal(t, map[string]interface{}{
+			"source":        "input",
+			"first_output":  "first-value",
+			"second_output": "second-value",
+		}, parent.LocalVariables())
+	})
+}

--- a/pkg/bpmn/start_event_mapping_persistence_test.go
+++ b/pkg/bpmn/start_event_mapping_persistence_test.go
@@ -1,0 +1,236 @@
+package bpmn
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/model/extensions"
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/storage"
+	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartEventMappingPersistence(t *testing.T) {
+	t.Run("Transition failure preserves variables and retry maps them once", func(t *testing.T) {
+		engine, store, definition := setupStartMappingPersistence(t)
+		store.failure = "transition"
+
+		instance, err := engine.CreateInstanceByKey(t.Context(), definition.Key, map[string]any{"attempt": "initial"})
+		require.ErrorIs(t, err, errStartMappingStorage)
+		require.True(t, store.injected)
+		incident := assertUncommittedStartMapping(t, store, instance)
+
+		require.NoError(t, engine.ResolveIncident(t.Context(), incident.Key))
+		assertCommittedStartMapping(t, store, instance.ProcessInstance().Key, incident.ElementInstanceKey)
+	})
+
+	t.Run("History failure preserves variables and retry maps them once", func(t *testing.T) {
+		engine, store, definition := setupStartMappingPersistence(t)
+		store.failure = "history"
+
+		instance, err := engine.CreateInstanceByKey(t.Context(), definition.Key, map[string]any{"attempt": "initial"})
+		require.ErrorIs(t, err, errStartMappingStorage)
+		require.True(t, store.injected)
+		incident := assertUncommittedStartMapping(t, store, instance)
+
+		require.NoError(t, engine.ResolveIncident(t.Context(), incident.Key))
+		assertCommittedStartMapping(t, store, instance.ProcessInstance().Key, incident.ElementInstanceKey)
+	})
+
+	t.Run("Process instance save failure preserves variables and retry maps them once", func(t *testing.T) {
+		engine, store, definition := setupStartMappingPersistence(t)
+		store.failure = "instance"
+
+		instance, err := engine.CreateInstanceByKey(t.Context(), definition.Key, map[string]any{"attempt": "initial"})
+		require.ErrorIs(t, err, errStartMappingStorage)
+		require.True(t, store.injected)
+		incident := assertUncommittedStartMapping(t, store, instance)
+
+		require.NoError(t, engine.ResolveIncident(t.Context(), incident.Key))
+		assertCommittedStartMapping(t, store, instance.ProcessInstance().Key, incident.ElementInstanceKey)
+	})
+
+	t.Run("Flush failure keeps the token at the start until incident resolution", func(t *testing.T) {
+		engine, store, definition := setupStartMappingPersistence(t)
+		store.failure = "flush"
+
+		instance, err := engine.CreateInstanceByKey(t.Context(), definition.Key, map[string]any{"attempt": "initial"})
+		require.ErrorIs(t, err, errStartMappingStorage)
+		require.True(t, store.injected)
+		incident := assertUncommittedStartMapping(t, store, instance)
+
+		require.NoError(t, engine.ResolveIncident(t.Context(), incident.Key))
+		assertCommittedStartMapping(t, store, instance.ProcessInstance().Key, incident.ElementInstanceKey)
+	})
+
+	t.Run("Token save failure leaves the original variables available for recovery", func(t *testing.T) {
+		engine, store, definition := setupStartMappingPersistence(t)
+		store.failure = "token"
+
+		instance, err := engine.CreateInstanceByKey(t.Context(), definition.Key, map[string]any{"attempt": "initial"})
+		require.ErrorIs(t, err, errStartMappingStorage)
+		require.True(t, store.injected)
+		require.Equal(t, "initial", instance.ProcessInstance().VariableHolder.GetLocalVariable("attempt"))
+		persisted, err := store.FindProcessInstanceByKey(t.Context(), instance.ProcessInstance().Key)
+		require.NoError(t, err)
+		require.Equal(t, "initial", persisted.ProcessInstance().VariableHolder.GetLocalVariable("attempt"))
+		incidents, err := store.FindIncidentsByProcessInstanceKey(t.Context(), instance.ProcessInstance().Key)
+		require.NoError(t, err)
+		require.Empty(t, incidents)
+		tokens, err := store.GetActiveTokensForProcessInstance(t.Context(), instance.ProcessInstance().Key)
+		require.NoError(t, err)
+		require.Len(t, tokens, 1)
+		require.Equal(t, "StartEvent_1", tokens[0].ElementId)
+		require.Equal(t, runtime.TokenStateRunning, tokens[0].State)
+
+		require.NoError(t, engine.RunProcessInstance(t.Context(), persisted, tokens))
+		assertCommittedStartMapping(t, store, instance.ProcessInstance().Key, tokens[0].ElementInstanceKey)
+	})
+}
+
+func setupStartMappingPersistence(t *testing.T) (*Engine, *startMappingStorage, *runtime.ProcessDefinition) {
+	t.Helper()
+	store := &startMappingStorage{Storage: inmemory.NewStorage()}
+	engine := NewEngine(EngineWithStorage(store))
+	cleanupIncidentTestEngine(t, &engine)
+	definition, err := engine.LoadFromFile(t.Context(), "./test-cases/simple_task.bpmn")
+	require.NoError(t, err)
+	definition.Definitions.Process.StartEvents[0].Output = []extensions.TIoMapping{{Source: `=attempt + "-mapped"`, Target: "attempt"}}
+	require.NoError(t, store.SaveProcessDefinition(t.Context(), *definition))
+	return &engine, store, definition
+}
+
+func assertUncommittedStartMapping(t *testing.T, store *startMappingStorage, instance runtime.ProcessInstance) runtime.Incident {
+	t.Helper()
+	key := instance.ProcessInstance().Key
+	require.Equal(t, "initial", instance.ProcessInstance().VariableHolder.GetLocalVariable("attempt"))
+	persisted, err := store.FindProcessInstanceByKey(t.Context(), key)
+	require.NoError(t, err)
+	require.Equal(t, runtime.ActivityStateFailed, persisted.ProcessInstance().State)
+	require.Equal(t, "initial", persisted.ProcessInstance().VariableHolder.GetLocalVariable("attempt"))
+	incidents, err := store.FindIncidentsByProcessInstanceKey(t.Context(), key)
+	require.NoError(t, err)
+	require.Len(t, incidents, 1)
+	token, err := store.GetTokenByKey(t.Context(), incidents[0].Token.Key)
+	require.NoError(t, err)
+	require.Equal(t, "StartEvent_1", token.ElementId)
+	require.Equal(t, runtime.TokenStateFailed, token.State)
+	_, err = store.GetFlowElementInstanceByKey(t.Context(), token.ElementInstanceKey)
+	require.ErrorIs(t, err, storage.ErrNotFound, "the start history must be discarded with the transition")
+	jobs, err := store.FindPendingProcessInstanceJobs(t.Context(), key)
+	require.NoError(t, err)
+	require.Empty(t, jobs, "a failed start must not run its outgoing task")
+	return incidents[0]
+}
+
+func assertCommittedStartMapping(t *testing.T, store *startMappingStorage, key, startHistoryKey int64) {
+	t.Helper()
+	persisted, err := store.FindProcessInstanceByKey(t.Context(), key)
+	require.NoError(t, err)
+	require.Equal(t, runtime.ActivityStateActive, persisted.ProcessInstance().State)
+	require.Equal(t, "initial-mapped", persisted.ProcessInstance().VariableHolder.GetLocalVariable("attempt"))
+	history, err := store.GetFlowElementInstanceByKey(t.Context(), startHistoryKey)
+	require.NoError(t, err)
+	require.NotNil(t, history.CompletedAt)
+	require.Equal(t, map[string]any{"attempt": "initial-mapped"}, history.OutputVariables)
+	jobs, err := store.FindPendingProcessInstanceJobs(t.Context(), key)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "id", jobs[0].ElementId)
+	require.Equal(t, "initial-mapped", jobs[0].InputVariables["attempt"])
+}
+
+var errStartMappingStorage = errors.New("injected post-mapping storage failure")
+
+type startMappingStorage struct {
+	*inmemory.Storage
+	failure  string
+	injected bool
+}
+
+// Detach variable maps at storage boundaries so the in-memory backend cannot
+// expose uncommitted mutations through shared pointers.
+func cloneStartMappingInstance(instance runtime.ProcessInstance) runtime.ProcessInstance {
+	clonedInstance := *instance.(*runtime.DefaultProcessInstance)
+	clonedInstance.VariableHolder = runtime.NewVariableHolder(nil, maps.Clone(instance.ProcessInstance().VariableHolder.LocalVariables()))
+	return &clonedInstance
+}
+
+func (s *startMappingStorage) SaveProcessInstance(ctx context.Context, instance runtime.ProcessInstance) error {
+	return s.Storage.SaveProcessInstance(ctx, cloneStartMappingInstance(instance))
+}
+
+func (s *startMappingStorage) FindProcessInstanceByKey(ctx context.Context, key int64) (runtime.ProcessInstance, error) {
+	instance, err := s.Storage.FindProcessInstanceByKey(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return cloneStartMappingInstance(instance), nil
+}
+
+func (s *startMappingStorage) RefreshProcessInstance(ctx context.Context, instance runtime.ProcessInstance) error {
+	if err := s.Storage.RefreshProcessInstance(ctx, instance); err != nil {
+		return err
+	}
+	instance.ProcessInstance().VariableHolder = runtime.NewVariableHolder(nil, maps.Clone(instance.ProcessInstance().VariableHolder.LocalVariables()))
+	return nil
+}
+
+func (s *startMappingStorage) NewBatch() storage.Batch {
+	return &startMappingBatch{Batch: s.Storage.NewBatch(), store: s}
+}
+
+func (s *startMappingStorage) fail(operation string) bool {
+	if s.failure != operation || s.injected {
+		return false
+	}
+	s.injected = true
+	return true
+}
+
+type startMappingBatch struct {
+	storage.Batch
+	store          *startMappingStorage
+	completedStart bool
+}
+
+func (b *startMappingBatch) SaveProcessInstance(ctx context.Context, instance runtime.ProcessInstance) error {
+	if b.completedStart && b.store.fail("instance") {
+		return errStartMappingStorage
+	}
+	return b.Batch.SaveProcessInstance(ctx, cloneStartMappingInstance(instance))
+}
+
+func (b *startMappingBatch) SaveToken(ctx context.Context, token runtime.ExecutionToken) error {
+	if b.completedStart && b.store.fail("token") {
+		return errStartMappingStorage
+	}
+	return b.Batch.SaveToken(ctx, token)
+}
+
+func (b *startMappingBatch) SaveFlowElementInstance(ctx context.Context, history runtime.FlowElementInstance) error {
+	if history.ElementId == "Flow_0xt1d7q" && b.store.fail("transition") {
+		return errStartMappingStorage
+	}
+	return b.Batch.SaveFlowElementInstance(ctx, history)
+}
+
+func (b *startMappingBatch) UpdateOutputFlowElementInstance(ctx context.Context, history runtime.FlowElementInstance) error {
+	if history.ElementId == "StartEvent_1" {
+		b.completedStart = true
+		if b.store.fail("history") {
+			return errStartMappingStorage
+		}
+	}
+	return b.Batch.UpdateOutputFlowElementInstance(ctx, history)
+}
+
+func (b *startMappingBatch) Flush(ctx context.Context) error {
+	if b.completedStart && b.store.fail("flush") {
+		return errStartMappingStorage
+	}
+	return b.Batch.Flush(ctx)
+}

--- a/test/e2e/start_event_flow_test.go
+++ b/test/e2e/start_event_flow_test.go
@@ -1,0 +1,47 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/pbinitiative/zenbpm/pkg/zenflake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartEventFlow(t *testing.T) {
+	t.Run("Manual process creation moves the token to the first flow node and leaves the instance active", func(t *testing.T) {
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/start_event/start_event.bpmn", nil)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		waitForProcessInstanceActiveJobByElementId(t, processInstance.Key, "first_flow_node")
+
+		fetchedInstance, err := getProcessInstance(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Equal(t, zenclient.ProcessInstanceStateActive, fetchedInstance.State)
+		require.Len(t, fetchedInstance.ActiveElementInstances, 1)
+		require.Equal(t, "first_flow_node", fetchedInstance.ActiveElementInstances[0].ElementId)
+		require.Equal(t, runtime.TokenStateWaiting.String(), fetchedInstance.ActiveElementInstances[0].State)
+
+		store, err := app.node.GetPartitionStore(t.Context(), zenflake.GetPartitionId(processInstance.Key))
+		require.NoError(t, err)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			tokens, getTokensErr := store.GetAllTokensForProcessInstance(t.Context(), processInstance.Key)
+			if !assert.NoError(collect, getTokensErr) || !assert.Len(collect, tokens, 1) {
+				return
+			}
+			assert.Equal(collect, "first_flow_node", tokens[0].ElementId)
+			assert.Equal(collect, runtime.TokenStateWaiting, tokens[0].State)
+		}, 5*time.Second, 100*time.Millisecond, "the start event token should transition to the first flow node")
+
+		assertExactProcessInstanceHistoryStates(t, processInstance.Key,
+			completedFlowElementHistory("start_event"),
+			completedFlowElementHistory("flow_to_first_node"),
+			activeFlowElementHistory("first_flow_node"),
+		)
+	})
+}

--- a/test/e2e/start_event_incident_test.go
+++ b/test/e2e/start_event_incident_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartEventIncident(t *testing.T) {
+	t.Run("Failed output mappings are atomic across incident retries", func(t *testing.T) {
+		definitionKey := deployStartEventDefinition(t, `<bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=attempt + &#34;-mapped&#34;" target="attempt" />
+          <zenbpm:output source="=attempt." target="mapped_value" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>`)
+
+		processInstance := createProcessInstanceWithVariables(t, definitionKey, map[string]any{
+			"attempt": "initial",
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateFailed)
+		assertProcessInstanceTokenState(t, processInstance.Key, "start_event", runtime.TokenStateFailed)
+		assertProcessInstanceHasNoActiveJobByElementId(t, processInstance.Key, "first_flow_node")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"attempt": "initial",
+		})
+
+		incidents, err := getProcessInstanceIncidents(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Len(t, incidents, 1)
+		require.Equal(t, "start_event", incidents[0].ElementId)
+		require.Contains(t, incidents[0].Message, "failed to evaluate StartEvent output mappings")
+
+		response, err := app.restClient.ResolveIncidentWithResponse(t.Context(), incidents[0].Key)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, response.StatusCode())
+		require.Contains(t, string(response.Body), "failed to evaluate StartEvent output mappings")
+
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateFailed)
+		assertProcessInstanceTokenState(t, processInstance.Key, "start_event", runtime.TokenStateFailed)
+		assertProcessInstanceHasNoActiveJobByElementId(t, processInstance.Key, "first_flow_node")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{
+			"attempt": "initial",
+		})
+
+		incidents, err = getProcessInstanceIncidents(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Len(t, incidents, 2)
+
+		resolvedCount := 0
+		unresolvedCount := 0
+		for _, incident := range incidents {
+			require.Equal(t, "start_event", incident.ElementId)
+			require.Contains(t, incident.Message, "failed to evaluate StartEvent output mappings")
+			if incident.ResolvedAt == nil {
+				unresolvedCount++
+			} else {
+				resolvedCount++
+			}
+		}
+		require.Equal(t, 1, resolvedCount)
+		require.Equal(t, 1, unresolvedCount)
+	})
+}

--- a/test/e2e/start_event_variables_test.go
+++ b/test/e2e/start_event_variables_test.go
@@ -1,0 +1,84 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+const startEventFixturePath = "start_event/start_event.bpmn"
+
+func TestStartEventVariables(t *testing.T) {
+	t.Run("Process start variables are available at the first flow node", func(t *testing.T) {
+		initialVariables := map[string]any{
+			"order_id":      "order-123",
+			"customer_name": "Příliš žluťoučký kůň",
+		}
+		processInstance := deployAndCreateUniqueProcessDefinition(t, "testdata/"+startEventFixturePath, initialVariables)
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		job := waitForProcessInstanceActiveJobByElementId(t, processInstance.Key, "first_flow_node")
+		require.Equal(t, initialVariables, job.InputVariables)
+		assertProcessInstanceVariables(t, processInstance.Key, initialVariables)
+		assertFlowElementInputVariables(t, processInstance.Key, "start_event", nil)
+		assertFlowElementOutputVariables(t, processInstance.Key, "start_event", nil)
+	})
+
+	t.Run("Output mappings initialize and overwrite process variables before the first flow node", func(t *testing.T) {
+		definitionKey := deployStartEventDefinition(t, `<bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=source_value" target="mapped_value" />
+          <zenbpm:output source="=&#34;initialized-at-start&#34;" target="status" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>`)
+
+		processInstance := createProcessInstanceWithVariables(t, definitionKey, map[string]any{
+			"source_value": "source-from-api",
+			"status":       "before-start",
+		})
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		expectedVariables := map[string]any{
+			"source_value": "source-from-api",
+			"mapped_value": "source-from-api",
+			"status":       "initialized-at-start",
+		}
+		job := waitForProcessInstanceActiveJobByElementId(t, processInstance.Key, "first_flow_node")
+		require.Equal(t, expectedVariables, job.InputVariables)
+		assertProcessInstanceVariables(t, processInstance.Key, expectedVariables)
+		assertFlowElementInputVariables(t, processInstance.Key, "start_event", nil)
+		assertFlowElementOutputVariables(t, processInstance.Key, "start_event", map[string]any{
+			"mapped_value": "source-from-api",
+			"status":       "initialized-at-start",
+		})
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateActive)
+	})
+}
+
+func deployStartEventDefinition(t testing.TB, startEventExtensionElements string) int64 {
+	t.Helper()
+
+	bpmnData, err := readE2ETestDataBPMN(startEventFixturePath)
+	require.NoError(t, err)
+	content := string(bpmnData)
+
+	uniqueProcessID := fmt.Sprintf("start-event-process-%d", time.Now().UnixNano())
+	content = strings.Replace(content, `bpmn:process id="start_event_process"`, fmt.Sprintf(`bpmn:process id="%s"`, uniqueProcessID), 1)
+	require.NotEqual(t, string(bpmnData), content, "start event fixture process id must be replaced")
+
+	if startEventExtensionElements != "" {
+		const emptyExtensionElements = `<bpmn:extensionElements />`
+		require.Contains(t, content, emptyExtensionElements)
+		content = strings.Replace(content, emptyExtensionElements, startEventExtensionElements, 1)
+	}
+
+	return deployBPMNTestCaseContent(t, "start_event.bpmn", []byte(content))
+}

--- a/test/e2e/start_event_variables_test.go
+++ b/test/e2e/start_event_variables_test.go
@@ -80,5 +80,5 @@ func deployStartEventDefinition(t testing.TB, startEventExtensionElements string
 		content = strings.Replace(content, emptyExtensionElements, startEventExtensionElements, 1)
 	}
 
-	return deployBPMNTestCaseContent(t, "start_event.bpmn", []byte(content))
+	return deployBPMNTestCaseContent(t, []byte(content))
 }

--- a/test/e2e/testdata/start_event/start_event.bpmn
+++ b/test/e2e/testdata/start_event/start_event.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_start_event" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="start_event_process" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:extensionElements />
+      <bpmn:outgoing>flow_to_first_node</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_first_node" sourceRef="start_event" targetRef="first_flow_node" />
+    <bpmn:serviceTask id="first_flow_node">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="start-event-test" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_first_node</bpmn:incoming>
+      <bpmn:outgoing>flow_to_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_end" sourceRef="first_flow_node" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_start_event">
+    <bpmndi:BPMNPlane id="BPMNPlane_start_event" bpmnElement="start_event_process">
+      <bpmndi:BPMNShape id="Shape_start_event" bpmnElement="start_event">
+        <dc:Bounds x="180" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_first_flow_node" bpmnElement="first_flow_node">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_end_event" bpmnElement="end_event">
+        <dc:Bounds x="424" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Edge_flow_to_first_node" bpmnElement="flow_to_first_node">
+        <di:waypoint x="216" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_flow_to_end" bpmnElement="flow_to_end">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="424" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/testdata/timer_start_event/timer_start_event.bpmn
+++ b/test/e2e/testdata/timer_start_event/timer_start_event.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zenbpm="http://zenbpm.pbinitiative.org/1.0" id="Definitions_timer_start_event" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ZenBPM Modeler" exporterVersion="1.0.0">
+  <bpmn:process id="timer_start_event_process" isExecutable="true">
+    <bpmn:startEvent id="timer_start_event">
+      <bpmn:extensionElements />
+      <bpmn:outgoing>flow_to_first_node</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="timer_definition">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2000-01-01T00:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_first_node" sourceRef="timer_start_event" targetRef="first_flow_node" />
+    <bpmn:serviceTask id="first_flow_node">
+      <bpmn:extensionElements>
+        <zenbpm:taskDefinition type="timer-start-event-test" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_first_node</bpmn:incoming>
+      <bpmn:outgoing>flow_to_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_end" sourceRef="first_flow_node" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_timer_start_event">
+    <bpmndi:BPMNPlane id="BPMNPlane_timer_start_event" bpmnElement="timer_start_event_process">
+      <bpmndi:BPMNShape id="Shape_timer_start_event" bpmnElement="timer_start_event">
+        <dc:Bounds x="180" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_first_flow_node" bpmnElement="first_flow_node">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_end_event" bpmnElement="end_event">
+        <dc:Bounds x="424" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Edge_flow_to_first_node" bpmnElement="flow_to_first_node">
+        <di:waypoint x="216" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_flow_to_end" bpmnElement="flow_to_end">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="424" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/timer_start_event_variables_test.go
+++ b/test/e2e/timer_start_event_variables_test.go
@@ -1,0 +1,86 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/zenclient"
+	"github.com/stretchr/testify/require"
+)
+
+const timerStartEventFixturePath = "timer_start_event/timer_start_event.bpmn"
+
+func TestTimerStartEventVariables(t *testing.T) {
+	t.Run("Output mappings initialize process variables before the first flow node", func(t *testing.T) {
+		processID := deployTimerStartEventDefinition(t, `<bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=&#34;started-by-timer&#34;" target="trigger_type" />
+          <zenbpm:output source="=42" target="attempt" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>`)
+
+		instances := waitForProcessInstancesByBPMNProcessID(t, processID, 1)
+		processInstance := instances[0]
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		expectedVariables := map[string]any{
+			"trigger_type": "started-by-timer",
+			"attempt":      float64(42),
+		}
+		job := waitForProcessInstanceActiveJobByElementId(t, processInstance.Key, "first_flow_node")
+		require.Equal(t, expectedVariables, job.InputVariables)
+		assertProcessInstanceVariables(t, processInstance.Key, expectedVariables)
+		assertFlowElementInputVariables(t, processInstance.Key, "timer_start_event", nil)
+		assertFlowElementOutputVariables(t, processInstance.Key, "timer_start_event", expectedVariables)
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateActive)
+	})
+
+	t.Run("Invalid output mapping creates an incident on the timer start event", func(t *testing.T) {
+		processID := deployTimerStartEventDefinition(t, `<bpmn:extensionElements>
+        <zenbpm:ioMapping>
+          <zenbpm:output source="=timer_value." target="mapped_value" />
+        </zenbpm:ioMapping>
+      </bpmn:extensionElements>`)
+
+		instances := waitForProcessInstancesByBPMNProcessID(t, processID, 1)
+		processInstance := instances[0]
+		t.Cleanup(func() {
+			cleanupOwnedProcessInstance(t, processInstance.Key)
+		})
+
+		waitForProcessInstanceState(t, processInstance.Key, zenclient.ProcessInstanceStateFailed)
+		assertProcessInstanceTokenState(t, processInstance.Key, "timer_start_event", runtime.TokenStateFailed)
+		assertProcessInstanceHasNoActiveJobByElementId(t, processInstance.Key, "first_flow_node")
+		assertProcessInstanceVariables(t, processInstance.Key, map[string]any{})
+
+		incidents, err := getProcessInstanceIncidents(t, processInstance.Key)
+		require.NoError(t, err)
+		require.Len(t, incidents, 1)
+		require.Equal(t, "timer_start_event", incidents[0].ElementId)
+		require.Contains(t, incidents[0].Message, "failed to evaluate StartEvent output mappings")
+	})
+}
+
+func deployTimerStartEventDefinition(t testing.TB, startEventExtensionElements string) string {
+	t.Helper()
+
+	bpmnData, err := readE2ETestDataBPMN(timerStartEventFixturePath)
+	require.NoError(t, err)
+	content := string(bpmnData)
+
+	uniqueProcessID := fmt.Sprintf("timer-start-event-%d", time.Now().UnixNano())
+	content = strings.Replace(content, `bpmn:process id="timer_start_event_process"`, fmt.Sprintf(`bpmn:process id="%s"`, uniqueProcessID), 1)
+	require.NotEqual(t, string(bpmnData), content, "timer start event fixture process id must be replaced")
+
+	const emptyExtensionElements = `<bpmn:extensionElements />`
+	require.Contains(t, content, emptyExtensionElements)
+	content = strings.Replace(content, emptyExtensionElements, startEventExtensionElements, 1)
+
+	deployBPMNTestCaseContent(t, "timer_start_event.bpmn", []byte(content))
+	return uniqueProcessID
+}

--- a/test/e2e/timer_start_event_variables_test.go
+++ b/test/e2e/timer_start_event_variables_test.go
@@ -81,6 +81,6 @@ func deployTimerStartEventDefinition(t testing.TB, startEventExtensionElements s
 	require.Contains(t, content, emptyExtensionElements)
 	content = strings.Replace(content, emptyExtensionElements, startEventExtensionElements, 1)
 
-	deployBPMNTestCaseContent(t, "timer_start_event.bpmn", []byte(content))
+	deployBPMNTestCaseContent(t, []byte(content))
 	return uniqueProcessID
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Start events can initialize or derive process variables using output mappings before the process flow begins.
  - None, timer, and message start events support output mappings; message starts can map values from the message payload.
  - Variables supplied when creating a process are available at the first flow node.
  - Link events and timer boundary events support output mappings.

- **Bug Fixes**
  - Prevented partial variable updates when a mapping fails.
  - Mapping failures preserve existing variables and report an incident.

- **Documentation**
  - Updated BPMN reference documentation with event mapping guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->