### PR TITLE
#724: Reuse compiled FEEL programs and fix script runtime lifecycle leaks

### DIFF
--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -49,6 +49,18 @@ type Engine struct {
 	feelRuntime    script.FeelRuntime
 	jsRuntime      script.JsRuntime
 
+	// ownsFeelRuntime reports whether the engine created feelRuntime itself and is therefore responsible for stopping it.
+	// Runtimes injected through EngineWithStorageAndFeel remain owned by the caller and are never stopped by the engine.
+	ownsFeelRuntime bool
+
+	// ownsJsRuntime reports whether the engine created jsRuntime itself and is therefore responsible for stopping it.
+	// Runtimes injected through EngineWithJs remain owned by the caller and are never stopped by the engine.
+	ownsJsRuntime bool
+
+	// stopOnce guarantees that Stop releases engine-owned resources exactly once, even when Stop is called multiple times
+	// or from multiple goroutines. It is a pointer because Engine values are copied (NewEngine returns Engine by value).
+	stopOnce *sync.Once
+
 	// pollTimerDelay is the interval between timer polling cycles.
 	// Defaults to 10 seconds if not set via EngineWithPollTimerDelay.
 	pollTimerDelay time.Duration
@@ -84,6 +96,12 @@ type Engine struct {
 
 type EngineOption = func(*Engine)
 
+type engineFactories struct {
+	newFeelRuntime func() script.FeelRuntime
+	newJsRuntime   func() script.JsRuntime
+	newDmnEngine   func(storage.Storage, script.FeelRuntime) *dmn.ZenDmnEngine
+}
+
 // DefaultMaxProcessInstanceNestingDepth is the default maximum nesting depth of a process
 // instance in the parent-child chain. It can be overridden via EngineWithMaxProcessInstanceNestingDepth.
 const DefaultMaxProcessInstanceNestingDepth int64 = 100
@@ -97,6 +115,23 @@ const DefaultMaxProcessInstanceFlowNodeCount int64 = 10000
 
 // NewEngine creates a new instance of the BPMN Engine;
 func NewEngine(options ...EngineOption) Engine {
+	return newEngine(engineFactories{
+		newFeelRuntime: func() script.FeelRuntime {
+			return feel.NewFeelinRuntime(1, 1)
+		},
+		newJsRuntime: func() script.JsRuntime {
+			return js.NewJsRuntime(1, 1)
+		},
+		newDmnEngine: func(persistence storage.Storage, feelRuntime script.FeelRuntime) *dmn.ZenDmnEngine {
+			return dmn.NewEngine(
+				dmn.EngineWithStorage(persistence),
+				dmn.EngineWithFeel(feelRuntime),
+			)
+		},
+	}, options...)
+}
+
+func newEngine(factories engineFactories, options ...EngineOption) Engine {
 	ctx, cancel := context.WithCancel(context.Background())
 	logger := hclog.Default()
 	meter := otel.GetMeterProvider().Meter("bpmn-engine")
@@ -106,8 +141,6 @@ func NewEngine(options ...EngineOption) Engine {
 		logger.Error("Failed to initialize metrics for the engine", "err", err)
 	}
 	persistence := inmemory.NewStorage()
-	feelRuntime := feel.NewFeelinRuntime(1, 1)
-	jsRuntime := js.NewJsRuntime(1, 1)
 
 	engine := Engine{
 		context:                         ctx,
@@ -122,16 +155,29 @@ func NewEngine(options ...EngineOption) Engine {
 		tracer:                          tracer,
 		meter:                           meter,
 		metrics:                         metrics,
-		feelRuntime:                     feelRuntime,
-		jsRuntime:                       jsRuntime,
 		maxProcessInstanceNestingDepth:  DefaultMaxProcessInstanceNestingDepth,
 		maxProcessInstanceFlowNodeCount: DefaultMaxProcessInstanceFlowNodeCount,
-		dmnEngine:                       dmn.NewEngine(dmn.EngineWithStorage(persistence), dmn.EngineWithFeel(feelRuntime)),
+		stopOnce:                        &sync.Once{},
 	}
 
 	for _, option := range options {
 		option(&engine)
 	}
+
+	// Create default runtimes only when none were injected through options.
+	// This avoids paying the pool startup cost (and leaving cleanup goroutines behind) for runtimes
+	// that would immediately be replaced. Defaults created here are owned by the engine and stopped in Stop;
+	// injected runtimes remain owned by their callers.
+	if engine.feelRuntime == nil {
+		engine.feelRuntime = factories.newFeelRuntime()
+		engine.ownsFeelRuntime = true
+	}
+	if engine.jsRuntime == nil {
+		engine.jsRuntime = factories.newJsRuntime()
+		engine.ownsJsRuntime = true
+	}
+	// The DMN engine always reuses the BPMN engine's FEEL runtime and storage, so it never owns a FEEL pool of its own.
+	engine.dmnEngine = factories.newDmnEngine(engine.persistence, engine.feelRuntime)
 
 	return engine
 }
@@ -140,32 +186,52 @@ func EngineWithExporter(exporter exporter.EventExporter) EngineOption {
 	return func(engine *Engine) { engine.AddEventExporter(exporter) }
 }
 
+// EngineWithStorage sets the storage used by the BPMN engine and its embedded DMN engine.
+// It is meant for construction time only (through NewEngine).
+// The engine's FEEL runtime (default or injected) is reused for DMN evaluation, so no independent FEEL pool is created.
 func EngineWithStorage(persistence storage.Storage) EngineOption {
 	return func(engine *Engine) {
 		engine.persistence = persistence
-		// The BPMN engine owns this runtime. Reuse it for DMN evaluation instead
-		// of creating a second default FEEL worker pool with no shutdown owner.
-		engine.dmnEngine = dmn.NewEngine(
-			dmn.EngineWithStorage(persistence),
-			dmn.EngineWithFeel(engine.feelRuntime),
-		)
 	}
 }
 
+// EngineWithStorageAndFeel sets the storage and the FEEL runtime used by the BPMN engine and its embedded DMN engine.
+// The supplied runtime remains owned by the caller: the engine will never stop it.
+// It is meant for construction time only (through NewEngine).
 func EngineWithStorageAndFeel(persistence storage.Storage, feelRuntime script.FeelRuntime) EngineOption {
 	return func(engine *Engine) {
 		engine.persistence = persistence
-		engine.feelRuntime.Stop()
+		engine.stopOwnedFeelRuntime()
 		engine.feelRuntime = feelRuntime
-		engine.dmnEngine = dmn.NewEngine(dmn.EngineWithStorage(persistence), dmn.EngineWithFeel(feelRuntime))
 	}
 }
 
+// EngineWithJs sets the JavaScript runtime used by the BPMN engine.
+// The supplied runtime remains owned by the caller: the engine will never stop it.
+// It is meant for construction time only (through NewEngine).
 func EngineWithJs(jsRuntime script.JsRuntime) EngineOption {
 	return func(engine *Engine) {
-		engine.jsRuntime.Stop()
+		engine.stopOwnedJsRuntime()
 		engine.jsRuntime = jsRuntime
 	}
+}
+
+// stopOwnedFeelRuntime stops the FEEL runtime if the engine owns it and clears
+// ownership so the runtime cannot be stopped a second time.
+func (engine *Engine) stopOwnedFeelRuntime() {
+	if engine.ownsFeelRuntime && engine.feelRuntime != nil {
+		engine.feelRuntime.Stop()
+	}
+	engine.ownsFeelRuntime = false
+}
+
+// stopOwnedJsRuntime stops the JavaScript runtime if the engine owns it and
+// clears ownership so the runtime cannot be stopped a second time.
+func (engine *Engine) stopOwnedJsRuntime() {
+	if engine.ownsJsRuntime && engine.jsRuntime != nil {
+		engine.jsRuntime.Stop()
+	}
+	engine.ownsJsRuntime = false
 }
 
 func EngineWithLogger(logger hclog.Logger) EngineOption {

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -63,6 +63,11 @@ type Engine struct {
 	// copied (NewEngine returns Engine by value).
 	stopOnce *sync.Once
 
+	// constructed is set once newEngine has finished applying options and creating default runtimes.
+	// Runtime-injecting options consult it to reject being applied to an already constructed engine,
+	// which would orphan an engine-owned runtime and swap the runtime under in-flight evaluations.
+	constructed bool
+
 	// pollTimerDelay is the interval between timer polling cycles.
 	// Defaults to 10 seconds if not set via EngineWithPollTimerDelay.
 	pollTimerDelay time.Duration
@@ -180,6 +185,7 @@ func newEngine(factories engineFactories, options ...EngineOption) Engine {
 	}
 	// The DMN engine always reuses the BPMN engine's FEEL runtime and storage, so it never owns a FEEL pool of its own.
 	engine.dmnEngine = factories.newDmnEngine(engine.persistence, engine.feelRuntime)
+	engine.constructed = true
 
 	return engine
 }
@@ -199,10 +205,12 @@ func EngineWithStorage(persistence storage.Storage) EngineOption {
 
 // EngineWithStorageAndFeel sets the storage and the FEEL runtime used by the BPMN engine and its embedded DMN engine.
 // The supplied runtime remains owned by the caller: the engine will never stop it.
-// It is meant for construction time only (through NewEngine), where options are applied before any default
-// runtime is created, so no engine-owned pool ever needs to be released here.
+// It must only be passed to NewEngine, where options are applied before any default runtime is created, so no
+// engine-owned pool ever needs to be released here. Applying it to an already constructed engine panics: doing so
+// would orphan the engine-owned runtime and replace the runtime underneath in-flight evaluations.
 func EngineWithStorageAndFeel(persistence storage.Storage, feelRuntime script.FeelRuntime) EngineOption {
 	return func(engine *Engine) {
+		engine.mustBeUnderConstruction("EngineWithStorageAndFeel")
 		engine.persistence = persistence
 		engine.feelRuntime = feelRuntime
 		engine.ownsFeelRuntime = false
@@ -211,12 +219,22 @@ func EngineWithStorageAndFeel(persistence storage.Storage, feelRuntime script.Fe
 
 // EngineWithJs sets the JavaScript runtime used by the BPMN engine.
 // The supplied runtime remains owned by the caller: the engine will never stop it.
-// It is meant for construction time only (through NewEngine), where options are applied before any default
-// runtime is created, so no engine-owned pool ever needs to be released here.
+// It must only be passed to NewEngine, where options are applied before any default runtime is created, so no
+// engine-owned pool ever needs to be released here. Applying it to an already constructed engine panics: doing so
+// would orphan the engine-owned runtime and replace the runtime underneath in-flight evaluations.
 func EngineWithJs(jsRuntime script.JsRuntime) EngineOption {
 	return func(engine *Engine) {
+		engine.mustBeUnderConstruction("EngineWithJs")
 		engine.jsRuntime = jsRuntime
 		engine.ownsJsRuntime = false
+	}
+}
+
+// mustBeUnderConstruction panics when a construction-only option is applied to an engine that newEngine has
+// already finished building.
+func (engine *Engine) mustBeUnderConstruction(option string) {
+	if engine.constructed {
+		panic(fmt.Sprintf("bpmn: %s must only be passed to NewEngine; applying it to a constructed engine is not supported", option))
 	}
 }
 

--- a/pkg/bpmn/engine.go
+++ b/pkg/bpmn/engine.go
@@ -57,8 +57,10 @@ type Engine struct {
 	// Runtimes injected through EngineWithJs remain owned by the caller and are never stopped by the engine.
 	ownsJsRuntime bool
 
-	// stopOnce guarantees that Stop releases engine-owned resources exactly once, even when Stop is called multiple times
-	// or from multiple goroutines. It is a pointer because Engine values are copied (NewEngine returns Engine by value).
+	// stopOnce guarantees that Stop releases engine-owned script pools (DMN engine, FEEL and JavaScript runtimes)
+	// exactly once, even when Stop is called multiple times or from multiple goroutines. Timer manager shutdown and
+	// context cancellation are intentionally NOT guarded by it (see Stop). It is a pointer because Engine values are
+	// copied (NewEngine returns Engine by value).
 	stopOnce *sync.Once
 
 	// pollTimerDelay is the interval between timer polling cycles.
@@ -197,27 +199,29 @@ func EngineWithStorage(persistence storage.Storage) EngineOption {
 
 // EngineWithStorageAndFeel sets the storage and the FEEL runtime used by the BPMN engine and its embedded DMN engine.
 // The supplied runtime remains owned by the caller: the engine will never stop it.
-// It is meant for construction time only (through NewEngine).
+// It is meant for construction time only (through NewEngine), where options are applied before any default
+// runtime is created, so no engine-owned pool ever needs to be released here.
 func EngineWithStorageAndFeel(persistence storage.Storage, feelRuntime script.FeelRuntime) EngineOption {
 	return func(engine *Engine) {
 		engine.persistence = persistence
-		engine.stopOwnedFeelRuntime()
 		engine.feelRuntime = feelRuntime
+		engine.ownsFeelRuntime = false
 	}
 }
 
 // EngineWithJs sets the JavaScript runtime used by the BPMN engine.
 // The supplied runtime remains owned by the caller: the engine will never stop it.
-// It is meant for construction time only (through NewEngine).
+// It is meant for construction time only (through NewEngine), where options are applied before any default
+// runtime is created, so no engine-owned pool ever needs to be released here.
 func EngineWithJs(jsRuntime script.JsRuntime) EngineOption {
 	return func(engine *Engine) {
-		engine.stopOwnedJsRuntime()
 		engine.jsRuntime = jsRuntime
+		engine.ownsJsRuntime = false
 	}
 }
 
 // stopOwnedFeelRuntime stops the FEEL runtime if the engine owns it and clears
-// ownership so the runtime cannot be stopped a second time.
+// ownership so the runtime cannot be stopped a second time. It is only called from Stop.
 func (engine *Engine) stopOwnedFeelRuntime() {
 	if engine.ownsFeelRuntime && engine.feelRuntime != nil {
 		engine.feelRuntime.Stop()
@@ -226,7 +230,7 @@ func (engine *Engine) stopOwnedFeelRuntime() {
 }
 
 // stopOwnedJsRuntime stops the JavaScript runtime if the engine owns it and
-// clears ownership so the runtime cannot be stopped a second time.
+// clears ownership so the runtime cannot be stopped a second time. It is only called from Stop.
 func (engine *Engine) stopOwnedJsRuntime() {
 	if engine.ownsJsRuntime && engine.jsRuntime != nil {
 		engine.jsRuntime.Stop()

--- a/pkg/bpmn/engine_api.go
+++ b/pkg/bpmn/engine_api.go
@@ -131,11 +131,23 @@ func (engine *Engine) recoverInstantiatingReceiveTaskSubscriptions(ctx context.C
 	return errors.Join(errs...)
 }
 
+// Stop shuts the engine down and releases engine-owned resources exactly once: the timer manager, the engine context,
+// the embedded DMN engine, and the FEEL and JavaScript script pools created by the engine itself.
+// Runtimes injected through EngineWithStorageAndFeel or EngineWithJs remain owned by the caller and are left running.
+// Calling Stop multiple times is safe.
 func (engine *Engine) Stop() {
-	if engine.timerManager != nil {
-		engine.timerManager.stop()
-	}
-	engine.contextCancel()
+	engine.stopOnce.Do(func() {
+		if engine.timerManager != nil {
+			engine.timerManager.stop()
+		}
+		engine.contextCancel()
+		if engine.dmnEngine != nil {
+			// The DMN engine never owns the shared FEEL runtime, so this only releases DMN-owned resources (if any).
+			engine.dmnEngine.Stop()
+		}
+		engine.stopOwnedFeelRuntime()
+		engine.stopOwnedJsRuntime()
+	})
 }
 
 // RunProcessInstance will run the process instance with supplied tokens.

--- a/pkg/bpmn/engine_api.go
+++ b/pkg/bpmn/engine_api.go
@@ -131,16 +131,22 @@ func (engine *Engine) recoverInstantiatingReceiveTaskSubscriptions(ctx context.C
 	return errors.Join(errs...)
 }
 
-// Stop shuts the engine down and releases engine-owned resources exactly once: the timer manager, the engine context,
-// the embedded DMN engine, and the FEEL and JavaScript script pools created by the engine itself.
+// Stop shuts the engine down: it stops the timer manager, cancels the engine context and releases engine-owned
+// resources (the embedded DMN engine and the FEEL and JavaScript script pools created by the engine itself).
 // Runtimes injected through EngineWithStorageAndFeel or EngineWithJs remain owned by the caller and are left running.
 // Calling Stop multiple times is safe.
 func (engine *Engine) Stop() {
+	// The timer manager and the engine context are deliberately handled outside stopOnce. Both operations are
+	// idempotent and must always act on the receiver's current state: Start may create a fresh timer manager
+	// after a previous Stop, and (because NewEngine returns Engine by value) a copy sharing the same stopOnce
+	// may be stopped before the running engine. Guarding them with the one-shot Once would leave the live
+	// timer manager goroutine running forever in both cases.
+	if engine.timerManager != nil {
+		engine.timerManager.stop()
+	}
+	engine.contextCancel()
+	// Owned script pools are released exactly once, even when Stop is called repeatedly or concurrently.
 	engine.stopOnce.Do(func() {
-		if engine.timerManager != nil {
-			engine.timerManager.stop()
-		}
-		engine.contextCancel()
 		if engine.dmnEngine != nil {
 			// The DMN engine never owns the shared FEEL runtime, so this only releases DMN-owned resources (if any).
 			engine.dmnEngine.Stop()

--- a/pkg/bpmn/engine_batch_incident_test.go
+++ b/pkg/bpmn/engine_batch_incident_test.go
@@ -242,8 +242,5 @@ func incidentTestInstance() runtime.ProcessInstance {
 
 func cleanupIncidentTestEngine(t *testing.T, engine *Engine) {
 	t.Helper()
-	t.Cleanup(func() {
-		engine.feelRuntime.Stop()
-		engine.jsRuntime.Stop()
-	})
+	t.Cleanup(engine.Stop)
 }

--- a/pkg/bpmn/engine_cancel_terminate_test.go
+++ b/pkg/bpmn/engine_cancel_terminate_test.go
@@ -203,11 +203,7 @@ func newCancelTerminateTestEngine(t *testing.T, options ...EngineOption) Engine 
 	t.Helper()
 
 	engine := NewEngine(options...)
-	t.Cleanup(func() {
-		engine.contextCancel()
-		engine.feelRuntime.Stop()
-		engine.jsRuntime.Stop()
-	})
+	t.Cleanup(engine.Stop)
 	return engine
 }
 

--- a/pkg/bpmn/engine_lifecycle_e2e_test.go
+++ b/pkg/bpmn/engine_lifecycle_e2e_test.go
@@ -1,0 +1,57 @@
+package bpmn
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/bpmn/runtime"
+	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// TestEngineLifecycleEndToEnd exercises a complete engine lifecycle:
+// construction with default (engine-owned) script runtimes, FEEL evaluation
+// through gateway conditions, DMN decision evaluation through the embedded DMN
+// engine (which reuses the BPMN engine's FEEL runtime), and shutdown. After
+// Stop, goleak verifies that no engine-owned script-pool cleanup goroutines are left running.
+func TestEngineLifecycleEndToEnd(t *testing.T) {
+	defer goleak.VerifyNone(t, sharedEngineGoleakOptions()...)
+
+	engine := NewEngine(EngineWithStorage(inmemory.NewStorage()))
+	defer engine.Stop()
+
+	// FEEL evaluation: exclusive gateway with a FEEL condition.
+	gatewayProcess, err := engine.LoadFromFile(t.Context(), "./test-cases/exclusive-gateway-with-condition.bpmn")
+	require.NoError(t, err)
+
+	cp := CallPath{}
+	gatewayHandler := engine.NewTaskHandler().Type("task-b").Handler(cp.TaskHandler)
+	defer engine.RemoveHandler(gatewayHandler)
+
+	gatewayInstance, err := engine.CreateInstanceByKey(t.Context(), gatewayProcess.Key, map[string]interface{}{"price": -50})
+	require.NoError(t, err)
+	assert.Equal(t, runtime.ActivityStateCompleted, gatewayInstance.ProcessInstance().State)
+	assert.Equal(t, "task-b", cp.CallPath)
+
+	// DMN evaluation: business rule task evaluated by the embedded DMN engine,
+	// which shares the BPMN engine's FEEL runtime.
+	dmnDefinition, dmnXml, err := engine.dmnEngine.ParseDmnFromFile(filepath.Join("..", "dmn", "test-data", "bulk-evaluation-test", "can-autoliquidate-rule.dmn"))
+	require.NoError(t, err)
+	_, _, err = engine.dmnEngine.SaveDmnResourceDefinition(t.Context(), dmnDefinition, dmnXml, engine.generateKey())
+	require.NoError(t, err)
+
+	ruleProcess, err := engine.LoadFromFile(t.Context(), filepath.Join(".", "test-cases", "business_rule", "simple-business-rule-task-local.bpmn"))
+	require.NoError(t, err)
+
+	ruleInstance, err := engine.CreateInstanceByKey(t.Context(), ruleProcess.Key, nil)
+	require.NoError(t, err)
+	assert.Equal(t, runtime.ActivityStateCompleted, ruleInstance.ProcessInstance().State)
+	assert.Equal(t, true, ruleInstance.ProcessInstance().VariableHolder.LocalVariables()["OutputTestResultVariable"])
+
+	// Shutdown: Stop must terminate the engine-owned FEEL and JS pools exactly
+	// once; the deferred goleak verification proves their cleanup goroutines exit.
+	engine.Stop()
+	engine.Stop()
+}

--- a/pkg/bpmn/engine_lifecycle_e2e_test.go
+++ b/pkg/bpmn/engine_lifecycle_e2e_test.go
@@ -37,9 +37,9 @@ func TestEngineLifecycleEndToEnd(t *testing.T) {
 
 	// DMN evaluation: business rule task evaluated by the embedded DMN engine,
 	// which shares the BPMN engine's FEEL runtime.
-	dmnDefinition, dmnXml, err := engine.dmnEngine.ParseDmnFromFile(filepath.Join("..", "dmn", "test-data", "bulk-evaluation-test", "can-autoliquidate-rule.dmn"))
+	dmnDefinition, dmnXML, err := engine.dmnEngine.ParseDmnFromFile(filepath.Join("..", "dmn", "test-data", "bulk-evaluation-test", "can-autoliquidate-rule.dmn"))
 	require.NoError(t, err)
-	_, _, err = engine.dmnEngine.SaveDmnResourceDefinition(t.Context(), dmnDefinition, dmnXml, engine.generateKey())
+	_, _, err = engine.dmnEngine.SaveDmnResourceDefinition(t.Context(), dmnDefinition, dmnXML, engine.generateKey())
 	require.NoError(t, err)
 
 	ruleProcess, err := engine.LoadFromFile(t.Context(), filepath.Join(".", "test-cases", "business_rule", "simple-business-rule-task-local.bpmn"))

--- a/pkg/bpmn/engine_lifecycle_e2e_test.go
+++ b/pkg/bpmn/engine_lifecycle_e2e_test.go
@@ -12,15 +12,18 @@ import (
 )
 
 // TestEngineLifecycleEndToEnd exercises a complete engine lifecycle:
-// construction with default (engine-owned) script runtimes, FEEL evaluation
-// through gateway conditions, DMN decision evaluation through the embedded DMN
-// engine (which reuses the BPMN engine's FEEL runtime), and shutdown. After
-// Stop, goleak verifies that no engine-owned script-pool cleanup goroutines are left running.
+// construction with default (engine-owned) script runtimes, Start (which brings up the
+// timer manager), FEEL evaluation through gateway conditions, DMN decision evaluation
+// through the embedded DMN engine (which reuses the BPMN engine's FEEL runtime), and
+// shutdown. After Stop, goleak verifies that neither the timer manager goroutine nor any
+// engine-owned script-pool cleanup goroutines are left running.
 func TestEngineLifecycleEndToEnd(t *testing.T) {
 	defer goleak.VerifyNone(t, sharedEngineGoleakOptions()...)
 
 	engine := NewEngine(EngineWithStorage(inmemory.NewStorage()))
 	defer engine.Stop()
+	require.NoError(t, engine.Start(t.Context()))
+	require.NotNil(t, engine.timerManager, "Start must create the timer manager")
 
 	// FEEL evaluation: exclusive gateway with a FEEL condition.
 	gatewayProcess, err := engine.LoadFromFile(t.Context(), "./test-cases/exclusive-gateway-with-condition.bpmn")
@@ -50,8 +53,10 @@ func TestEngineLifecycleEndToEnd(t *testing.T) {
 	assert.Equal(t, runtime.ActivityStateCompleted, ruleInstance.ProcessInstance().State)
 	assert.Equal(t, true, ruleInstance.ProcessInstance().VariableHolder.LocalVariables()["OutputTestResultVariable"])
 
-	// Shutdown: Stop must terminate the engine-owned FEEL and JS pools exactly
-	// once; the deferred goleak verification proves their cleanup goroutines exit.
+	// Shutdown: Stop must terminate the timer manager and the engine-owned FEEL and JS pools
+	// exactly once; the deferred goleak verification proves their goroutines exit.
 	engine.Stop()
 	engine.Stop()
+	require.Error(t, engine.timerManager.ctx.Err(), "timer manager must be stopped")
+	require.Error(t, engine.context.Err(), "engine context must be cancelled")
 }

--- a/pkg/bpmn/engine_lifecycle_test.go
+++ b/pkg/bpmn/engine_lifecycle_test.go
@@ -1,0 +1,68 @@
+package bpmn
+
+import (
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// TestEngineStopOnCopyDoesNotPreventStoppingOriginal guards against a value copy of an
+// Engine (NewEngine returns Engine by value) consuming the shared stopOnce before the
+// running engine is stopped. The copy has no timer manager, so stopping it must not
+// prevent the original engine's timer manager goroutine from being stopped later.
+func TestEngineStopOnCopyDoesNotPreventStoppingOriginal(t *testing.T) {
+	defer goleak.VerifyNone(t, sharedEngineGoleakOptions()...)
+
+	engine := NewEngine(EngineWithStorage(inmemory.NewStorage()))
+	copied := engine // shares *stopOnce, copied.timerManager stays nil
+	require.NoError(t, engine.Start(t.Context()))
+	require.NotNil(t, engine.timerManager)
+	require.Nil(t, copied.timerManager)
+
+	copied.Stop()
+	engine.Stop()
+
+	require.Error(t, engine.timerManager.ctx.Err(), "running engine's timer manager must be stopped")
+	require.Error(t, engine.context.Err(), "engine context must be cancelled")
+}
+
+// TestEngineRestartAfterStopStopsNewTimerManager guards against Stop becoming a permanent
+// no-op after the first call: Start creates a fresh timer manager, and a subsequent Stop must
+// terminate it rather than leak its goroutine.
+func TestEngineRestartAfterStopStopsNewTimerManager(t *testing.T) {
+	defer goleak.VerifyNone(t, sharedEngineGoleakOptions()...)
+
+	engine := NewEngine(EngineWithStorage(inmemory.NewStorage()))
+	engine.Stop()
+
+	// Start creates and starts a new timer manager before touching persistence.
+	_ = engine.Start(t.Context())
+	require.NotNil(t, engine.timerManager)
+	restartedTimerManager := engine.timerManager
+
+	engine.Stop()
+
+	require.Error(t, restartedTimerManager.ctx.Err(), "restarted timer manager must be stopped")
+}
+
+// TestEngineStartStopStopsTimerManagerAndOwnedPools verifies the full Start -> Stop lifecycle
+// releases the timer manager, engine context and engine-owned script pools, and that repeated
+// Stop calls remain safe.
+func TestEngineStartStopStopsTimerManagerAndOwnedPools(t *testing.T) {
+	defer goleak.VerifyNone(t, sharedEngineGoleakOptions()...)
+
+	tracker := newEngineConstructionTracker()
+	engine := newEngine(tracker.factories(), EngineWithStorage(inmemory.NewStorage()))
+	require.NoError(t, engine.Start(t.Context()))
+	require.NotNil(t, engine.timerManager)
+
+	engine.Stop()
+	engine.Stop()
+
+	require.Error(t, engine.timerManager.ctx.Err(), "timer manager must be stopped")
+	require.Error(t, engine.context.Err(), "engine context must be cancelled")
+	require.EqualValues(t, 1, tracker.feelRuntime.stopCalls.Load(), "owned FEEL runtime must be stopped exactly once")
+	require.EqualValues(t, 1, tracker.jsRuntime.stopCalls.Load(), "owned JavaScript runtime must be stopped exactly once")
+}

--- a/pkg/bpmn/engine_options_test.go
+++ b/pkg/bpmn/engine_options_test.go
@@ -1,26 +1,176 @@
 package bpmn
 
 import (
+	"sync/atomic"
 	"testing"
 
+	"github.com/pbinitiative/zenbpm/pkg/dmn"
+	"github.com/pbinitiative/zenbpm/pkg/script"
+	"github.com/pbinitiative/zenbpm/pkg/storage"
 	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
+func TestDefaultEngineOwnsAndStopsItsScriptPools(t *testing.T) {
+	defer goleak.VerifyNone(t, sharedEngineGoleakOptions()...)
+
+	tracker := newEngineConstructionTracker()
+	engine := newEngine(tracker.factories())
+
+	require.EqualValues(t, 1, tracker.feelConstructionCalls.Load(), "default construction must create exactly one FEEL runtime")
+	require.EqualValues(t, 1, tracker.jsConstructionCalls.Load(), "default construction must create exactly one JavaScript runtime")
+	require.EqualValues(t, 1, tracker.dmnConstructionCalls.Load(), "default construction must create exactly one DMN engine")
+	require.True(t, engine.ownsFeelRuntime, "engine must own the default FEEL runtime")
+	require.True(t, engine.ownsJsRuntime, "engine must own the default JS runtime")
+	require.NotNil(t, engine.dmnEngine, "engine must create an embedded DMN engine")
+	require.Same(t, engine.feelRuntime, tracker.dmnFeelRuntime, "DMN must reuse the BPMN engine's FEEL runtime")
+
+	// Stop must release both engine-owned runtimes exactly once.
+	engine.Stop()
+	engine.Stop()
+	require.EqualValues(t, 1, tracker.feelRuntime.stopCalls.Load(), "owned FEEL runtime must be stopped exactly once")
+	require.EqualValues(t, 1, tracker.jsRuntime.stopCalls.Load(), "owned JavaScript runtime must be stopped exactly once")
+}
+
 func TestEngineWithStorageDoesNotCreateAdditionalFeelRuntime(t *testing.T) {
-	// The shared package-level bpmnEngine (started in TestMain) keeps polling timers in the
-	// background. Its timer manager may spawn transient timer-waiter goroutines while this
-	// test runs, after goleak.IgnoreCurrent() takes its snapshot. Those goroutines belong to
-	// the shared engine, not the engine under test, so ignore them explicitly.
-	defer goleak.VerifyNone(t,
-		goleak.IgnoreCurrent(),
-		goleak.IgnoreTopFunction("github.com/pbinitiative/zenbpm/pkg/bpmn.(*timerManager).addWaitingTimer.func1"),
+	defer goleak.VerifyNone(t, sharedEngineGoleakOptions()...)
+
+	tracker := newEngineConstructionTracker()
+	engine := newEngine(tracker.factories(), EngineWithStorage(inmemory.NewStorage()))
+
+	require.EqualValues(t, 1, tracker.feelConstructionCalls.Load(), "storage-only construction must create exactly one FEEL runtime")
+	require.EqualValues(t, 1, tracker.jsConstructionCalls.Load(), "storage-only construction must create exactly one JavaScript runtime")
+	require.EqualValues(t, 1, tracker.dmnConstructionCalls.Load(), "storage-only construction must create exactly one DMN engine")
+	require.True(t, engine.ownsFeelRuntime, "engine must own the default FEEL runtime")
+	require.True(t, engine.ownsJsRuntime, "engine must own the default JS runtime")
+	require.Same(t, engine.feelRuntime, tracker.dmnFeelRuntime, "DMN must reuse the BPMN engine's FEEL runtime")
+
+	engine.Stop()
+}
+
+func TestEngineWithInjectedRuntimesDoesNotStopOrReplaceThem(t *testing.T) {
+	defer goleak.VerifyNone(t, sharedEngineGoleakOptions()...)
+
+	feelRuntime := &stopCountingFeelRuntime{}
+	jsRuntime := &stopCountingJsRuntime{}
+	tracker := newEngineConstructionTracker()
+
+	engine := newEngine(
+		tracker.factories(),
+		EngineWithStorageAndFeel(inmemory.NewStorage(), feelRuntime),
+		EngineWithJs(jsRuntime),
 	)
 
+	require.Zero(t, tracker.feelConstructionCalls.Load(), "injected construction must not create a default FEEL runtime")
+	require.Zero(t, tracker.jsConstructionCalls.Load(), "injected construction must not create a default JavaScript runtime")
+	require.EqualValues(t, 1, tracker.dmnConstructionCalls.Load(), "injected construction must create exactly one DMN engine")
+	require.False(t, engine.ownsFeelRuntime, "injected FEEL runtime must stay caller-owned")
+	require.False(t, engine.ownsJsRuntime, "injected JS runtime must stay caller-owned")
+	require.Same(t, feelRuntime, engine.feelRuntime.(*stopCountingFeelRuntime), "injected FEEL runtime must be used as-is")
+	require.Same(t, jsRuntime, engine.jsRuntime.(*stopCountingJsRuntime), "injected JS runtime must be used as-is")
+	require.Same(t, feelRuntime, tracker.dmnFeelRuntime, "DMN must reuse the injected BPMN FEEL runtime")
+
+	// Stopping the engine (and its embedded DMN engine) must never stop
+	// caller-owned runtimes, no matter how many times Stop is called.
+	engine.GetDmnEngine().Stop()
+	engine.Stop()
+	engine.Stop()
+
+	require.Zero(t, feelRuntime.stopCalls.Load(), "caller-owned FEEL runtime must not be stopped by the engine")
+	require.Zero(t, jsRuntime.stopCalls.Load(), "caller-owned JS runtime must not be stopped by the engine")
+
+}
+
+func TestEngineStopIsIdempotentWithOwnedRuntimes(t *testing.T) {
+	defer goleak.VerifyNone(t, sharedEngineGoleakOptions()...)
+
 	engine := NewEngine(EngineWithStorage(inmemory.NewStorage()))
-	defer func() {
-		engine.contextCancel()
-		engine.feelRuntime.Stop()
-		engine.jsRuntime.Stop()
-	}()
+	engine.Stop()
+	// A second Stop must not panic, deadlock, or double-stop the pools.
+	engine.Stop()
+	require.False(t, engine.ownsFeelRuntime, "ownership must be cleared after Stop")
+	require.False(t, engine.ownsJsRuntime, "ownership must be cleared after Stop")
+}
+
+// sharedEngineGoleakOptions returns the goleak options used by engine
+// construction tests. The shared package-level bpmnEngine (started in TestMain)
+// keeps polling timers in the background. Its timer manager may spawn transient
+// timer-waiter goroutines while a test runs, after goleak.IgnoreCurrent() takes
+// its snapshot. Those goroutines belong to the shared engine, not the engine
+// under test, so they are ignored explicitly.
+func sharedEngineGoleakOptions() []goleak.Option {
+	return []goleak.Option{
+		goleak.IgnoreCurrent(),
+		goleak.IgnoreTopFunction("github.com/pbinitiative/zenbpm/pkg/bpmn.(*timerManager).addWaitingTimer.func1"),
+	}
+}
+
+// stopCountingFeelRuntime is a caller-owned script.FeelRuntime stub that counts
+// how many times the engine tried to stop it.
+type stopCountingFeelRuntime struct {
+	stopCalls atomic.Int64
+}
+
+func (r *stopCountingFeelRuntime) UnaryTest(string, map[string]any) (bool, error) {
+	return true, nil
+}
+
+func (r *stopCountingFeelRuntime) Evaluate(string, map[string]any) (any, error) {
+	return nil, nil
+}
+
+func (r *stopCountingFeelRuntime) Stop() {
+	r.stopCalls.Add(1)
+}
+
+// stopCountingJsRuntime is a caller-owned script.JsRuntime stub that counts how
+// many times the engine tried to stop it.
+type stopCountingJsRuntime struct {
+	stopCalls atomic.Int64
+}
+
+func (r *stopCountingJsRuntime) RunScript(string) (any, error) {
+	return nil, nil
+}
+
+func (r *stopCountingJsRuntime) Stop() {
+	r.stopCalls.Add(1)
+}
+
+type engineConstructionTracker struct {
+	feelRuntime           *stopCountingFeelRuntime
+	jsRuntime             *stopCountingJsRuntime
+	feelConstructionCalls atomic.Int64
+	jsConstructionCalls   atomic.Int64
+	dmnConstructionCalls  atomic.Int64
+	dmnFeelRuntime        script.FeelRuntime
+}
+
+func newEngineConstructionTracker() *engineConstructionTracker {
+	return &engineConstructionTracker{
+		feelRuntime: &stopCountingFeelRuntime{},
+		jsRuntime:   &stopCountingJsRuntime{},
+	}
+}
+
+func (tracker *engineConstructionTracker) factories() engineFactories {
+	return engineFactories{
+		newFeelRuntime: func() script.FeelRuntime {
+			tracker.feelConstructionCalls.Add(1)
+			return tracker.feelRuntime
+		},
+		newJsRuntime: func() script.JsRuntime {
+			tracker.jsConstructionCalls.Add(1)
+			return tracker.jsRuntime
+		},
+		newDmnEngine: func(persistence storage.Storage, feelRuntime script.FeelRuntime) *dmn.ZenDmnEngine {
+			tracker.dmnConstructionCalls.Add(1)
+			tracker.dmnFeelRuntime = feelRuntime
+			return dmn.NewEngine(
+				dmn.EngineWithStorage(persistence),
+				dmn.EngineWithFeel(feelRuntime),
+			)
+		},
+	}
 }

--- a/pkg/bpmn/engine_options_test.go
+++ b/pkg/bpmn/engine_options_test.go
@@ -113,6 +113,38 @@ func TestEngineRuntimeOptionsArePureSetters(t *testing.T) {
 	require.False(t, engine.ownsJsRuntime, "injected JS runtime must be caller-owned")
 }
 
+// TestEngineRuntimeOptionsRejectConstructedEngine verifies that applying a runtime-injecting option to an
+// already constructed engine panics instead of silently orphaning the engine-owned runtimes, and that the
+// owned runtimes are still released by Stop afterwards.
+func TestEngineRuntimeOptionsRejectConstructedEngine(t *testing.T) {
+	defer goleak.VerifyNone(t, sharedEngineGoleakOptions()...)
+
+	tracker := newEngineConstructionTracker()
+	injectedFeel := &stopCountingFeelRuntime{}
+	injectedJs := &stopCountingJsRuntime{}
+	engine := newEngine(tracker.factories(), EngineWithStorage(inmemory.NewStorage()))
+	require.True(t, engine.ownsFeelRuntime)
+	require.True(t, engine.ownsJsRuntime)
+
+	require.PanicsWithValue(t,
+		"bpmn: EngineWithStorageAndFeel must only be passed to NewEngine; applying it to a constructed engine is not supported",
+		func() { EngineWithStorageAndFeel(inmemory.NewStorage(), injectedFeel)(&engine) })
+	require.PanicsWithValue(t,
+		"bpmn: EngineWithJs must only be passed to NewEngine; applying it to a constructed engine is not supported",
+		func() { EngineWithJs(injectedJs)(&engine) })
+
+	require.Same(t, tracker.feelRuntime, engine.feelRuntime.(*stopCountingFeelRuntime), "rejected option must not replace the FEEL runtime")
+	require.Same(t, tracker.jsRuntime, engine.jsRuntime.(*stopCountingJsRuntime), "rejected option must not replace the JS runtime")
+	require.True(t, engine.ownsFeelRuntime, "rejected option must not clear FEEL ownership")
+	require.True(t, engine.ownsJsRuntime, "rejected option must not clear JS ownership")
+
+	engine.Stop()
+	require.EqualValues(t, 1, tracker.feelRuntime.stopCalls.Load(), "owned FEEL runtime must still be released by Stop")
+	require.EqualValues(t, 1, tracker.jsRuntime.stopCalls.Load(), "owned JS runtime must still be released by Stop")
+	require.Zero(t, injectedFeel.stopCalls.Load(), "runtime from the rejected option must never be touched")
+	require.Zero(t, injectedJs.stopCalls.Load(), "runtime from the rejected option must never be touched")
+}
+
 // sharedEngineGoleakOptions returns the goleak options used by engine
 // construction tests. The shared package-level bpmnEngine (started in TestMain)
 // keeps polling timers in the background. Its timer manager may spawn transient

--- a/pkg/bpmn/engine_options_test.go
+++ b/pkg/bpmn/engine_options_test.go
@@ -93,6 +93,26 @@ func TestEngineStopIsIdempotentWithOwnedRuntimes(t *testing.T) {
 	require.False(t, engine.ownsJsRuntime, "ownership must be cleared after Stop")
 }
 
+// TestEngineRuntimeOptionsArePureSetters verifies that construction options only assign the injected
+// runtime and record caller ownership; they never stop a previously assigned runtime. Cleanup is Stop's job.
+func TestEngineRuntimeOptionsArePureSetters(t *testing.T) {
+	previousFeel := &stopCountingFeelRuntime{}
+	previousJs := &stopCountingJsRuntime{}
+	injectedFeel := &stopCountingFeelRuntime{}
+	injectedJs := &stopCountingJsRuntime{}
+	engine := &Engine{feelRuntime: previousFeel, ownsFeelRuntime: true, jsRuntime: previousJs, ownsJsRuntime: true}
+
+	EngineWithStorageAndFeel(inmemory.NewStorage(), injectedFeel)(engine)
+	EngineWithJs(injectedJs)(engine)
+
+	require.Zero(t, previousFeel.stopCalls.Load(), "options must not stop the previous FEEL runtime")
+	require.Zero(t, previousJs.stopCalls.Load(), "options must not stop the previous JS runtime")
+	require.Same(t, injectedFeel, engine.feelRuntime.(*stopCountingFeelRuntime))
+	require.Same(t, injectedJs, engine.jsRuntime.(*stopCountingJsRuntime))
+	require.False(t, engine.ownsFeelRuntime, "injected FEEL runtime must be caller-owned")
+	require.False(t, engine.ownsJsRuntime, "injected JS runtime must be caller-owned")
+}
+
 // sharedEngineGoleakOptions returns the goleak options used by engine
 // construction tests. The shared package-level bpmnEngine (started in TestMain)
 // keeps polling timers in the background. Its timer manager may spawn transient

--- a/pkg/dmn/dmn_engine.go
+++ b/pkg/dmn/dmn_engine.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dop251/goja"
@@ -34,6 +35,7 @@ const dmnEngineName = "dmn-engine"
 type ZenDmnEngine struct {
 	persistence     storage.DecisionStorage
 	feelRuntime     script.FeelRuntime
+	runtimeMu       sync.Mutex
 	ownsFeelRuntime bool
 
 	tracer             trace.Tracer
@@ -43,8 +45,16 @@ type ZenDmnEngine struct {
 
 type EngineOption = func(*ZenDmnEngine)
 
+type feelRuntimeFactory func() script.FeelRuntime
+
 // NewEngine creates a new instance of the DMN Engine;
 func NewEngine(options ...EngineOption) *ZenDmnEngine {
+	return newEngine(func() script.FeelRuntime {
+		return feel.NewFeelinRuntime(1, 1)
+	}, options...)
+}
+
+func newEngine(newFeelRuntime feelRuntimeFactory, options ...EngineOption) *ZenDmnEngine {
 	engine := ZenDmnEngine{
 		persistence: inmemory.NewStorage(),
 		tracer:      otel.GetTracerProvider().Tracer(dmnEngineName),
@@ -68,7 +78,7 @@ func NewEngine(options ...EngineOption) *ZenDmnEngine {
 		option(&engine)
 	}
 	if engine.feelRuntime == nil {
-		engine.feelRuntime = feel.NewFeelinRuntime(1, 1)
+		engine.feelRuntime = newFeelRuntime()
 		engine.ownsFeelRuntime = true
 	}
 
@@ -90,6 +100,8 @@ func EngineWithStorage(persistence storage.DecisionStorage) EngineOption {
 func EngineWithFeel(feel script.FeelRuntime) EngineOption {
 	return func(engine *ZenDmnEngine) {
 		engine.Stop()
+		engine.runtimeMu.Lock()
+		defer engine.runtimeMu.Unlock()
 		engine.feelRuntime = feel
 		engine.ownsFeelRuntime = false
 	}
@@ -109,11 +121,16 @@ func (engine *ZenDmnEngine) decisionTableFeelRuntime() (script.DmnFeelRuntime, e
 // Stop releases resources created and owned by the DMN engine. A runtime
 // supplied through EngineWithFeel remains owned by the caller.
 func (engine *ZenDmnEngine) Stop() {
+	engine.runtimeMu.Lock()
 	if !engine.ownsFeelRuntime || engine.feelRuntime == nil {
+		engine.runtimeMu.Unlock()
 		return
 	}
+	feelRuntime := engine.feelRuntime
 	engine.ownsFeelRuntime = false
-	engine.feelRuntime.Stop()
+	engine.runtimeMu.Unlock()
+
+	feelRuntime.Stop()
 }
 
 func (engine *ZenDmnEngine) ParseDmnFromFile(filename string) (*dmn.TDefinitions, []byte, error) {

--- a/pkg/dmn/dmn_engine.go
+++ b/pkg/dmn/dmn_engine.go
@@ -91,15 +91,15 @@ func EngineWithStorage(persistence storage.DecisionStorage) EngineOption {
 	}
 }
 
-// EngineWithFeel sets the FEEL runtime used for expression evaluation and hands
-// its ownership to the caller. DMN decision tables require the supplied runtime
-// to implement script.DmnFeelRuntime; incomplete runtimes are rejected during
-// deployment and evaluation. It is meant for construction time only (through
-// NewEngine): applying it to a running engine stops an already owned runtime and
-// with it any FEEL evaluation in flight.
+// EngineWithFeel sets the FEEL runtime used for expression evaluation. The
+// supplied runtime remains owned by the caller: the engine will never stop it.
+// DMN decision tables require the supplied runtime to implement
+// script.DmnFeelRuntime; incomplete runtimes are rejected during deployment and
+// evaluation. It is meant for construction time only (through NewEngine), where
+// it is applied before any default runtime is created, so no engine-owned pool
+// ever needs to be released here.
 func EngineWithFeel(feel script.FeelRuntime) EngineOption {
 	return func(engine *ZenDmnEngine) {
-		engine.Stop()
 		engine.runtimeMu.Lock()
 		defer engine.runtimeMu.Unlock()
 		engine.feelRuntime = feel
@@ -120,17 +120,18 @@ func (engine *ZenDmnEngine) decisionTableFeelRuntime() (script.DmnFeelRuntime, e
 
 // Stop releases resources created and owned by the DMN engine. A runtime
 // supplied through EngineWithFeel remains owned by the caller.
+// Stop is safe to call multiple times and from multiple goroutines: the owned
+// runtime is stopped exactly once, and every caller returns only after that
+// shutdown has completed (concurrent callers block on runtimeMu until the
+// first one has finished releasing the runtime).
 func (engine *ZenDmnEngine) Stop() {
 	engine.runtimeMu.Lock()
+	defer engine.runtimeMu.Unlock()
 	if !engine.ownsFeelRuntime || engine.feelRuntime == nil {
-		engine.runtimeMu.Unlock()
 		return
 	}
-	feelRuntime := engine.feelRuntime
 	engine.ownsFeelRuntime = false
-	engine.runtimeMu.Unlock()
-
-	feelRuntime.Stop()
+	engine.feelRuntime.Stop()
 }
 
 func (engine *ZenDmnEngine) ParseDmnFromFile(filename string) (*dmn.TDefinitions, []byte, error) {

--- a/pkg/dmn/dmn_engine.go
+++ b/pkg/dmn/dmn_engine.go
@@ -38,6 +38,11 @@ type ZenDmnEngine struct {
 	runtimeMu       sync.Mutex
 	ownsFeelRuntime bool
 
+	// constructed is set once NewEngine has finished applying options and creating default runtimes.
+	// Runtime-injecting options consult it to reject being applied to an already constructed engine,
+	// which would orphan an engine-owned runtime and swap the runtime under in-flight evaluations.
+	constructed bool
+
 	tracer             trace.Tracer
 	evaluationsTotal   metric.Int64Counter
 	evaluationDuration metric.Float64Histogram
@@ -81,6 +86,7 @@ func newEngine(newFeelRuntime feelRuntimeFactory, options ...EngineOption) *ZenD
 		engine.feelRuntime = newFeelRuntime()
 		engine.ownsFeelRuntime = true
 	}
+	engine.constructed = true
 
 	return &engine
 }
@@ -95,15 +101,26 @@ func EngineWithStorage(persistence storage.DecisionStorage) EngineOption {
 // supplied runtime remains owned by the caller: the engine will never stop it.
 // DMN decision tables require the supplied runtime to implement
 // script.DmnFeelRuntime; incomplete runtimes are rejected during deployment and
-// evaluation. It is meant for construction time only (through NewEngine), where
-// it is applied before any default runtime is created, so no engine-owned pool
-// ever needs to be released here.
+// evaluation. It must only be passed to NewEngine, where it is applied before
+// any default runtime is created, so no engine-owned pool ever needs to be
+// released here. Applying it to an already constructed engine panics: doing so
+// would orphan the engine-owned runtime and replace the runtime underneath
+// in-flight evaluations.
 func EngineWithFeel(feel script.FeelRuntime) EngineOption {
 	return func(engine *ZenDmnEngine) {
+		engine.mustBeUnderConstruction("EngineWithFeel")
 		engine.runtimeMu.Lock()
 		defer engine.runtimeMu.Unlock()
 		engine.feelRuntime = feel
 		engine.ownsFeelRuntime = false
+	}
+}
+
+// mustBeUnderConstruction panics when a construction-only option is applied to
+// an engine that NewEngine has already finished building.
+func (engine *ZenDmnEngine) mustBeUnderConstruction(option string) {
+	if engine.constructed {
+		panic(fmt.Sprintf("dmn: %s must only be passed to NewEngine; applying it to a constructed engine is not supported", option))
 	}
 }
 

--- a/pkg/dmn/dmn_engine_ownership_test.go
+++ b/pkg/dmn/dmn_engine_ownership_test.go
@@ -1,0 +1,123 @@
+package dmn
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pbinitiative/zenbpm/pkg/script"
+	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestDmnDefaultEngineOwnsAndStopsItsFeelRuntime(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	feelRuntime := &stopCountingDmnFeelRuntime{}
+	var constructionCalls atomic.Int64
+	engine := newEngine(func() script.FeelRuntime {
+		constructionCalls.Add(1)
+		return feelRuntime
+	})
+
+	require.EqualValues(t, 1, constructionCalls.Load(), "default construction must create exactly one FEEL runtime")
+	require.True(t, engine.ownsFeelRuntime, "engine must own the default FEEL runtime")
+	require.Same(t, feelRuntime, engine.feelRuntime, "engine must retain the runtime created by its factory")
+
+	// Stop must release the engine-owned runtime exactly once.
+	engine.Stop()
+	engine.Stop()
+	require.EqualValues(t, 1, feelRuntime.stopCalls.Load(), "owned FEEL runtime must be stopped exactly once")
+}
+
+func TestDmnEngineWithStorageOwnsAndStopsItsFeelRuntime(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	feelRuntime := &stopCountingDmnFeelRuntime{}
+	var constructionCalls atomic.Int64
+	engine := newEngine(func() script.FeelRuntime {
+		constructionCalls.Add(1)
+		return feelRuntime
+	}, EngineWithStorage(inmemory.NewStorage()))
+
+	require.EqualValues(t, 1, constructionCalls.Load(), "storage-only construction must create exactly one FEEL runtime")
+	require.True(t, engine.ownsFeelRuntime, "engine must own the default FEEL runtime")
+
+	engine.Stop()
+	engine.Stop()
+	require.EqualValues(t, 1, feelRuntime.stopCalls.Load(), "owned FEEL runtime must be stopped exactly once")
+}
+
+func TestDmnEngineWithInjectedRuntimeCreatesNoDefaultPoolAndNeverStopsIt(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	feelRuntime := &stopCountingDmnFeelRuntime{}
+	var constructionCalls atomic.Int64
+	engine := newEngine(func() script.FeelRuntime {
+		constructionCalls.Add(1)
+		return &stopCountingDmnFeelRuntime{}
+	}, EngineWithFeel(feelRuntime))
+
+	require.Zero(t, constructionCalls.Load(), "injected construction must not create a default FEEL runtime")
+	require.False(t, engine.ownsFeelRuntime, "injected FEEL runtime must stay caller-owned")
+	require.Same(t, feelRuntime, engine.feelRuntime.(*stopCountingDmnFeelRuntime), "injected FEEL runtime must be used as-is")
+
+	engine.Stop()
+	engine.Stop()
+
+	require.Zero(t, feelRuntime.stopCalls.Load(), "caller-owned FEEL runtime must not be stopped by the engine")
+
+}
+
+func TestDmnEngineStopIsConcurrentAndExactlyOnce(t *testing.T) {
+	feelRuntime := &stopCountingDmnFeelRuntime{}
+	engine := &ZenDmnEngine{feelRuntime: feelRuntime, ownsFeelRuntime: true}
+	start := make(chan struct{})
+	var callers sync.WaitGroup
+
+	for range 100 {
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			<-start
+			engine.Stop()
+		}()
+	}
+
+	close(start)
+	callers.Wait()
+
+	require.EqualValues(t, 1, feelRuntime.stopCalls.Load(), "concurrent shutdown must stop the owned FEEL runtime exactly once")
+	require.False(t, engine.ownsFeelRuntime, "shutdown must clear runtime ownership")
+}
+
+// stopCountingDmnFeelRuntime is a caller-owned script.DmnFeelRuntime stub that
+// counts how many times the engine tried to stop it.
+type stopCountingDmnFeelRuntime struct {
+	stopCalls atomic.Int64
+}
+
+func (r *stopCountingDmnFeelRuntime) UnaryTest(string, map[string]any) (bool, error) {
+	return true, nil
+}
+
+func (r *stopCountingDmnFeelRuntime) UnaryTestStrict(string, map[string]any) (bool, error) {
+	return true, nil
+}
+
+func (r *stopCountingDmnFeelRuntime) Evaluate(string, map[string]any) (any, error) {
+	return nil, nil
+}
+
+func (r *stopCountingDmnFeelRuntime) ValidateExpression(string) error {
+	return nil
+}
+
+func (r *stopCountingDmnFeelRuntime) ValidateUnaryTest(string) error {
+	return nil
+}
+
+func (r *stopCountingDmnFeelRuntime) Stop() {
+	r.stopCalls.Add(1)
+}

--- a/pkg/dmn/dmn_engine_ownership_test.go
+++ b/pkg/dmn/dmn_engine_ownership_test.go
@@ -93,6 +93,27 @@ func TestDmnEngineStopIsConcurrentAndExactlyOnce(t *testing.T) {
 	require.False(t, engine.ownsFeelRuntime, "shutdown must clear runtime ownership")
 }
 
+// TestEngineWithFeelRejectsConstructedEngine verifies that applying EngineWithFeel to an already
+// constructed engine panics instead of silently orphaning the engine-owned runtime, and that the
+// owned runtime is still released by Stop afterwards.
+func TestEngineWithFeelRejectsConstructedEngine(t *testing.T) {
+	ownedRuntime := &stopCountingDmnFeelRuntime{}
+	injectedRuntime := &stopCountingDmnFeelRuntime{}
+	engine := newEngine(func() script.FeelRuntime { return ownedRuntime })
+	require.True(t, engine.ownsFeelRuntime)
+
+	require.PanicsWithValue(t,
+		"dmn: EngineWithFeel must only be passed to NewEngine; applying it to a constructed engine is not supported",
+		func() { EngineWithFeel(injectedRuntime)(engine) })
+
+	require.Same(t, ownedRuntime, engine.feelRuntime.(*stopCountingDmnFeelRuntime), "rejected option must not replace the runtime")
+	require.True(t, engine.ownsFeelRuntime, "rejected option must not clear ownership")
+
+	engine.Stop()
+	require.EqualValues(t, 1, ownedRuntime.stopCalls.Load(), "owned runtime must still be released by Stop")
+	require.Zero(t, injectedRuntime.stopCalls.Load(), "runtime from the rejected option must never be touched")
+}
+
 // TestDmnEngineStopWaitsForInFlightShutdown verifies that a Stop call racing with another
 // Stop call does not return before the owned runtime has actually finished shutting down.
 func TestDmnEngineStopWaitsForInFlightShutdown(t *testing.T) {

--- a/pkg/dmn/dmn_engine_ownership_test.go
+++ b/pkg/dmn/dmn_engine_ownership_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/pbinitiative/zenbpm/pkg/script"
 	"github.com/pbinitiative/zenbpm/pkg/storage/inmemory"
@@ -92,6 +93,53 @@ func TestDmnEngineStopIsConcurrentAndExactlyOnce(t *testing.T) {
 	require.False(t, engine.ownsFeelRuntime, "shutdown must clear runtime ownership")
 }
 
+// TestDmnEngineStopWaitsForInFlightShutdown verifies that a Stop call racing with another
+// Stop call does not return before the owned runtime has actually finished shutting down.
+func TestDmnEngineStopWaitsForInFlightShutdown(t *testing.T) {
+	feelRuntime := &blockingStopDmnFeelRuntime{
+		stopCountingDmnFeelRuntime: stopCountingDmnFeelRuntime{},
+		entered:                    make(chan struct{}),
+		release:                    make(chan struct{}),
+	}
+	engine := &ZenDmnEngine{feelRuntime: feelRuntime, ownsFeelRuntime: true}
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		engine.Stop()
+	}()
+	<-feelRuntime.entered // first caller is now inside feelRuntime.Stop()
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		engine.Stop()
+	}()
+
+	select {
+	case <-secondDone:
+		t.Fatal("second Stop returned while the owned runtime shutdown was still in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(feelRuntime.release)
+	require.Eventually(t, func() bool {
+		select {
+		case <-firstDone:
+		default:
+			return false
+		}
+		select {
+		case <-secondDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 5*time.Millisecond, "both Stop callers must return once shutdown completes")
+	require.True(t, feelRuntime.finished.Load(), "runtime shutdown must have completed before Stop returned")
+	require.EqualValues(t, 1, feelRuntime.stopCalls.Load(), "owned FEEL runtime must be stopped exactly once")
+}
+
 // stopCountingDmnFeelRuntime is a caller-owned script.DmnFeelRuntime stub that
 // counts how many times the engine tried to stop it.
 type stopCountingDmnFeelRuntime struct {
@@ -120,4 +168,20 @@ func (r *stopCountingDmnFeelRuntime) ValidateUnaryTest(string) error {
 
 func (r *stopCountingDmnFeelRuntime) Stop() {
 	r.stopCalls.Add(1)
+}
+
+// blockingStopDmnFeelRuntime is a script.DmnFeelRuntime stub whose Stop blocks until
+// released, so tests can observe an in-flight shutdown.
+type blockingStopDmnFeelRuntime struct {
+	stopCountingDmnFeelRuntime
+	entered  chan struct{}
+	release  chan struct{}
+	finished atomic.Bool
+}
+
+func (r *blockingStopDmnFeelRuntime) Stop() {
+	r.stopCountingDmnFeelRuntime.Stop()
+	close(r.entered)
+	<-r.release
+	r.finished.Store(true)
 }

--- a/pkg/dmn/dmn_engine_test.go
+++ b/pkg/dmn/dmn_engine_test.go
@@ -203,16 +203,19 @@ func TestZenDmnEngineStopPreservesInjectedRuntime(t *testing.T) {
 	assert.Equal(t, 0, runtime.stopCount)
 }
 
-func TestEngineWithFeelStopsReplacedOwnedRuntime(t *testing.T) {
-	ownedRuntime := &trackingFeelRuntime{}
+func TestEngineWithFeelIsAPureSetter(t *testing.T) {
+	previousRuntime := &trackingFeelRuntime{}
 	injectedRuntime := &trackingFeelRuntime{}
-	engine := &ZenDmnEngine{feelRuntime: ownedRuntime, ownsFeelRuntime: true}
+	engine := &ZenDmnEngine{feelRuntime: previousRuntime, ownsFeelRuntime: true}
 
 	EngineWithFeel(injectedRuntime)(engine)
 
-	assert.Equal(t, 1, ownedRuntime.stopCount)
+	assert.Equal(t, 0, previousRuntime.stopCount, "construction options must not perform cleanup")
 	assert.Same(t, injectedRuntime, engine.feelRuntime)
 	assert.False(t, engine.ownsFeelRuntime)
+
+	engine.Stop()
+	assert.Equal(t, 0, injectedRuntime.stopCount, "injected runtime stays caller-owned")
 }
 
 func TestMetadataIsGivenFromLoadedXmlFile(t *testing.T) {

--- a/pkg/script/feel/feel_program_test.go
+++ b/pkg/script/feel/feel_program_test.go
@@ -1,3 +1,6 @@
+// Package feel provides FEEL (Friendly Enough Expression Language) evaluation
+// support backed by the Goja JavaScript runtime, including compilation and
+// reuse of FEEL programs across independent runners.
 package feel
 
 import (

--- a/pkg/script/feel/feel_program_test.go
+++ b/pkg/script/feel/feel_program_test.go
@@ -1,0 +1,44 @@
+package feel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompiledProgramsAreSharedAcrossCalls(t *testing.T) {
+	first := compiledPrograms()
+	second := compiledPrograms()
+
+	require.Len(t, first, 3, "polyfill, feelin bundle, and extensions must all be compiled")
+	require.Len(t, second, len(first))
+	for i := range first {
+		require.NotNil(t, first[i])
+		// The bundle must be compiled only once: every call returns the very same immutable *goja.Program instances.
+		require.Same(t, first[i], second[i], "program %d must be the shared compiled instance", i)
+	}
+}
+
+func TestNewRunnersShareCompiledProgramsButOwnIndependentRuntimes(t *testing.T) {
+	firstRunner := newFeelRunner()
+	secondRunner := newFeelRunner()
+
+	require.NotSame(t, firstRunner.vm, secondRunner.vm, "each runner must own an independent goja.Runtime")
+
+	// Both runners must be fully functional after executing the shared compiled programs.
+	firstResult, err := (*firstRunner.evalFunc)("1 + 1", nil)
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, firstResult)
+
+	secondResult, err := (*secondRunner.evalFunc)("2 + 3", nil)
+	require.NoError(t, err)
+	assert.EqualValues(t, 5, secondResult)
+
+	// State written into one runtime must never leak into the other.
+	_, err = (*firstRunner.evalFunc)("a", map[string]any{"a": 42})
+	require.NoError(t, err)
+	leaked, err := (*secondRunner.evalFunc)("a", nil)
+	require.NoError(t, err)
+	assert.Nil(t, leaked, "variable context of one runner must not leak into another runner")
+}

--- a/pkg/script/feel/feel_runtime.go
+++ b/pkg/script/feel/feel_runtime.go
@@ -2,6 +2,7 @@ package feel
 
 import (
 	_ "embed"
+	"sync"
 
 	"github.com/dop251/goja"
 	"github.com/pbinitiative/zenbpm/pkg/script"
@@ -126,18 +127,25 @@ type FeelinRunner struct {
 
 func (r *FeelinRunner) Runner() {}
 
+// compiledPrograms lazily compiles the Intl polyfill, the embedded feelin bundle,
+// and the FEEL runtime extensions exactly once into immutable *goja.Program instances.
+// goja.Program is safe for concurrent use by multiple goja.Runtime instances, so every new runner only has to execute
+// the already-compiled programs instead of recompiling the whole JavaScript bundle from source.
+var compiledPrograms = sync.OnceValue(func() []*goja.Program {
+	return []*goja.Program{
+		goja.MustCompile("intl-polyfill.js", intlPolyfill, false),
+		goja.MustCompile("feelin/index.esm.js", feelinSource, false),
+		goja.MustCompile("feel-runtime-extensions.js", feelRuntimeExtensions, false),
+	}
+})
+
 func newFeelRunner() *FeelinRunner {
 	r := FeelinRunner{vm: goja.New()}
-	if _, err := r.vm.RunString(intlPolyfill); err != nil {
-		panic(err)
-	}
-	//TODO: this can be optimized into using already compiled *Program to skip compilation step
-	_, err := r.vm.RunString(feelinSource)
-	if err != nil {
-		panic(err)
-	}
-	if _, err := r.vm.RunString(feelRuntimeExtensions); err != nil {
-		panic(err)
+	// Each runner owns an independent goja.Runtime; only the immutable compiled programs are shared between runners.
+	for _, program := range compiledPrograms() {
+		if _, err := r.vm.RunProgram(program); err != nil {
+			panic(err)
+		}
 	}
 	r.exportEvaluate()
 	r.exportUnaryTest()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Engine shutdown is now safe to call repeatedly or concurrently.
  * Injected FEEL and JavaScript runtimes remain caller-owned and are not stopped unexpectedly.
  * Runtime replacement and DMN processing behave more reliably during lifecycle changes.
  * Improved synchronization prevents conflicts while updating or shutting down DMN runtimes.

* **Performance**
  * FEEL programs are compiled once and reused across runners, improving startup efficiency while preserving isolated runtime state.

* **Tests**
  * Expanded coverage for engine lifecycle, runtime ownership, concurrent shutdown, DMN processing, and resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->