### PR TITLE
docs: fix internal documentation links

### DIFF
--- a/docs/explanation/bpm-concepts.md
+++ b/docs/explanation/bpm-concepts.md
@@ -6,7 +6,7 @@ description: The core concepts behind ZenBPM - processes, instances, tokens, tas
 
 # BPM Concepts
 
-This page explains the ideas behind ZenBPM. You don't need to read it before the [Getting Started tutorial](/tutorials/getting-started/first-bpmn-process) - but whenever a term there feels unclear, this is the place to look it up.
+This page explains the ideas behind ZenBPM. You don't need to read it before the [Getting Started tutorial](../getting-started/first-bpmn-process.mdx) - but whenever a term there feels unclear, this is the place to look it up.
 
 If you already know Camunda, Zeebe, or another BPMN engine, skip to [How ZenBPM maps to other engines](#terminology-mapping).
 
@@ -109,7 +109,7 @@ This decoupling is intentional. Workers can be written in any language, scaled i
 
 Putting it all together, working with ZenBPM follows one loop: **model** the diagram, **deploy** it to the engine, **start instances** with their variables, let workers and people **execute** the work, and **observe** state and history - then improve the diagram and go around again.
 
-The [Getting Started tutorial](/tutorials/getting-started/first-bpmn-process) walks this exact loop once, end to end.
+The [Getting Started tutorial](../getting-started/first-bpmn-process.mdx) walks this exact loop once, end to end.
 
 ## How ZenBPM maps to other engines {#terminology-mapping}
 
@@ -130,6 +130,6 @@ ZenBPM follows the Zeebe-style architecture: an external-worker model over gRPC,
 
 ## Where to go next
 
-- Run the loop yourself: [Getting Started tutorial](/tutorials/getting-started/first-bpmn-process)
+- Run the loop yourself: [Getting Started tutorial](../getting-started/first-bpmn-process.mdx)
 - See working processes and workers: [zenbpm-examples](https://github.com/pbinitiative/zenbpm-examples)
-- Engine internals: [Architecture](/category/architecture)
+- Engine internals: [Architecture](./architecture/architecture-overview.md)

--- a/docs/getting-started/first-bpmn-process.mdx
+++ b/docs/getting-started/first-bpmn-process.mdx
@@ -308,5 +308,5 @@ docker compose down
 - **Understand the model.** [BPM Concepts](../../explanation/bpm-concepts) — definitions, instances, tokens, and the job/worker mechanic in one short read.
 - **Service tasks.** Look at the detailed [Service Task](../../reference/bpmn/supported-elements/activities/tasks/service-task) reference overview.
 - **More workers.** [`examples/workers/`](https://github.com/pbinitiative/zenbpm-examples/tree/main/examples/workers) shows several workers in one Go project.
-- **The APIs in full.** [REST (OpenAPI)](../../static/openapi) and the [gRPC proto](/zenbpm.proto).
-- **Engine internals.** [Architecture](/category/architecture).
+- **The APIs in full.** [REST (OpenAPI)](../static/openapi.mdx) and the [gRPC proto](pathname:///zenbpm.proto).
+- **Engine internals.** [Architecture](../explanation/architecture/architecture-overview.md).

--- a/docs/getting-started/run-the-engine.mdx
+++ b/docs/getting-started/run-the-engine.mdx
@@ -90,7 +90,7 @@ docker compose down -v
 **Port already in use** (`bind: address already in use`) — another process holds `8080` or `9090`. Stop it, or change the host ports in `compose.yaml` (e.g. `18080:8080`) and use those ports in the following chapters.
 
 :::note Beyond local
-The compose file mounts a small single-node config (`conf/zenbpm/conf.yaml`) that bootstraps the engine's cluster with one partition — a shard of process/job data with its own Raft-replicated leader; production clusters split work across several — which is enough to run everything in this tutorial. That file is where cluster, partition, and script-engine settings live. Durable persistence (rqlite), multi-node clustering, and observability are operational topics covered in the [How-to guides](/category/how-to).
+The compose file mounts a small single-node config (`conf/zenbpm/conf.yaml`) that bootstraps the engine's cluster with one partition — a shard of process/job data with its own Raft-replicated leader; production clusters split work across several — which is enough to run everything in this tutorial. That file is where cluster, partition, and script-engine settings live. See the reference documentation for [configuration](../reference/configuration.md), [storage](../reference/storage.md), and [observability](../reference/observability.md).
 :::
 
 ## Next {#next}

--- a/docs/reference/cluster.md
+++ b/docs/reference/cluster.md
@@ -68,7 +68,7 @@ Current theoretical limit for partitions is 122 due to network multiplexer imple
 :::
 
 :::note[Future plans]
-You can specify how many partitions and partition replicas will be created through the [application configuration](/reference/configuration). After the cluster has been created you can modify these through [zenctl](/reference/zenctl) cli that is used to manage Zen clusters.
+You can specify how many partitions and partition replicas will be created through the [application configuration](./configuration.md). After the cluster has been created you can modify these through [zenctl](./zenctl.md) cli that is used to manage Zen clusters.
 :::
 
 :::note[Future plans]
@@ -82,7 +82,7 @@ ZenBPM provides a whole-cluster backup and restore API. A backup captures a poin
 
 Backup and restore live under `/system/v1/...`, not the business API prefix. The convention: `/v1/**` is the business API and is fully documented in `openapi/api.yaml`; `/system` is the operational plane. Directly under `/system` sit the unversioned probes (`/system/status`, `/system/metrics`) that Kubernetes probes and Prometheus scrapers rely on staying stable; operational APIs that carry payload contracts (like the backup bundle format and the restore report) are versioned under `/system/v1/...` so they can evolve without breaking probes or clients.
 
-The operational endpoints are described in [`openapi/system.yaml`](../../openapi/system.yaml) (documentation spec — the handlers are hand-registered in `internal/rest/server.go`, no server code is generated from it).
+The operational endpoints are described in [`openapi/system.yaml`](https://github.com/pbinitiative/zenbpm/blob/main/openapi/system.yaml) (documentation spec — the handlers are hand-registered in `internal/rest/server.go`, no server code is generated from it).
 
 ### What is backed up
 

--- a/docs/reference/opentelemetry.md
+++ b/docs/reference/opentelemetry.md
@@ -6,7 +6,7 @@ sidebar_position: 110
 
 ## Traces
 We provide a tracing implementation as a means to gain view into the system performance and bottlenecks.
-You can configure the collectors through [application configuration](/reference/configuration#tracing-configuration-tracing)
+You can configure the collectors through [application configuration](./configuration.md#tracing-configuration-tracing)
 :::note[Future plans]
 You can specify the custom headers that you want to transfer through the application.
 :::
@@ -26,4 +26,3 @@ We provide metrics such as:
 
 They are are available at:
  - REST(prometheus exporter): `/system/metrics`
-

--- a/docs/reference/storage.md
+++ b/docs/reference/storage.md
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 # Storage
-[RqLite](https://rqlite.io/) is used as a storage layer. Read more about partitions in [cluster section](/reference/cluster)
+[RqLite](https://rqlite.io/) is used as a storage layer. Read more about partitions in [cluster section](./cluster.md)
 
 RqLite is a distributed relational database that combines the simplicity of SQLite with the robustness of a fault-tolerant, highly available system. It's developer-friendly, exceptionally easy to operate, and it's designed for reliability with minimal complexity.
 

--- a/docs/superpowers/specs/2026-07-08-phase2-configurable-partitions-design.md
+++ b/docs/superpowers/specs/2026-07-08-phase2-configurable-partitions-design.md
@@ -21,7 +21,7 @@ Make `DesiredPartitions` changeable at runtime through Raft consensus instead of
 | D2 | Convergence / stall safety | Leader-gated periodic reconcile ticker; one partition created per pass (prior-art: K8s resync, TiKV PD, MongoDB balancer) |
 | D3 | RPC routing on follower | Forward to leader via existing `ClusterLeader()` client |
 | D4 | Validation | Increase-only, `1 ≤ n ≤ 122` (mux single-byte partition-id limit) |
-| D5 | Replication scope in Phase 2 | Full replication: every partition gets **all** started nodes as members (RF = cluster size); RF<N placement stays Phase 4 |
+| D5 | Replication scope in Phase 2 | Full replication: every partition gets **all** started nodes as members (RF = cluster size); `RF < N` placement stays Phase 4 |
 | D6 | Pointer staleness on scale-up | Keep `hash % N` addressing; rebuild pointers after formation using existing `RebuildMessageSubscriptionPointers` machinery, tracked by a replicated `RoutingPartitions` marker. No broadcast lookup. |
 | D7 | App-config scope exception | `DesiredPartitions` field added to `internal/config/config.go` (user-approved exception to cluster-scope boundary) |
 | D8 | Operator-facing API | REST admin endpoint in `openapi/system.yaml` following the backup/restore precedent; cluster gRPC `ConfigurationUpdate` remains the internal transport (user-approved scope exception for `internal/rest/` + `openapi/system.yaml`) |


### PR DESCRIPTION
## Summary
- fix the MDX syntax error blocking the Docusaurus build
- replace stale root-relative documentation links with version-aware source-relative links
- keep static and repository-source links valid for the documentation deployment

## Verification
- Docusaurus internal link check passed
- full Docusaurus production build passed
- synchronized ZenBPM and Docusaurus documentation trees match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation links across getting-started, reference, and architecture pages for more reliable navigation.
  - Improved links to configuration, storage, observability, OpenAPI, gRPC, and cluster documentation.
  - Corrected external repository linking for the system API specification.
  - Improved formatting in the configurable partitions design specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->